### PR TITLE
feat: formal landing page for grant review — honest content, working navigation

### DIFF
--- a/app/(pages)/(landingPage)/About.jsx
+++ b/app/(pages)/(landingPage)/About.jsx
@@ -5,7 +5,7 @@ import Button from "@/components/atoms/form/Button";
 
 const About = () => {
   return (
-    <section className="py-16 px-4 sm:px-6 lg:px-8 bg-white/80 backdrop-blur-xl">
+    <section id="mission" className="py-16 px-4 sm:px-6 lg:px-8 bg-white/80 backdrop-blur-xl">
       <div className="max-w-7xl mx-auto">
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-12 lg:gap-16 items-center">
           {/* Left Section - Text Content */}

--- a/app/(pages)/(landingPage)/Footer.jsx
+++ b/app/(pages)/(landingPage)/Footer.jsx
@@ -1,16 +1,10 @@
-import {
-  FaFacebookF,
-  FaTwitter,
-  FaLinkedinIn,
-  FaLongArrowAltRight,
-} from "react-icons/fa";
-import Button from "@/components/atoms/form/Button";
+import { FaTwitter, FaGithub } from "react-icons/fa";
 import { cn } from "@/lib/utils";
 import { poppins_600 } from "@/lib/config/font.config";
 import Link from "next/link";
 export default function Footer() {
   return (
-    <footer className="relative bg-basic text-white overflow-hidden ">
+    <footer id="contact" className="relative bg-basic text-white overflow-hidden ">
      
       {/* Glowing Gradient Background */}
       <div className="absolute inset-0 bg-gradient-to-tr from-green-500 via-slate-800 to-green-500 opacity-30 blur-2xl z-0" />
@@ -41,20 +35,19 @@ export default function Footer() {
             </h3>
             <ul className="space-y-4 text-sm">
               {[
-                "Pricing Policy",
-                "Payment and Refund Policy",
-                "Scheduling Policy",
-                "Cancellation and rescheduling policy",
-                "Privacy Policy",
-                "Terms of Service",
-                "Cookies Policy",
+                { name: "Courses", href: "/dashboard/courses" },
+                { name: "Library", href: "/dashboard/library" },
+                { name: "Community Spaces", href: "/dashboard/spaces" },
+                { name: "Sadaqah Fund", href: "/dashboard/sadaqah" },
+                { name: "Blog", href: "/blog" },
+                { name: "Open Source on GitHub", href: "https://github.com/Deen-Bridge" },
               ].map((link) => (
-                <li key={link}>
+                <li key={link.name}>
                   <a
-                    href={`/${link.toLowerCase()}`}
+                    href={link.href}
                     className="hover:text-secondary transition duration-300 font-light"
                   >
-                    {link}
+                    {link.name}
                   </a>
                 </li>
               ))}
@@ -64,40 +57,31 @@ export default function Footer() {
           {/* Newsletter & Socials */}
           <div>
             <h3 className="text-3xl sm:text-4xl  font-semibold  mb-4 font-stretch-125%">
-              Stay in the Loop
+              Join the Community
             </h3>
-            <form className="flex items-center mb-4">
-              <input
-                type="email"
-                placeholder="Input your email"
-                className="px-4 py-2 w-full sm:w-auto flex-grow text-white rounded-full rounded-r-none focus:outline-none border border-accent placeholder-white"
-              />
-              <Button
-                type="submit"
-                round
-                className="px-4 py-2  rounded-l-md transition border border-accent"
-              >
-                Subscribe
-              </Button>
-            </form>
-            <div className="flex space-x-4 text-2xl  justify-start hover:text-green-600">
+            <p className="text-gray-200 text-sm leading-relaxed mb-6">
+              Deen Bridge is open source and built in public on the Stellar
+              network. Follow our journey, star the project, or contribute
+              on GitHub.
+            </p>
+            <div className="flex items-center gap-4 text-2xl">
               <Link
-                href="#"
-                className="hover:bg-slate-200 rounded-full p-2 sm:p-6 "
+                href="https://github.com/Deen-Bridge"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Deen Bridge on GitHub"
+                className="hover:text-secondary rounded-full p-2 transition"
               >
-                <FaFacebookF className=" transition" />
+                <FaGithub />
               </Link>
               <Link
-                href="#"
-                className="hover:bg-slate-200 rounded-full p-2 sm:p-6"
+                href="https://x.com/deen_bridge"
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="Deen Bridge on X"
+                className="hover:text-secondary rounded-full p-2 transition"
               >
-                <FaTwitter className=" transition" />
-              </Link>
-              <Link
-                href="#"
-                className="hover:bg-slate-200 rounded-full p-2 sm:p-6"
-              >
-                <FaLinkedinIn className=" transition" />
+                <FaTwitter />
               </Link>
             </div>
           </div>
@@ -106,7 +90,7 @@ export default function Footer() {
         {/* Bottom Bar */}
         <div className="border-t border-green-900 pt-6 flex items-center justify-center text-sm text-white font-stretch-125%">
           <p className="text-center md:text-left mt-4 md:mt-0">
-            © 2025 Deen Bridge . All rights reserved.
+            © {new Date().getFullYear()} Deen Bridge. All rights reserved.
           </p>
         </div>
       </div>

--- a/app/(pages)/(landingPage)/Partners.jsx
+++ b/app/(pages)/(landingPage)/Partners.jsx
@@ -1,19 +1,48 @@
 "use client";
 
-import Image from "next/image";
 import { partners } from "@/lib/data";
+
+function initials(name) {
+  const words = name.split(/\s+/).filter((w) => /^[A-Za-z]/.test(w));
+  return words
+    .slice(0, 2)
+    .map((w) => w[0].toUpperCase())
+    .join("");
+}
 
 export default function Partners() {
   return (
     <section className="w-full py-16 px-4 sm:px-8 bg-white dark:bg-basic text-basic dark:text-white flex flex-col items-center overflow-hidden">
-      <h2 className="text-4xl sm:text-8xl font-bold mb-5 text-center">
-        Our Partners
+      <h2 className="text-4xl sm:text-7xl font-bold mb-5 text-center">
+        Trusted Voices in the Ummah
       </h2>
-      <p className="text-xl mb-20 text-center max-w-2xl">
-        We're proud to collaborate with Islamic organizations and communities
-        that share our vision for growth and learning. 
+      <p className="text-xl mb-16 text-center max-w-2xl">
+        We draw inspiration from the Islamic organizations and institutions
+        leading the way in education, community, and service worldwide.
       </p>
-    
+
+      {/* Auto-scrolling marquee */}
+      <div className="relative w-full overflow-hidden">
+        <div className="pointer-events-none absolute inset-y-0 left-0 w-16 sm:w-32 z-10 bg-gradient-to-r from-white dark:from-basic to-transparent" />
+        <div className="pointer-events-none absolute inset-y-0 right-0 w-16 sm:w-32 z-10 bg-gradient-to-l from-white dark:from-basic to-transparent" />
+
+        <div className="flex w-max animate-scroll items-center gap-4 sm:gap-6 py-2">
+          {[...partners, ...partners].map((partner, index) => (
+            <div
+              key={`${partner.name}-${index}`}
+              className="flex items-center gap-3 shrink-0 rounded-full border border-green-900/10 dark:border-white/10 bg-green-50/60 dark:bg-white/5 px-5 py-3 opacity-80 hover:opacity-100 transition-all duration-300"
+              title={partner.name}
+            >
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-green-500 to-emerald-700 text-white text-sm font-bold">
+                {initials(partner.name)}
+              </span>
+              <span className="text-sm sm:text-base font-medium whitespace-nowrap">
+                {partner.name}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
     </section>
   );
 }

--- a/app/(pages)/(landingPage)/Stats.jsx
+++ b/app/(pages)/(landingPage)/Stats.jsx
@@ -7,31 +7,31 @@ import { cn } from "@/lib/utils";
 
 const stats = [
   {
-    k: "10K+",
-    v: "Active Members",
-    icon: Users,
-    description: "Join our growing community of Muslims worldwide",
-    isDark: true,
-  },
-  {
-    k: "500+",
-    v: "Islamic Resources",
+    k: "100%",
+    v: "Non-Custodial Payments",
     icon: CheckCircle2,
-    description: "Curated books, courses, and authentic knowledge",
+    description: "You sign every transaction in your own wallet — we never hold your funds",
     isDark: true,
   },
   {
-    k: "50K+",
-    v: "Discussions",
-    icon: TrendingUp,
-    description: "Meaningful conversations and knowledge sharing",
-    isDark: true,
-  },
-  {
-    k: "98%",
-    v: "Satisfaction Rate",
+    k: "$0.01",
+    v: "Max Network Fees",
     icon: DollarSign,
-    description: "Community members satisfied with their journey",
+    description: "Near-zero fees on Stellar make learning accessible worldwide",
+    isDark: true,
+  },
+  {
+    k: "5s",
+    v: "Payment Settlement",
+    icon: TrendingUp,
+    description: "Educators receive USDC in seconds, not weeks",
+    isDark: true,
+  },
+  {
+    k: "3",
+    v: "Open-Source Services",
+    icon: Users,
+    description: "Web app, API, and AI — all MIT-licensed and built in the open",
     isDark: true,
   },
 ];

--- a/app/(pages)/(landingPage)/WhyDeenBridge.jsx
+++ b/app/(pages)/(landingPage)/WhyDeenBridge.jsx
@@ -46,7 +46,7 @@ const features = [
 
 export default function WhyDeenBridge() {
   return (
-    <section className="relative py-20 px-2 sm:px-6 bg-basic overflow-hidden">
+    <section id="services" className="relative py-20 px-2 sm:px-6 bg-basic overflow-hidden">
       {/* Decorative Islamic motif background */}
       <div className="absolute inset-0 pointer-events-none z-0">
         <div className="absolute left-0 top-0 w-1/2 h-1/2 bg-gradient-to-br from-accent/10 to-transparent rounded-full blur-3xl" />

--- a/app/layout.js
+++ b/app/layout.js
@@ -15,7 +15,7 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata = {
-  title: "Deen Bridge ",
+  title: "Deen Bridge",
   description:
     "Empowering Muslims with authentic knowledge — Learn Qur'an, Arabic, Fiqh, and more through 1-on-1 live mentorship and lots more.",
   openGraph: {
@@ -44,7 +44,7 @@ export const metadata = {
 
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="en" className="scroll-smooth">
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -4,7 +4,7 @@ import React from "react";
 import About from "./(pages)/(landingPage)/About";
 import WhyDeenBridge from "./(pages)/(landingPage)/WhyDeenBridge";
 import HowItWorks from "./(pages)/(landingPage)/HowItWorks";
-import Testimonials from "./(pages)/(landingPage)/Testimonials";
+// import Testimonials from "./(pages)/(landingPage)/Testimonials"; // re-enable with real testimonials
 import CTA from "./(pages)/(landingPage)/CTA";
 import Partners from "./(pages)/(landingPage)/Partners";
 import Stats from "./(pages)/(landingPage)/Stats";
@@ -17,9 +17,9 @@ const page = () => {
       <WhyDeenBridge />
       <Stats />
       {/* <HowItWorks /> */}
-      <Testimonials />
+      {/* <Testimonials /> — disabled until we have real, attributable testimonials */}
       <Partners />
-      {/* <CTA /> */}
+      <CTA />
       <Footer />
     </>
   );

--- a/components/molecules/ladingpage/Navbar.jsx
+++ b/components/molecules/ladingpage/Navbar.jsx
@@ -11,10 +11,11 @@ import {
 } from "@/components/ui/sheet";
 import { AlignJustify } from 'lucide-react';
 const links = [
-  { name: "Service", to: "#services" },
-  { name: "Contact", to: "#contact" },
-  { name: "Blog", to: "/blog" },
   { name: "Mission", to: "#mission" },
+  { name: "Services", to: "#services" },
+  { name: "Blog", to: "/blog" },
+  { name: "GitHub", to: "https://github.com/Deen-Bridge" },
+  { name: "Contact", to: "#contact" },
 ];
 
 const Navbar = () => {

--- a/components/molecules/ladingpage/Navbar.jsx
+++ b/components/molecules/ladingpage/Navbar.jsx
@@ -11,11 +11,11 @@ import {
 } from "@/components/ui/sheet";
 import { AlignJustify } from 'lucide-react';
 const links = [
-  { name: "Mission", to: "#mission" },
-  { name: "Services", to: "#services" },
+  { name: "Mission", to: "/#mission" },
+  { name: "Services", to: "/#services" },
   { name: "Blog", to: "/blog" },
   { name: "GitHub", to: "https://github.com/Deen-Bridge" },
-  { name: "Contact", to: "#contact" },
+  { name: "Contact", to: "/#contact" },
 ];
 
 const Navbar = () => {
@@ -23,6 +23,7 @@ const Navbar = () => {
     <>
       {/* Desktop Nav */}
       <nav className="px-4 sticky top-0 z-10 bg-transparent text-secondary hidden lg:flex justify-between items-center h-20 font-stretch-125%">
+        <Link href="/">
         <Image
           src="/images/dnb-nobg.png"
           width={150}
@@ -30,6 +31,7 @@ const Navbar = () => {
           alt="Logo"
           className="m-6"
         />
+        </Link>
         <div className="flex items-center space-x-6">
           {links.map((link) => (
             <Link
@@ -46,12 +48,14 @@ const Navbar = () => {
 
       {/* Mobile Nav */}
       <nav className="lg:hidden flex items-center justify-between   sticky top-0 z-10 bg-transparent text-secondary">
+        <Link href="/">
         <Image
           src="/images/dnb-nobg.png"
           width={80}
           height={26}
           alt="Logo"
         />
+        </Link>
         <MobileNav />
       </nav>
     </>


### PR DESCRIPTION
## Why

The live site is the first thing OSS grant reviewers (GrantFox, Drips Wave) open. This pass makes the landing page formal, functional, and — critically — **accurate**, since both programs disqualify applications with fabricated information.

## Changes

- **Stats section**: replaced invented metrics (10K+ members, 50K+ discussions, 98% satisfaction) with true, defensible platform facts: 100% non-custodial payments, sub-cent Stellar fees, ~5s settlement, 3 open-source services
- **Testimonials**: disabled until we have real, attributable quotes (fabricated named endorsements are a disqualification risk)
- **Partners**: the empty 'Our Partners' section (with a collaboration claim we can't back) is now an 'inspiration' marquee of Islamic organizations — monogram chips, no dead image URLs (the old Clearbit logo API no longer exists), no partnership claims
- **Navbar**: anchors now work (Mission → About, Services → WhyDeenBridge, Contact → Footer) with smooth scrolling; added a GitHub link for open-source visibility
- **Footer**: removed links to non-existent policy pages and dead social icons; now links to real app sections (Courses, Library, Spaces, Sadaqah, Blog) and real GitHub/X profiles; the non-functional subscribe form is now a 'Join the Community' open-source callout; copyright year is dynamic
- **CTA enabled**: 'Ready to Join Deen Bridge → Get Started' (signup route exists)
- **Metadata**: trimmed stray whitespace in the site title

## Testing

Verified on the dev server: all three anchors render and resolve, no fabricated strings remain in the HTML, new sections render. `npm run lint` and `npm run build` pass.