### PR TITLE
fix: await params and cookies() for Next 15 compatibility

### DIFF
--- a/app/api/books/[bookId]/preview/route.js
+++ b/app/api/books/[bookId]/preview/route.js
@@ -7,7 +7,7 @@ const getBackendBaseUrl = () => {
 };
 
 export async function GET(_request, { params }) {
-  const { bookId } = params || {};
+  const { bookId } = await params;
 
   if (!bookId) {
     return NextResponse.json(
@@ -18,7 +18,8 @@ export async function GET(_request, { params }) {
 
   try {
     const backendUrl = `${getBackendBaseUrl()}/api/books/${bookId}/preview`;
-    const token = cookies().get("authToken")?.value;
+    const cookieStore = await cookies();
+    const token = cookieStore.get("authToken")?.value;
 
     const headers = new Headers();
     if (token) {

--- a/app/dashboard/courses/[courseId]/page.jsx
+++ b/app/dashboard/courses/[courseId]/page.jsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { getCourseById } from "@/lib/actions/courses/get-course";
 import CourseDetailClient from "./CourseDetailPageClient";
 export default async function Page({ params }) {
-  const { courseId } = params;
+  const { courseId } = await params;
   const course = await getCourseById(courseId);
 
   if (!course) return notFound();

--- a/app/dashboard/library/[bookid]/page.jsx
+++ b/app/dashboard/library/[bookid]/page.jsx
@@ -2,7 +2,7 @@ import { notFound } from "next/navigation";
 import { getBookById } from '@/lib/actions/library/get-book';
 import BookDetailPage from "./BookDetailPageClient";
 export default async function Page({ params }) {
-    const { bookid } = params;
+    const { bookid } = await params;
     const book = await getBookById(bookid);
     if (!book) return notFound();
     return <BookDetailPage book={book} />;

--- a/app/dashboard/library/read/[bookid]/page.jsx
+++ b/app/dashboard/library/read/[bookid]/page.jsx
@@ -3,7 +3,7 @@ import { getBookById } from "@/lib/actions/library/get-book";
 import BookReaderClient from "./BookReaderClient";
 
 export default async function Page({ params }) {
-  const { bookid } = params;
+  const { bookid } = await params;
 
   try {
     const book = await getBookById(bookid);

--- a/app/dashboard/spaces/[spacesid]/page.jsx
+++ b/app/dashboard/spaces/[spacesid]/page.jsx
@@ -8,7 +8,7 @@ import JaasMeetingClientButtons from "@/components/organisms/dashboard/JaasMeeti
 import { joinSpaceWaitlist } from "@/lib/actions/spaces/joinSpaceWaitlist";
 
 export default async function Page({ params }) {
-    const { spacesid } = params;
+    const { spacesid } = await params;
     let space = null;
     try {
         space = await getSpaceById(spacesid);


### PR DESCRIPTION
## Description
Fixes #89 - Updates all synchronous params and cookies() usage to the async API required by Next.js 15.

### Problem
Next.js 15 deprecated synchronous access to params and cookies(). The current code uses params.bookId / params.someId and cookies().get(...) which should be awaited.

This currently works via a deprecation shim but will break in Next 16.

### Changes
1. app/api/books/[bookId]/preview/route.js - await params and await cookies()
2. app/dashboard/spaces/[spacesid]/page.jsx - await params in server component
3. app/dashboard/courses/[courseId]/page.jsx - await params in server component
4. app/dashboard/library/read/[bookid]/page.jsx - await params in server component
5. app/dashboard/library/[bookid]/page.jsx - await params in server component

### Not changed
- Client components already correctly use React.use(params)
- AI route handlers verified they don not use params or cookies()

Closes #89