### PR TITLE
fix: await params and cookies() in book preview route for Next 15 compat

### DIFF
--- a/app/api/books/[bookId]/preview/route.js
+++ b/app/api/books/[bookId]/preview/route.js
@@ -7,7 +7,7 @@ const getBackendBaseUrl = () => {
 };
 
 export async function GET(_request, { params }) {
-  const { bookId } = params || {};
+  const { bookId } = await params;
 
   if (!bookId) {
     return NextResponse.json(
@@ -18,7 +18,8 @@ export async function GET(_request, { params }) {
 
   try {
     const backendUrl = `${getBackendBaseUrl()}/api/books/${bookId}/preview`;
-    const token = cookies().get("authToken")?.value;
+    const cookieStore = await cookies();
+  const token = cookieStore.get("authToken")?.value;
 
     const headers = new Headers();
     if (token) {


### PR DESCRIPTION
Fixes deprecated synchronous access to params and cookies() in the book preview API route. Closes #89