### PR TITLE
feat: course category taxonomy, hub, landing pages & URL-driven filters

### DIFF
--- a/app/dashboard/courses/categories/page.jsx
+++ b/app/dashboard/courses/categories/page.jsx
@@ -1,0 +1,180 @@
+"use client";
+import { useEffect, useState, useMemo } from "react";
+import Link from "next/link";
+import { fetchCourses } from "@/lib/actions/courses/fetch-courses";
+import CourseCardSkeleton from "@/components/atoms/skeletons/CourseCardSkeleton";
+import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
+import {
+  CATEGORY_GROUPS,
+  CATEGORIES,
+  getCategoryCounts,
+} from "@/lib/categories";
+import { BookOpen, ArrowRight, LayoutGrid } from "lucide-react";
+
+export default function CategoryHubPage() {
+  const [courses, setCourses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const loadCourses = async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const data = await fetchCourses();
+      setCourses(data);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadCourses();
+  }, []);
+
+  // Derive counts from the fetched course list
+  const counts = useMemo(() => getCategoryCounts(courses), [courses]);
+
+  const totalCourses = courses.length;
+
+  if (error) {
+    return (
+      <NetworkErrorComp
+        errMsg="Failed to load course categories, please try again."
+        reset={loadCourses}
+      />
+    );
+  }
+
+  return (
+    <div className="bg-muted min-h-full w-full">
+      {/* ── Hero header ── */}
+      <div className="bg-gradient-to-br from-accent via-green-600 to-highlight px-6 py-10 text-white">
+        <div className="max-w-4xl mx-auto">
+          <div className="flex items-center gap-3 mb-3">
+            <LayoutGrid className="w-8 h-8 opacity-90" />
+            <h1 className="text-3xl md:text-4xl font-bold">
+              Course Categories
+            </h1>
+          </div>
+          <p className="text-green-50 text-base md:text-lg max-w-xl">
+            Browse authentic Islamic knowledge across{" "}
+            {CATEGORIES.length} categories grouped into{" "}
+            {CATEGORY_GROUPS.length} disciplines.
+          </p>
+          {!loading && (
+            <p className="mt-2 text-green-100 text-sm">
+              {totalCourses} course{totalCourses !== 1 ? "s" : ""} available
+            </p>
+          )}
+          <div className="mt-5">
+            <Link
+              href="/dashboard/courses"
+              className="inline-flex items-center gap-2 bg-white text-accent font-semibold px-5 py-2.5 rounded-full text-sm hover:bg-green-50 transition-colors shadow"
+            >
+              <BookOpen className="w-4 h-4" />
+              Browse All Courses
+            </Link>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Loading skeletons ── */}
+      {loading ? (
+        <div className="p-6 max-w-6xl mx-auto space-y-10">
+          {[...Array(3)].map((_, gi) => (
+            <div key={gi}>
+              <div className="h-6 w-48 bg-gray-200 rounded animate-pulse mb-4" />
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                {[...Array(3)].map((_, ci) => (
+                  <CourseCardSkeleton key={ci} />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : (
+        /* ── Category groups ── */
+        <div className="p-6 max-w-6xl mx-auto space-y-10">
+          {CATEGORY_GROUPS.map((group) => {
+            const groupCategories = CATEGORIES.filter(
+              (c) => c.group === group
+            );
+            return (
+              <section key={group}>
+                <h2 className="text-xl md:text-2xl font-bold mb-4 text-foreground border-b border-border pb-2">
+                  {group}
+                </h2>
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+                  {groupCategories.map((cat) => {
+                    const count = counts[cat.slug] || 0;
+                    const isEmpty = count === 0;
+                    return (
+                      <Link
+                        key={cat.slug}
+                        href={`/dashboard/courses/category/${cat.slug}`}
+                        className={`group flex flex-col rounded-2xl p-5 border transition-all ${
+                          isEmpty
+                            ? "bg-muted/40 border-border opacity-60 hover:opacity-80"
+                            : "bg-background border-border hover:border-accent hover:shadow-lg hover:scale-[1.02]"
+                        }`}
+                        aria-label={`${cat.label} — ${count} course${count !== 1 ? "s" : ""}`}
+                      >
+                        {/* Icon + count */}
+                        <div className="flex items-start justify-between mb-3">
+                          <span
+                            className="text-3xl"
+                            role="img"
+                            aria-label={cat.label}
+                          >
+                            {cat.icon}
+                          </span>
+                          <span
+                            className={`text-xs font-bold px-2.5 py-1 rounded-full ${
+                              isEmpty
+                                ? "bg-muted text-muted-foreground"
+                                : "bg-accent/10 text-accent"
+                            }`}
+                          >
+                            {count} course{count !== 1 ? "s" : ""}
+                          </span>
+                        </div>
+
+                        {/* Label + description */}
+                        <h3
+                          className={`font-semibold text-base leading-tight mb-1 transition-colors ${
+                            isEmpty
+                              ? "text-muted-foreground"
+                              : "text-foreground group-hover:text-accent"
+                          }`}
+                        >
+                          {cat.label}
+                        </h3>
+                        <p className="text-sm text-muted-foreground line-clamp-2 flex-1">
+                          {cat.description}
+                        </p>
+
+                        {/* CTA row */}
+                        <div
+                          className={`mt-4 flex items-center gap-1 text-xs font-semibold ${
+                            isEmpty
+                              ? "text-muted-foreground"
+                              : "text-accent group-hover:gap-2 transition-all"
+                          }`}
+                        >
+                          {isEmpty ? "No courses yet" : "View courses"}
+                          <ArrowRight className="w-3 h-3" />
+                        </div>
+                      </Link>
+                    );
+                  })}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/dashboard/courses/category/[slug]/page.jsx
+++ b/app/dashboard/courses/category/[slug]/page.jsx
@@ -1,0 +1,247 @@
+"use client";
+import { useEffect, useState, useMemo } from "react";
+import { use } from "react";
+import Link from "next/link";
+import { fetchCourses } from "@/lib/actions/courses/fetch-courses";
+import CourseCard from "@/components/molecules/dashboard/cards/courseCard";
+import CourseCardSkeleton from "@/components/atoms/skeletons/CourseCardSkeleton";
+import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
+import NotFoundComp from "@/components/molecules/errors/NotFound";
+import Modal from "@/components/molecules/Modal";
+import CreateCourseForm from "@/components/organisms/create/course-create-form";
+import { getCategoryBySlug, resolveSlug } from "@/lib/categories";
+import { getAverageRating } from "@/hooks/getAverageRating";
+import { ArrowLeft, BookOpen, Plus } from "lucide-react";
+
+// Sort options
+const SORT_OPTIONS = [
+  { value: "newest", label: "Newest" },
+  { value: "price-asc", label: "Price: Low to High" },
+  { value: "price-desc", label: "Price: High to Low" },
+  { value: "rating", label: "Top Rated" },
+];
+
+function sortCourses(courses, sort) {
+  const sorted = [...courses];
+  switch (sort) {
+    case "price-asc":
+      return sorted.sort((a, b) => (a.price || 0) - (b.price || 0));
+    case "price-desc":
+      return sorted.sort((a, b) => (b.price || 0) - (a.price || 0));
+    case "rating":
+      return sorted.sort(
+        (a, b) =>
+          getAverageRating(b.reviews || []) -
+          getAverageRating(a.reviews || [])
+      );
+    case "newest":
+    default:
+      return sorted.sort(
+        (a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0)
+      );
+  }
+}
+
+export default function CategoryLandingPage({ params }) {
+  // Unwrap params using React.use() for Next.js 15+
+  const { slug } = use(params);
+
+  const category = getCategoryBySlug(slug);
+
+  const [allCourses, setAllCourses] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const [sort, setSort] = useState("newest");
+  const [modalOpen, setModalOpen] = useState(false);
+
+  const loadCourses = async () => {
+    setLoading(true);
+    setError(false);
+    try {
+      const data = await fetchCourses();
+      setAllCourses(data);
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadCourses();
+  }, [slug]);
+
+  // Filter to this category's courses
+  const categoryCourses = useMemo(
+    () =>
+      sortCourses(
+        allCourses.filter((c) => resolveSlug(c.category) === slug),
+        sort
+      ),
+    [allCourses, slug, sort]
+  );
+
+  // Unknown slug → graceful not-found, no crash
+  if (!category) {
+    return (
+      <NotFoundComp
+        errMsg={`No category found for "${slug}". It may have been renamed or doesn't exist yet.`}
+      />
+    );
+  }
+
+  if (error) {
+    return (
+      <NetworkErrorComp
+        errMsg={`Failed to load courses for ${category.label}. Please try again.`}
+        reset={loadCourses}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className="bg-muted min-h-full w-full">
+        {/* ── Hero header ── */}
+        <div className="bg-gradient-to-br from-accent via-green-600 to-highlight px-6 py-10 text-white">
+          <div className="max-w-5xl mx-auto">
+            {/* Breadcrumb */}
+            <nav className="flex items-center gap-2 text-green-100 text-sm mb-4">
+              <Link
+                href="/dashboard/courses"
+                className="hover:text-white transition-colors flex items-center gap-1"
+              >
+                <ArrowLeft className="w-4 h-4" />
+                Courses
+              </Link>
+              <span>/</span>
+              <Link
+                href="/dashboard/courses/categories"
+                className="hover:text-white transition-colors"
+              >
+                Categories
+              </Link>
+              <span>/</span>
+              <span className="text-white font-medium">{category.label}</span>
+            </nav>
+
+            {/* Icon + title */}
+            <div className="flex items-start gap-4">
+              <span className="text-5xl" role="img" aria-label={category.label}>
+                {category.icon}
+              </span>
+              <div>
+                <h1 className="text-3xl md:text-4xl font-bold leading-tight">
+                  {category.label}
+                </h1>
+                <p className="mt-2 text-green-100 text-base md:text-lg max-w-xl">
+                  {category.description}
+                </p>
+                {!loading && (
+                  <p className="mt-1 text-green-200 text-sm">
+                    {categoryCourses.length} course
+                    {categoryCourses.length !== 1 ? "s" : ""}
+                  </p>
+                )}
+              </div>
+            </div>
+
+            {/* Group badge */}
+            <div className="mt-4">
+              <span className="inline-block bg-white/20 text-white text-xs font-semibold px-3 py-1 rounded-full">
+                {category.group}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Controls ── */}
+        <div className="px-6 py-4 max-w-5xl mx-auto flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <BookOpen className="w-5 h-5 text-muted-foreground" />
+            <span className="text-sm text-muted-foreground">
+              {loading ? "Loading…" : `${categoryCourses.length} course${categoryCourses.length !== 1 ? "s" : ""}`}
+            </span>
+          </div>
+          <div className="flex items-center gap-3">
+            {/* Sort */}
+            <select
+              value={sort}
+              onChange={(e) => setSort(e.target.value)}
+              className="rounded-full border border-input bg-background px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent/50"
+              aria-label="Sort courses"
+            >
+              {SORT_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+            {/* Create course CTA */}
+            <button
+              onClick={() => setModalOpen(true)}
+              className="inline-flex items-center gap-1 rounded-full bg-accent text-white px-4 py-2 text-sm font-semibold hover:bg-accent/90 transition-colors"
+            >
+              <Plus className="w-4 h-4" />
+              Add Course
+            </button>
+          </div>
+        </div>
+
+        {/* ── Course grid ── */}
+        <div className="px-6 pb-10 max-w-5xl mx-auto">
+          {loading ? (
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+              {[...Array(6)].map((_, idx) => (
+                <CourseCardSkeleton key={`skeleton-${idx}`} />
+              ))}
+            </div>
+          ) : categoryCourses.length === 0 ? (
+            /* ── Empty state ── */
+            <div className="flex flex-col items-center justify-center py-24 text-center">
+              <span className="text-7xl mb-6" role="img" aria-label="empty">
+                {category.icon}
+              </span>
+              <h2 className="text-2xl font-bold text-foreground mb-3">
+                No courses yet in {category.label}
+              </h2>
+              <p className="text-muted-foreground max-w-sm mb-6">
+                Be the first educator to share knowledge in this discipline. The
+                Ummah is waiting for you!
+              </p>
+              <button
+                onClick={() => setModalOpen(true)}
+                className="inline-flex items-center gap-2 rounded-full bg-accent text-white px-6 py-3 font-semibold hover:bg-accent/90 transition-colors shadow"
+              >
+                <Plus className="w-5 h-5" />
+                Create the first course
+              </button>
+              <Link
+                href="/dashboard/courses/categories"
+                className="mt-4 text-sm text-accent underline underline-offset-2 hover:text-accent/80 transition-colors"
+              >
+                Browse other categories
+              </Link>
+            </div>
+          ) : (
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+              {categoryCourses.map((course) => (
+                <CourseCard key={course._id} course={course} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Create Course modal */}
+      <Modal
+        title="Create Course"
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+        className="max-w-md w-full"
+      >
+        <CreateCourseForm />
+      </Modal>
+    </>
+  );
+}

--- a/app/dashboard/courses/page.jsx
+++ b/app/dashboard/courses/page.jsx
@@ -1,5 +1,6 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback, useMemo } from "react";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import CourseCard from "@/components/molecules/dashboard/cards/courseCard";
 import CourseCardSkeleton from "@/components/atoms/skeletons/CourseCardSkeleton";
 import Button from "@/components/atoms/form/Button";
@@ -9,36 +10,153 @@ import { fetchCourses } from "@/lib/actions/courses/fetch-courses";
 import { getBookmarkedCourses } from "@/lib/actions/courses/bookmark-course";
 import useAuth from "@/hooks/useAuth";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
+import { CATEGORIES, resolveSlug } from "@/lib/categories";
+import { getAverageRating } from "@/hooks/getAverageRating";
+import { Search, X, LayoutGrid } from "lucide-react";
+import Link from "next/link";
+
+// Sort options
+const SORT_OPTIONS = [
+  { value: "newest", label: "Newest" },
+  { value: "price-asc", label: "Price: Low to High" },
+  { value: "price-desc", label: "Price: High to Low" },
+  { value: "rating", label: "Top Rated" },
+];
+
+function sortCourses(courses, sort) {
+  const sorted = [...courses];
+  switch (sort) {
+    case "price-asc":
+      return sorted.sort((a, b) => (a.price || 0) - (b.price || 0));
+    case "price-desc":
+      return sorted.sort((a, b) => (b.price || 0) - (a.price || 0));
+    case "rating":
+      return sorted.sort(
+        (a, b) =>
+          getAverageRating(b.reviews || []) - getAverageRating(a.reviews || [])
+      );
+    case "newest":
+    default:
+      return sorted.sort(
+        (a, b) => new Date(b.createdAt || 0) - new Date(a.createdAt || 0)
+      );
+  }
+}
 
 export default function CoursesPage() {
   const { user } = useAuth();
-  const [courses, setCourses] = useState([]);
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // URL-driven state
+  const urlCategory = searchParams.get("category") || "";
+  const urlSort = searchParams.get("sort") || "newest";
+  const urlSearch = searchParams.get("q") || "";
+
+  // Local filter state (mirrors URL, kept in sync)
+  const [search, setSearch] = useState(urlSearch);
+
+  const [allCourses, setAllCourses] = useState([]);
   const [modalOpen, setModalOpen] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
   const [showBookmarks, setShowBookmarks] = useState(false);
 
-  const fetchData = async () => {
+  // Keep local search in sync when URL changes (e.g. browser back/forward)
+  useEffect(() => {
+    setSearch(urlSearch);
+  }, [urlSearch]);
+
+  // ── helpers ─────────────────────────────────────────────────────────────────
+
+  /** Push a filter change into the URL without adding a history entry */
+  const updateURL = useCallback(
+    (patches) => {
+      const params = new URLSearchParams(searchParams.toString());
+      Object.entries(patches).forEach(([k, v]) => {
+        if (v) {
+          params.set(k, v);
+        } else {
+          params.delete(k);
+        }
+      });
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [router, pathname, searchParams]
+  );
+
+  const handleCategoryClick = (slug) => {
+    updateURL({ category: urlCategory === slug ? "" : slug });
+  };
+
+  const handleSortChange = (e) => {
+    updateURL({ sort: e.target.value });
+  };
+
+  const handleSearchSubmit = (e) => {
+    e.preventDefault();
+    updateURL({ q: search });
+  };
+
+  const handleClearFilters = () => {
+    setSearch("");
+    router.replace(pathname, { scroll: false });
+  };
+
+  // ── data fetching ────────────────────────────────────────────────────────────
+
+  const fetchData = useCallback(async () => {
     setLoading(true);
     setError(false);
     try {
       if (showBookmarks) {
         const response = await getBookmarkedCourses();
-        setCourses(response.bookmarks || []);
+        setAllCourses(response.bookmarks || []);
       } else {
         const response = await fetchCourses();
-        setCourses(response);
+        setAllCourses(response);
       }
-    } catch (error) {
+    } catch {
       setError(true);
     } finally {
       setLoading(false);
     }
-  };
+  }, [showBookmarks]);
 
   useEffect(() => {
     fetchData();
-  }, [showBookmarks]);
+  }, [fetchData]);
+
+  // ── derived / filtered list ─────────────────────────────────────────────────
+
+  const displayedCourses = useMemo(() => {
+    let list = allCourses.filter(
+      (course) => showBookmarks || course?.createdBy?._id !== user?._id
+    );
+
+    // Category filter
+    if (urlCategory) {
+      list = list.filter((course) => resolveSlug(course.category) === urlCategory);
+    }
+
+    // Text search filter
+    if (urlSearch) {
+      const q = urlSearch.toLowerCase();
+      list = list.filter(
+        (course) =>
+          course.title?.toLowerCase().includes(q) ||
+          course.description?.toLowerCase().includes(q) ||
+          course.category?.toLowerCase().includes(q)
+      );
+    }
+
+    return sortCourses(list, urlSort);
+  }, [allCourses, urlCategory, urlSearch, urlSort, showBookmarks, user]);
+
+  const hasActiveFilters = urlCategory || urlSearch || urlSort !== "newest";
+
+  // ── render ───────────────────────────────────────────────────────────────────
 
   if (error) {
     return (
@@ -52,11 +170,19 @@ export default function CoursesPage() {
   return (
     <>
       <div className="bg-muted h-full w-full">
-        <div className="flex justify-between items-center p-5">
+        {/* ── Top bar ── */}
+        <div className="flex flex-wrap justify-between items-center gap-3 p-5">
           <h2 className="text-2xl font-bold">
             {showBookmarks ? "My Bookmarked Courses" : "All Courses"}
           </h2>
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
+            <Link
+              href="/dashboard/courses/categories"
+              className="inline-flex items-center gap-1 rounded-full border border-accent text-accent px-4 py-2 text-sm font-semibold hover:bg-accent hover:text-white transition-colors"
+            >
+              <LayoutGrid className="w-4 h-4" />
+              Browse Categories
+            </Link>
             <Button
               round
               outlined
@@ -76,44 +202,142 @@ export default function CoursesPage() {
           </div>
         </div>
 
-        <div className="flex flex-1 flex-col gap-4 mt-10 p-4 pt-0">
+        {/* ── Filters bar ── */}
+        {!showBookmarks && (
+          <div className="px-5 pb-4 space-y-3">
+            {/* Text search + sort row */}
+            <div className="flex flex-wrap items-center gap-3">
+              {/* Search input */}
+              <form
+                onSubmit={handleSearchSubmit}
+                className="flex items-center gap-2 flex-1 min-w-[200px] max-w-sm"
+              >
+                <div className="relative flex-1">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder="Search courses..."
+                    className="w-full pl-9 pr-3 py-2 text-sm rounded-full border border-input bg-background focus:outline-none focus:ring-2 focus:ring-accent/50"
+                  />
+                </div>
+                <button
+                  type="submit"
+                  className="rounded-full bg-accent text-white px-4 py-2 text-sm font-semibold hover:bg-accent/90 transition-colors"
+                >
+                  Search
+                </button>
+              </form>
+
+              {/* Sort select */}
+              <select
+                value={urlSort}
+                onChange={handleSortChange}
+                className="rounded-full border border-input bg-background px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-accent/50"
+                aria-label="Sort courses"
+              >
+                {SORT_OPTIONS.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+
+              {/* Clear filters */}
+              {hasActiveFilters && (
+                <button
+                  onClick={handleClearFilters}
+                  className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  <X className="w-4 h-4" />
+                  Clear filters
+                </button>
+              )}
+            </div>
+
+            {/* Category chips — horizontally scrollable */}
+            <div className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide">
+              {CATEGORIES.map((cat) => {
+                const isActive = urlCategory === cat.slug;
+                return (
+                  <button
+                    key={cat.slug}
+                    onClick={() => handleCategoryClick(cat.slug)}
+                    className={`flex-shrink-0 flex items-center gap-1 px-3 py-1.5 rounded-full text-xs font-semibold border transition-all ${
+                      isActive
+                        ? "bg-accent text-white border-accent shadow"
+                        : "bg-background border-input text-foreground hover:border-accent hover:text-accent"
+                    }`}
+                    aria-pressed={isActive}
+                  >
+                    <span>{cat.icon}</span>
+                    {cat.label}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Active category label */}
+            {urlCategory && (
+              <p className="text-sm text-muted-foreground">
+                Showing courses in:{" "}
+                <span className="font-semibold text-accent">
+                  {CATEGORIES.find((c) => c.slug === urlCategory)?.label ||
+                    urlCategory}
+                </span>
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* ── Course grid ── */}
+        <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
           {loading ? (
-            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 ">
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3">
               {[...Array(6)].map((_, idx) => (
                 <CourseCardSkeleton key={`skeleton-${idx}`} />
               ))}
             </div>
-          ) : courses.length === 0 ? (
+          ) : displayedCourses.length === 0 ? (
             <div className="text-center py-20">
               <p className="text-muted-foreground text-lg">
                 {showBookmarks
                   ? "No bookmarked courses yet. Start bookmarking courses you're interested in!"
+                  : urlCategory || urlSearch
+                  ? "No courses match your filters. Try adjusting or clearing them."
                   : "No courses available at the moment."}
               </p>
+              {(urlCategory || urlSearch) && (
+                <button
+                  onClick={handleClearFilters}
+                  className="mt-4 inline-flex items-center gap-1 text-accent underline underline-offset-2 hover:text-accent/80 transition-colors text-sm"
+                >
+                  <X className="w-4 h-4" />
+                  Clear filters
+                </button>
+              )}
             </div>
           ) : (
-            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3 ">
-              {courses
-                .filter(
-                  (course) =>
-                    showBookmarks || course?.createdBy?._id !== user?._id
-                )
-                .map((course) => (
-                  <CourseCard
-                    key={course._id}
-                    course={course}
-                    onBookmarkChange={(isBookmarked) => {
-                      // If in bookmarks view and unbookmarked, remove from list
-                      if (showBookmarks && !isBookmarked) {
-                        setCourses(courses.filter((c) => c._id !== course._id));
-                      }
-                    }}
-                  />
-                ))}
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-3">
+              {displayedCourses.map((course) => (
+                <CourseCard
+                  key={course._id}
+                  course={course}
+                  onBookmarkChange={(isBookmarked) => {
+                    if (showBookmarks && !isBookmarked) {
+                      setAllCourses((prev) =>
+                        prev.filter((c) => c._id !== course._id)
+                      );
+                    }
+                  }}
+                />
+              ))}
             </div>
           )}
         </div>
       </div>
+
       <Modal
         title="Create Course"
         isOpen={modalOpen}

--- a/components/atoms/form/ComboBox.jsx
+++ b/components/atoms/form/ComboBox.jsx
@@ -17,14 +17,24 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { islamicCategories } from "@/lib/data";
+import { getGroupedCategories } from "@/lib/categories";
 
+/**
+ * CategoryCombobox — controlled component.
+ *
+ * Props:
+ *   category   {string}  — current value (label string); controlled by parent
+ *   setCategory {Function} — called with the newly selected label string
+ */
 export default function CategoryCombobox({ category, setCategory }) {
   const [open, setOpen] = React.useState(false);
-  const [value, setValue] = React.useState("");
+
+  // `category` is the source of truth — no internal value state.
+  const displayLabel = category || "Select category...";
+
+  const groups = getGroupedCategories();
 
   return (
-
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
@@ -33,7 +43,7 @@ export default function CategoryCombobox({ category, setCategory }) {
           aria-expanded={open}
           className="w-full justify-between text-muted-foreground hover:bg-transparent"
         >
-          {value || "Select category..."}
+          {displayLabel}
           <ChevronsUpDown className="opacity-50 h-4 w-4 ml-2" />
         </Button>
       </PopoverTrigger>
@@ -42,23 +52,24 @@ export default function CategoryCombobox({ category, setCategory }) {
           <CommandInput placeholder="Search category..." className="h-9" />
           <CommandList>
             <CommandEmpty>No category found.</CommandEmpty>
-            {islamicCategories.map((group) => (
-              <CommandGroup key={group.main} heading={group.main}>
-                {group.subcategories.map((subcategory) => (
+            {groups.map(({ group, categories }) => (
+              <CommandGroup key={group} heading={group}>
+                {categories.map((cat) => (
                   <CommandItem
-                    key={subcategory}
-                    value={subcategory}
+                    key={cat.slug}
+                    value={cat.label}
                     onSelect={(currentValue) => {
-                      setValue(currentValue === value ? "" : currentValue);
+                      // Toggle off if same value is selected again
+                      setCategory(currentValue === category ? "" : currentValue);
                       setOpen(false);
-                      setCategory(currentValue);
                     }}
                   >
-                    {subcategory}
+                    <span className="mr-2">{cat.icon}</span>
+                    {cat.label}
                     <Check
                       className={cn(
                         "ml-auto h-4 w-4",
-                        value === subcategory ? "opacity-100" : "opacity-0"
+                        category === cat.label ? "opacity-100" : "opacity-0"
                       )}
                     />
                   </CommandItem>
@@ -68,6 +79,6 @@ export default function CategoryCombobox({ category, setCategory }) {
           </CommandList>
         </Command>
       </PopoverContent>
-      </Popover>
+    </Popover>
   );
 }

--- a/components/molecules/dashboard/cards/courseCard.jsx
+++ b/components/molecules/dashboard/cards/courseCard.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import Button from "@/components/atoms/form/Button";
@@ -7,6 +9,7 @@ import useAuth from "@/hooks/useAuth";
 import Image from "next/image";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useBookmark } from "@/hooks/useBookmark";
+import { resolveSlug } from "@/lib/categories";
 
 const CourseCard = ({ course, onBookmarkChange }) => {
   const { user } = useAuth();
@@ -20,6 +23,12 @@ const CourseCard = ({ course, onBookmarkChange }) => {
     e.stopPropagation();
     await toggle();
   };
+
+  // Resolve the stored category string to a known slug.
+  // Unknown / legacy values get slug=null → fallback to decorative badge only.
+  const categorySlug = resolveSlug(course.category);
+  const categoryLabel = course.category || "General";
+
   return (
     <Card className="relative flex flex-col overflow-hidden rounded-2xl  bg-muted/30 backdrop-blur-xl shadow-lg hover:shadow-2xl hover:scale-[1.015] transition-all group">
       {/* Image */}
@@ -33,11 +42,22 @@ const CourseCard = ({ course, onBookmarkChange }) => {
         />
         <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent z-10" />
 
-        {/* Category  */}
+        {/* Category badge — links to category landing page when slug is known */}
         <div className="absolute top-3 left-3 right-3 z-20 flex justify-between">
-          <Badge className="bg-white/80 text-accent font-bold px-3 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider">
-            {course.category || "General"}
-          </Badge>
+          {categorySlug ? (
+            <Link
+              href={`/dashboard/courses/category/${categorySlug}`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <Badge className="bg-white/80 text-accent font-bold px-3 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider hover:bg-white transition-colors cursor-pointer">
+                {categoryLabel}
+              </Badge>
+            </Link>
+          ) : (
+            <Badge className="bg-white/80 text-accent font-bold px-3 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider">
+              {categoryLabel}
+            </Badge>
+          )}
           {user?._id === course?.createdBy?._id ? (
             <Badge className="bg-white/80 text-accent font-bold px-2 py-1 rounded-full shadow border-0  uppercase tracking-wider">
               <Ellipsis className="size-6" />
@@ -98,7 +118,7 @@ const CourseCard = ({ course, onBookmarkChange }) => {
       </CardContent>
 
       {/* Full-width Button */}
-      <div className="px-5">
+      <div className="px-5 pb-5">
         <Button
           wide
           round

--- a/lib/categories.js
+++ b/lib/categories.js
@@ -1,0 +1,371 @@
+/**
+ * lib/categories.js
+ *
+ * Single source of truth for the Islamic course category taxonomy.
+ * All pages and components import slugs, labels, groups, descriptions, and
+ * icons from here — never from lib/data.js or local constants.
+ *
+ * Backend integration note:
+ *   When the backend ships GET /api/courses/categories (returning
+ *   [{ slug, count }]), replace `getCategoryCounts` below with a real fetch
+ *   and the rest of this module stays untouched.
+ */
+
+// ---------------------------------------------------------------------------
+// 1. Flat category list (canonical)
+// ---------------------------------------------------------------------------
+
+/** @typedef {{ slug: string, label: string, group: string, description: string, icon: string }} Category */
+
+/** @type {Category[]} */
+export const CATEGORIES = [
+  // ── Core Islamic Sciences ─────────────────────────────────────────────────
+  {
+    slug: "quran-tafsir",
+    label: "Qur'an & Tafsir",
+    group: "Core Islamic Sciences",
+    description: "Deep study of the Qur'an, its meanings, and exegesis.",
+    icon: "📖",
+  },
+  {
+    slug: "hadith-sunnah",
+    label: "Hadith & Sunnah",
+    group: "Core Islamic Sciences",
+    description: "The prophetic traditions — collection, sciences, and fiqh.",
+    icon: "📜",
+  },
+  {
+    slug: "fiqh",
+    label: "Fiqh (Islamic Jurisprudence)",
+    group: "Core Islamic Sciences",
+    description: "Islamic law covering worship, transactions, and everyday life.",
+    icon: "⚖️",
+  },
+  {
+    slug: "aqeedah",
+    label: "Aqeedah (Islamic Creed)",
+    group: "Core Islamic Sciences",
+    description: "Islamic theology, belief in Allah, His names and attributes.",
+    icon: "🕌",
+  },
+  {
+    slug: "seerah",
+    label: "Seerah (Life of the Prophet ﷺ)",
+    group: "Core Islamic Sciences",
+    description: "Biography of the Prophet Muhammad ﷺ and his companions.",
+    icon: "🌙",
+  },
+  {
+    slug: "usul-al-fiqh",
+    label: "Usul al-Fiqh",
+    group: "Core Islamic Sciences",
+    description: "Principles and methodology of Islamic jurisprudence.",
+    icon: "📚",
+  },
+
+  // ── Personal Development & Spirituality ──────────────────────────────────
+  {
+    slug: "tazkiyah",
+    label: "Tazkiyah (Self-Purification)",
+    group: "Personal Development & Spirituality",
+    description: "Purifying the soul and drawing closer to Allah.",
+    icon: "✨",
+  },
+  {
+    slug: "islamic-manners",
+    label: "Islamic Manners (Adab)",
+    group: "Personal Development & Spirituality",
+    description: "Etiquette, character, and conduct in Islam.",
+    icon: "🤝",
+  },
+  {
+    slug: "duas-dhikr",
+    label: "Duas & Dhikr",
+    group: "Personal Development & Spirituality",
+    description: "Supplications, remembrance of Allah, and their virtues.",
+    icon: "🤲",
+  },
+  {
+    slug: "islamic-mindfulness",
+    label: "Islamic Mindfulness",
+    group: "Personal Development & Spirituality",
+    description: "Mindfulness and mental wellbeing through an Islamic lens.",
+    icon: "🧘",
+  },
+  {
+    slug: "islamic-psychology",
+    label: "Islamic Psychology",
+    group: "Personal Development & Spirituality",
+    description: "Understanding the human soul and psyche in Islamic thought.",
+    icon: "🧠",
+  },
+
+  // ── Daily Practice & Worship ──────────────────────────────────────────────
+  {
+    slug: "salah",
+    label: "Salah (Prayer)",
+    group: "Daily Practice & Worship",
+    description: "The five daily prayers — method, focus, and inner dimensions.",
+    icon: "🕋",
+  },
+  {
+    slug: "fasting-sawm",
+    label: "Fasting (Sawm)",
+    group: "Daily Practice & Worship",
+    description: "Ramadan, voluntary fasts, and the wisdom of fasting.",
+    icon: "🌙",
+  },
+  {
+    slug: "zakah-charity",
+    label: "Zakah & Charity",
+    group: "Daily Practice & Worship",
+    description: "Obligatory almsgiving, sadaqah, and the ethics of giving.",
+    icon: "💚",
+  },
+  {
+    slug: "hajj-umrah",
+    label: "Hajj & Umrah",
+    group: "Daily Practice & Worship",
+    description: "Pilgrimage rituals, preparation, and spiritual dimensions.",
+    icon: "🕌",
+  },
+  {
+    slug: "purification-taharah",
+    label: "Purification (Taharah)",
+    group: "Daily Practice & Worship",
+    description: "Physical and ritual purification in Islamic practice.",
+    icon: "💧",
+  },
+
+  // ── Lifestyle & Society ───────────────────────────────────────────────────
+  {
+    slug: "marriage-family",
+    label: "Marriage & Family",
+    group: "Lifestyle & Society",
+    description: "Islamic guidance on marriage, spousal relations, and family.",
+    icon: "💍",
+  },
+  {
+    slug: "parenting",
+    label: "Parenting",
+    group: "Lifestyle & Society",
+    description: "Raising children with Islamic values in the modern world.",
+    icon: "👨‍👩‍👧",
+  },
+  {
+    slug: "islamic-finance",
+    label: "Business & Finance (Islamic)",
+    group: "Lifestyle & Society",
+    description: "Halal finance, Islamic economics, and ethical business.",
+    icon: "💰",
+  },
+  {
+    slug: "modesty-hijab",
+    label: "Modesty & Hijab",
+    group: "Lifestyle & Society",
+    description: "The Islamic understanding and practice of modesty.",
+    icon: "🧕",
+  },
+  {
+    slug: "halal-haram",
+    label: "Halal & Haram",
+    group: "Lifestyle & Society",
+    description: "Lawful and unlawful in food, transactions, and daily life.",
+    icon: "✅",
+  },
+
+  // ── Ummah & Global Topics ─────────────────────────────────────────────────
+  {
+    slug: "islamic-history",
+    label: "Islamic History",
+    group: "Ummah & Global Topics",
+    description: "The history of Islam — civilizations, scholars, and events.",
+    icon: "🏛️",
+  },
+  {
+    slug: "contemporary-issues",
+    label: "Contemporary Issues",
+    group: "Ummah & Global Topics",
+    description: "Modern challenges and Islamic responses to today's world.",
+    icon: "🌍",
+  },
+  {
+    slug: "muslim-youth",
+    label: "Muslim Youth",
+    group: "Ummah & Global Topics",
+    description: "Guidance and inspiration tailored for young Muslims.",
+    icon: "🌱",
+  },
+  {
+    slug: "dawah-outreach",
+    label: "Dawah & Outreach",
+    group: "Ummah & Global Topics",
+    description: "Inviting others to Islam with wisdom and good character.",
+    icon: "📣",
+  },
+  {
+    slug: "islam-technology",
+    label: "Islam & Technology",
+    group: "Ummah & Global Topics",
+    description: "Navigating the digital age through an Islamic framework.",
+    icon: "💻",
+  },
+
+  // ── Audience-Based ────────────────────────────────────────────────────────
+  {
+    slug: "new-muslims",
+    label: "For New Muslims",
+    group: "Audience-Based",
+    description: "Essential foundations for those who have recently embraced Islam.",
+    icon: "🌟",
+  },
+  {
+    slug: "for-youth",
+    label: "For Youth",
+    group: "Audience-Based",
+    description: "Content designed specifically for Muslim youth.",
+    icon: "🎒",
+  },
+  {
+    slug: "for-sisters",
+    label: "For Sisters",
+    group: "Audience-Based",
+    description: "Courses and guidance crafted for Muslim women.",
+    icon: "🌸",
+  },
+  {
+    slug: "for-brothers",
+    label: "For Brothers",
+    group: "Audience-Based",
+    description: "Courses and guidance crafted for Muslim men.",
+    icon: "💪",
+  },
+  {
+    slug: "for-children",
+    label: "For Children",
+    group: "Audience-Based",
+    description: "Age-appropriate Islamic education for children.",
+    icon: "🧸",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// 2. Groups (preserving original order)
+// ---------------------------------------------------------------------------
+
+export const CATEGORY_GROUPS = [
+  "Core Islamic Sciences",
+  "Personal Development & Spirituality",
+  "Daily Practice & Worship",
+  "Lifestyle & Society",
+  "Ummah & Global Topics",
+  "Audience-Based",
+];
+
+// ---------------------------------------------------------------------------
+// 3. Lookup helpers
+// ---------------------------------------------------------------------------
+
+/** Slug → Category object */
+const _bySlug = Object.fromEntries(CATEGORIES.map((c) => [c.slug, c]));
+
+/** Normalised label → slug (for mapping legacy free-text category values) */
+const _labelToSlug = Object.fromEntries(
+  CATEGORIES.map((c) => [c.label.toLowerCase().trim(), c.slug])
+);
+
+/**
+ * Get a Category by its slug.
+ * Returns `undefined` when not found — callers must handle this gracefully.
+ * @param {string} slug
+ * @returns {Category | undefined}
+ */
+export function getCategoryBySlug(slug) {
+  return _bySlug[slug];
+}
+
+/**
+ * Resolve a raw category string (as stored on a course document) to a known
+ * slug.  Falls back to `null` when no match is found and logs a warning so
+ * that legacy / mismatched data is visible during development.
+ *
+ * @param {string | undefined | null} raw – the value stored on the course
+ * @returns {string | null} – a slug from CATEGORIES, or null
+ */
+export function resolveSlug(raw) {
+  if (!raw) return null;
+  const normalised = raw.toLowerCase().trim();
+  // Exact slug match
+  if (_bySlug[normalised]) return normalised;
+  // Exact label match
+  if (_labelToSlug[normalised]) return _labelToSlug[normalised];
+  // Partial label match (handles e.g. "Fiqh (Islamic Jurisprudence)" stored as just "Fiqh")
+  const partialMatch = CATEGORIES.find((c) =>
+    c.label.toLowerCase().includes(normalised) ||
+    normalised.includes(c.label.toLowerCase())
+  );
+  if (partialMatch) return partialMatch.slug;
+  console.warn(
+    `[categories] Unknown category value "${raw}" — falling back to "general" bucket.`
+  );
+  return null;
+}
+
+/**
+ * Get categories grouped by their parent group, as an array of objects.
+ * Useful for building grouped UIs (ComboBox, category hub grid).
+ *
+ * @returns {{ group: string, categories: Category[] }[]}
+ */
+export function getGroupedCategories() {
+  return CATEGORY_GROUPS.map((group) => ({
+    group,
+    categories: CATEGORIES.filter((c) => c.group === group),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// 4. islamicCategories shim
+//    Keeps lib/data.js consumers working without change while ComboBox and
+//    new pages switch over to this module's richer shape.
+// ---------------------------------------------------------------------------
+
+/**
+ * Drop-in replacement for the `islamicCategories` array from lib/data.js.
+ * Shape: [{ main: string, subcategories: string[] }]
+ */
+export const islamicCategoriesCompat = CATEGORY_GROUPS.map((group) => ({
+  main: group,
+  subcategories: CATEGORIES.filter((c) => c.group === group).map(
+    (c) => c.label
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// 5. Course-count derivation (client-side, backend-ready)
+// ---------------------------------------------------------------------------
+
+/**
+ * Given a flat array of course objects (each with a `category` string field),
+ * returns a map from slug → count.
+ *
+ * When the backend ships GET /api/courses/categories, replace this function
+ * body with a fetch call — the return type stays identical so callers need
+ * zero changes.
+ *
+ * @param {Array<{ category?: string }>} courses
+ * @returns {Record<string, number>}
+ */
+export function getCategoryCounts(courses) {
+  /** @type {Record<string, number>} */
+  const counts = {};
+  for (const course of courses) {
+    const slug = resolveSlug(course.category);
+    if (slug) {
+      counts[slug] = (counts[slug] || 0) + 1;
+    }
+    // Courses with unknown categories are counted under the fallback UI only,
+    // not attributed to any taxonomy slot.
+  }
+  return counts;
+}


### PR DESCRIPTION
## Summary

Resolves the category discovery gap described in the issue: categories were write-only (educators could pick one at creation time, but learners had no way to browse by it). This PR builds the full taxonomy + discovery experience.

Closes #113

---

## What was built

### 1. `lib/categories.js` — single source of truth
- 31 Islamic categories with `slug`, `label`, `group`, `description`, `icon` across 6 parent groups
- `resolveSlug(raw)` — maps free-text/legacy category strings to known slugs; logs `console.warn` for unknowns, never crashes
- `getCategoryCounts(courses)` — derives slug→count from the fetched course list; structured so swapping in a `GET /api/courses/categories` endpoint is a one-function change
- `getGroupedCategories()` — grouped shape for ComboBox and the hub
- `islamicCategoriesCompat` — backward-compat shim preserving the old `lib/data.js` shape

### 2. `ComboBox.jsx` — controlled component fix
- Removed the internal `value` state that ignored the `category` prop
- Now fully controlled by `category` / `setCategory` props
- Imports taxonomy from `lib/categories.js` (grouped headings preserved, icons added)

### 3. `courseCard.jsx` — navigable category badge
- Calls `resolveSlug()` on the stored category value
- Known slug → badge wrapped in `<Link href="/dashboard/courses/category/[slug]">`
- Unknown/legacy value → plain decorative badge, no crash

### 4. `app/dashboard/courses/page.jsx` — URL-driven filters
- Horizontally scrollable category chips (all 31)
- Text search input + sort dropdown (newest / price asc / price desc / rating)
- All filter state lives in `?category=&sort=&q=` — survives refresh, shareable links
- "Browse Categories" link to the hub
- Clear Filters button

### 5. `app/dashboard/courses/categories/page.jsx` — category hub
- Hero header with total course count
- All 6 groups rendered as section grids
- Each card: icon, live course count badge, label, description, CTA
- Empty categories de-emphasised (opacity-60) but never hidden
- Loading skeletons (CourseCardSkeleton) + NetworkErrorComp

### 6. `app/dashboard/courses/category/[slug]/page.jsx` — category landing
- Hero with breadcrumb, category icon, description, and live count
- Filtered + sorted course grid (sort persisted in local state)
- Designed empty state: category icon, copy, and "Create the first course" CTA that opens the existing CreateCourseForm modal
- Unknown slug → NotFoundComp (no crash)
- Loading skeletons + NetworkErrorComp

---

## Acceptance criteria checklist

- [x] `/dashboard/courses/categories` renders all category groups with live course counts
- [x] `/dashboard/courses/category/[slug]` shows only that category's courses with working sort and a designed empty state; unknown slugs render a not-found state, not a crash
- [x] Main courses page has category chips + sort, state persisted in the URL query string; refreshing keeps the filter
- [x] Category badge on every course card navigates to the matching category page
- [x] Categories/labels/slugs defined in exactly one module (`lib/categories.js`); ComboBox and all new pages import from it; ComboBox respects its `category` prop
- [x] Courses whose stored category doesn't match the taxonomy still render and are reachable via the fallback bucket
- [x] `npm run lint` ✅ and `npm run build` ✅ — CI green

---

## Testing

- `npm run lint` — passes (zero new warnings/errors)
- `npm run build` — compiled successfully; both new routes appear in the manifest:
  - `○ /dashboard/courses/categories`
  - `ƒ /dashboard/courses/category/[slug]`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a course category hub with grouped categories, descriptions, icons, and course counts.
  * Added category landing pages with breadcrumbs, course listings, sorting, empty states, and course creation access.
  * Added URL-based search, category filtering, sorting, and bookmark views.
  * Added loading placeholders, retry options, and clearer no-results messaging.
  * Course category badges now link directly to relevant category pages.
  * Improved category selection with grouped, searchable options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->