### PR TITLE
fix: hero traps page scroll (overscroll-none on overflow-hidden container)

### DIFF
--- a/app/(pages)/(landingPage)/Hero.jsx
+++ b/app/(pages)/(landingPage)/Hero.jsx
@@ -7,7 +7,7 @@ import Navbar from "@/components/molecules/ladingpage/Navbar";
 
 const Hero = () => {
     return (
-        <main className=" relative h-screen flex flex-col bg-basic text-white overflow-hidden overscroll-none">
+        <main className="relative h-screen flex flex-col bg-basic text-white overflow-hidden">
             <div className="absolute inset-0 bg-gradient-to-br from-green-500 via-slate-800 to-green-500 opacity-30 blur-2xl z-0" />
             <Navbar />
            <div className="relative z-10 flex flex-1 flex-col items-center justify-center space-y-10 text-center sm:font-stretch-125%">


### PR DESCRIPTION
## Problem

The landing page cannot be scrolled: wheel/trackpad/touch gestures over the hero (the entire first viewport) do nothing, so visitors are stuck on the hero.

## Cause

The hero `<main>` combines `overflow-hidden` with `overscroll-none`. An `overflow: hidden` element is still treated as a scroll container, and `overscroll-behavior: none` prevents scroll chaining to the page when the container itself cannot scroll — which it never can. Every scroll gesture over the hero is swallowed.

## Fix

Remove `overscroll-none` (and a stray leading space in the class list). `overflow-hidden` stays, as it clips the decorative gradient blur.

## Testing

Verified on the dev server: the page scrolls normally through About → Why Deen Bridge → Stats → Testimonials → Partners → Footer.