### PR TITLE
fix(lint): assign anonymous default exports to named consts

### DIFF
--- a/lib/actions/cached-api.js
+++ b/lib/actions/cached-api.js
@@ -247,7 +247,7 @@ export const clearAllCaches = () => {
   console.log("✅ All API caches cleared");
 };
 
-export default {
+const cachedAPI = {
   courses: coursesAPI,
   books: booksAPI,
   spaces: spacesAPI,
@@ -256,3 +256,5 @@ export default {
   search: searchAPI,
   clearAll: clearAllCaches,
 };
+
+export default cachedAPI;

--- a/lib/utils/cloudinaryUpload.js
+++ b/lib/utils/cloudinaryUpload.js
@@ -181,7 +181,7 @@ export const formatFileSize = (bytes) => {
   return Math.round((bytes / Math.pow(k, i)) * 100) / 100 + " " + sizes[i];
 };
 
-export default {
+const cloudinaryUpload = {
   uploadToCloudinary,
   uploadWithProgress,
   uploadMultipleFiles,
@@ -189,3 +189,5 @@ export default {
   getResourceType,
   formatFileSize,
 };
+
+export default cloudinaryUpload;


### PR DESCRIPTION
## Summary

Resolves \`import/no-anonymous-default-export\` warnings from \`next/core-web-vitals\` ESLint config.

## Changes

- **\`lib/actions/cached-api.js\`**: Converted anonymous \`export default { ... }\` to a named const (\`cachedAPI\`) before exporting.
- **\`lib/utils/cloudinaryUpload.js\`**: Same pattern with \`const cloudinaryUpload = { ... }\`.

## Verification

- ✅ \`npm run lint\` — 0 warnings, 0 errors
- ✅ \`npm run build\` — succeeds (24/24 static pages)

The default exports were verified unused across the codebase via ripgrep; the change is purely a lint compliance fix with no runtime behavior impact.

Closes the lint failure surfaced in #144.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal module organization for API access and file-upload utilities.
  * Existing functionality and available operations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->