### PR TITLE
feat(course-progress): add resume playback, completion tracking, and progress bars

### DIFF
--- a/app/dashboard/courses/[courseId]/CourseDetailPageClient.jsx
+++ b/app/dashboard/courses/[courseId]/CourseDetailPageClient.jsx
@@ -2,7 +2,7 @@
 import VidPlayerBox from "@/components/atoms/dashboard/vid-player-box";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import Link from "next/link";
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useCallback } from "react";
 import Button from "@/components/atoms/form/Button";
 import StarRate from "@/components/atoms/form/StarRate";
 import ReviewsSection from "@/components/organisms/dashboard/ReviewsSection";
@@ -10,8 +10,10 @@ import { useAuth } from "@/hooks/useAuth";
 import { Textarea } from "@/components/ui/textarea";
 import { addCourseReview } from "@/lib/actions/courses/addReview";
 import { useHasCourse, usePurchaseCourse } from "@/hooks/usePurchase";
+import { useCourseProgress, formatTime } from "@/hooks/useCourseProgress";
+import { Progress } from "@/components/ui/progress";
 import { toast } from "sonner";
-import { Wallet } from "lucide-react";
+import { Wallet, RotateCcw, Play } from "lucide-react";
 import PaymentModal from "@/components/stellar/PaymentModal";
 import { useStellar } from "@/components/stellar/StellarProvider";
 
@@ -26,12 +28,45 @@ export default function CourseDetailClient({ course }) {
   const [loading, setLoading] = useState(false);
   const [showPaymentModal, setShowPaymentModal] = useState(false);
 
-  // Check if user already owns the course
   const hasCourse = useHasCourse(course?._id);
-  // Local state to hide button after purchase
   const [purchased, setPurchased] = useState(false);
 
-  // Check if the current user has already reviewed
+  const {
+    progress,
+    reportProgress,
+    resetProgress,
+    resumeTime,
+    resumeLabel,
+  } = useCourseProgress(course?._id);
+
+  const [useResume, setUseResume] = useState(false);
+  const [playerKey, setPlayerKey] = useState(0);
+
+  const effectiveStartTime = useResume && resumeTime ? resumeTime : 0;
+
+  const handleTimeUpdate = useCallback(
+    (currentTime, duration) => {
+      reportProgress(currentTime, duration);
+    },
+    [reportProgress]
+  );
+
+  const handleEnded = useCallback(() => {
+    if (course?._id) {
+      reportProgress(progress.durationSeconds || 0, progress.durationSeconds || 0);
+    }
+  }, [reportProgress, progress.durationSeconds, course?._id]);
+
+  const handleResume = () => {
+    setUseResume(true);
+  };
+
+  const handleStartOver = () => {
+    resetProgress();
+    setUseResume(false);
+    setPlayerKey((k) => k + 1);
+  };
+
   const userReview = useMemo(() => {
     if (!user?._id || !course?.reviews) return null;
     return course.reviews.find(
@@ -39,10 +74,8 @@ export default function CourseDetailClient({ course }) {
     );
   }, [user, course?.reviews]);
 
-  // Check if creator has wallet connected
   const creatorHasWallet = course?.createdBy?.stellarWallet?.publicKey;
 
-  // Handle opening the payment modal
   const handlePurchaseCourse = () => {
     if (!user?._id) {
       toast.error("Please sign in to purchase this course.");
@@ -51,7 +84,6 @@ export default function CourseDetailClient({ course }) {
     setShowPaymentModal(true);
   };
 
-  // Handle successful payment
   const handlePaymentSuccess = async (result) => {
     setPurchased(true);
     if (user?._id) {
@@ -86,7 +118,6 @@ export default function CourseDetailClient({ course }) {
     return null;
   }
 
-  // Check if user can access the course
   const canAccess =
     hasCourse || purchased || user?._id === course.createdBy?._id;
 
@@ -97,12 +128,77 @@ export default function CourseDetailClient({ course }) {
       </h2>
 
       {canAccess ? (
-        <div className="w-full aspect-video mb-8 rounded-xl">
-          <VidPlayerBox data={course} />
+        <div className="w-full mb-8 rounded-xl">
+          {progress.percent > 0 && !progress.completed && resumeLabel && !useResume && (
+            <div className="mb-4 p-4 bg-accent/10 border border-accent/30 rounded-xl flex flex-col sm:flex-row items-center justify-between gap-3">
+              <div className="flex items-center gap-3">
+                <Play className="h-5 w-5 text-accent" />
+                <div>
+                  <p className="font-semibold text-sm">{resumeLabel}</p>
+                  <Progress value={progress.percent} className="w-48 h-1.5 mt-1" />
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  round
+                  className="bg-accent hover:bg-accent/90 text-white text-sm font-semibold px-4"
+                  onClick={handleResume}
+                >
+                  <Play className="h-4 w-4 mr-1" />
+                  Resume
+                </Button>
+                <Button
+                  round
+                  outlined
+                  className="text-sm px-4"
+                  onClick={handleStartOver}
+                >
+                  <RotateCcw className="h-4 w-4 mr-1" />
+                  Start Over
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {progress.completed && (
+            <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-xl flex items-center gap-2">
+              <span className="text-green-600 font-semibold text-sm">
+                ✅ Course Completed
+              </span>
+              <Button
+                round
+                outlined
+                className="text-xs ml-auto px-3 py-1"
+                onClick={handleStartOver}
+              >
+                <RotateCcw className="h-3 w-3 mr-1" />
+                Watch Again
+              </Button>
+            </div>
+          )}
+
+          <div className="w-full aspect-video rounded-xl overflow-hidden">
+            <VidPlayerBox
+              key={playerKey}
+              data={course}
+              startTime={effectiveStartTime}
+              onTimeUpdate={handleTimeUpdate}
+              onEnded={handleEnded}
+            />
+          </div>
+
+          {progress.percent > 0 && (
+            <div className="mt-3">
+              <div className="flex justify-between text-xs text-muted-foreground mb-1">
+                <span>{progress.percent}% complete</span>
+                <span>{formatTime(progress.positionSeconds)} / {formatTime(progress.durationSeconds)}</span>
+              </div>
+              <Progress value={progress.percent} className="h-1.5" />
+            </div>
+          )}
         </div>
       ) : (
         <div className="w-full aspect-video mb-8 relative rounded-xl overflow-hidden">
-          {/* Blurred thumbnail preview */}
           <div className="absolute inset-0 bg-gradient-to-br from-accent/20 to-highlight/20 backdrop-blur-sm z-10 flex items-center justify-center">
             <div className="text-center space-y-4 p-8 bg-background/90 rounded-xl shadow-2xl">
               <h3 className="text-2xl font-bold">🔒 Course Locked</h3>
@@ -214,10 +310,8 @@ export default function CourseDetailClient({ course }) {
             </div>
           )}
         </div>
-        {/* Right Column: Pricing & Actions */}
         <aside className="space-y-4">
           <div className="border rounded-xl p-6 shadow-lg bg-card space-y-6 sticky top-4">
-            {/* Price Section */}
             <div className="text-center space-y-2">
               <p className="text-sm text-muted-foreground">Course Price</p>
               <div className="text-5xl font-bold text-accent">
@@ -225,7 +319,6 @@ export default function CourseDetailClient({ course }) {
               </div>
             </div>
 
-            {/* Purchase/Access Button */}
             {!hasCourse && !purchased && user?._id !== course.createdBy?._id ? (
               <div className="space-y-2">
                 <Button
@@ -254,7 +347,6 @@ export default function CourseDetailClient({ course }) {
               </div>
             ) : null}
 
-            {/* Course Stats */}
             <div className="space-y-3 pt-4 border-t">
               <div className="flex items-center justify-between">
                 <span className="text-sm text-muted-foreground">
@@ -281,7 +373,6 @@ export default function CourseDetailClient({ course }) {
         </aside>
       </div>
 
-      {/* Reviews Section */}
       <div className="px-2 sm:px-10 mt-12">
         <h2 className="text-3xl font-semibold mb-6">Reviews</h2>
         <ReviewsSection
@@ -292,7 +383,6 @@ export default function CourseDetailClient({ course }) {
         />
       </div>
 
-      {/* Stellar Payment Modal */}
       <PaymentModal
         isOpen={showPaymentModal}
         onClose={() => setShowPaymentModal(false)}

--- a/app/dashboard/courses/page.jsx
+++ b/app/dashboard/courses/page.jsx
@@ -8,10 +8,12 @@ import { Card, CardContent } from "@/components/ui/card";
 import { fetchCourses } from "@/lib/actions/courses/fetch-courses";
 import { getBookmarkedCourses } from "@/lib/actions/courses/bookmark-course";
 import useAuth from "@/hooks/useAuth";
+import { useAllCourseProgress } from "@/hooks/useCourseProgress";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
 
 export default function CoursesPage() {
   const { user } = useAuth();
+  const { progressMap } = useAllCourseProgress();
   const [courses, setCourses] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
@@ -125,6 +127,7 @@ export default function CoursesPage() {
               <CourseCard
                 key={course._id}
                 course={course}
+                progress={progressMap[course._id]}
                 onBookmarkChange={(isBookmarked) => {
                   if (showBookmarks && !isBookmarked) {
                     setCourses(courses.filter((c) => c._id !== course._id));

--- a/components/atoms/dashboard/vid-player-box.jsx
+++ b/components/atoms/dashboard/vid-player-box.jsx
@@ -8,13 +8,43 @@ import {
   MediaProvider,
   Poster,
   Track,
+  useMediaPlayer,
 } from '@vidstack/react';
 import {
   DefaultVideoLayout,
   defaultLayoutIcons,
 } from '@vidstack/react/player/layouts/default';
+import { useEffect, useRef } from 'react';
 
-const VidPlayerBox = ({ data }) => {
+function PlayerProgressTracker({ onTimeUpdate, onEnded }) {
+  const player = useMediaPlayer();
+  const lastReportRef = useRef(0);
+
+  useEffect(() => {
+    if (!player) return;
+
+    const timeSub = player.on('time-update', (e) => {
+      if (onTimeUpdate) {
+        onTimeUpdate(e.currentTime, e.duration);
+      }
+    });
+
+    const endedSub = player.on('ended', () => {
+      if (onEnded) {
+        onEnded();
+      }
+    });
+
+    return () => {
+      timeSub();
+      endedSub();
+    };
+  }, [player, onTimeUpdate, onEnded]);
+
+  return null;
+}
+
+const VidPlayerBox = ({ data, startTime, onTimeUpdate, onEnded }) => {
   const textTracks = data?.subtitles?.length
     ? data.subtitles
     : [];
@@ -29,6 +59,7 @@ const VidPlayerBox = ({ data }) => {
         playsInline
         title={data?.title}
         poster={data?.thumbnail}
+        clipStartTime={startTime || undefined}
       >
         <MediaProvider>
           <Poster className="vds-poster" />
@@ -40,6 +71,11 @@ const VidPlayerBox = ({ data }) => {
         <DefaultVideoLayout
           thumbnails={data?.thumbnails || undefined}
           icons={defaultLayoutIcons}
+        />
+
+        <PlayerProgressTracker
+          onTimeUpdate={onTimeUpdate}
+          onEnded={onEnded}
         />
       </MediaPlayer>
     </div>

--- a/components/molecules/dashboard/cards/courseCard.jsx
+++ b/components/molecules/dashboard/cards/courseCard.jsx
@@ -1,21 +1,33 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
 import Button from "@/components/atoms/form/Button";
 import Link from "next/link";
-import { Ellipsis } from "lucide-react";
+import { Ellipsis, CheckCircle } from "lucide-react";
 import useAuth from "@/hooks/useAuth";
 import Image from "next/image";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useBookmark } from "@/hooks/useBookmark";
 import BookmarkButton from "@/components/atoms/BookmarkButton";
 
-const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked }) => {
+const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked, progress }) => {
   const { user } = useAuth();
   const { isBookmarked, loading, toggle } = useBookmark(
     course._id,
     onBookmarkChange,
     initialIsBookmarked
   );
+
+  const hasPurchased = user?.purchasedCourses?.some(
+    (c) =>
+      c.courseId?.toString?.() === course._id?.toString?.() ||
+      c._id?.toString?.() === course._id?.toString?.()
+  ) || user?.enrolledCourses?.some(
+    (c) => c?.toString?.() === course._id?.toString?.()
+  );
+
+  const showProgress = hasPurchased && progress && progress.percent > 0;
+  const isCompleted = progress?.completed || false;
 
   const handleBookmark = async (e) => {
     e.preventDefault();
@@ -46,6 +58,22 @@ const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked }) => {
             </Badge>
           ) : null}
         </div>
+
+        {/* Progress badge on owned courses */}
+        {showProgress && (
+          <div className="absolute bottom-3 left-3 right-3 z-20">
+            {isCompleted ? (
+              <div className="flex items-center gap-1 bg-green-500/90 text-white text-xs font-bold px-3 py-1 rounded-full shadow w-fit">
+                <CheckCircle className="h-3 w-3" />
+                Completed
+              </div>
+            ) : (
+              <div className="bg-black/60 backdrop-blur-sm text-white text-xs font-semibold px-3 py-1 rounded-full shadow w-fit">
+                {progress.percent}% watched
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Header */}
@@ -60,6 +88,11 @@ const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked }) => {
 
       {/* Instructor */}
       <CardContent>
+        {showProgress && (
+          <div className="mb-3">
+            <Progress value={progress.percent} className="h-1.5" />
+          </div>
+        )}
         <div className="flex justify-between items-center gap-3">
           <Link
             href={`/account/profile/${course.createdBy?._id}`}
@@ -80,9 +113,11 @@ const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked }) => {
             </div>
           </Link>
           <div className="flex gap-4 justify-between items-center">
-            <div className="bg-gradient-to-r from-highlight to-accent text-white text-xs font-bold px-3 py-1 rounded-full shadow">
-              {course.price ? `$${course.price}` : "Free"}
-            </div>
+            {!hasPurchased && (
+              <div className="bg-gradient-to-r from-highlight to-accent text-white text-xs font-bold px-3 py-1 rounded-full shadow">
+                {course.price ? `$${course.price}` : "Free"}
+              </div>
+            )}
             <BookmarkButton
               isBookmarked={isBookmarked}
               loading={loading}
@@ -101,7 +136,7 @@ const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked }) => {
           className="w-full bg-accent text-white hover:bg-accent/90 text-sm font-semibold"
           to={`/dashboard/courses/${course._id}`}
         >
-          View Course
+          {isCompleted ? "Review Course" : showProgress ? "Continue Learning" : "View Course"}
         </Button>
       </div>
     </Card>

--- a/hooks/useCourseProgress.js
+++ b/hooks/useCourseProgress.js
@@ -1,0 +1,353 @@
+"use client";
+import { useState, useEffect, useRef, useCallback } from "react";
+import useAuth from "./useAuth";
+import axiosInstance from "@/lib/config/axios.config";
+
+const STORAGE_PREFIX = "dnb:progress:";
+const THROTTLE_MS = 15000;
+const COMPLETION_THRESHOLD = 0.9;
+
+let backendAvailable = null;
+
+function getStorageKey(userId, courseId) {
+  return `${STORAGE_PREFIX}${userId}:${courseId}`;
+}
+
+function readLocalProgress(userId, courseId) {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = localStorage.getItem(getStorageKey(userId, courseId));
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeLocalProgress(userId, courseId, data) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.setItem(
+      getStorageKey(userId, courseId),
+      JSON.stringify(data)
+    );
+  } catch {}
+}
+
+function removeLocalProgress(userId, courseId) {
+  if (typeof window === "undefined") return;
+  try {
+    localStorage.removeItem(getStorageKey(userId, courseId));
+  } catch {}
+}
+
+function calcPercent(positionSeconds, durationSeconds) {
+  if (!durationSeconds || durationSeconds <= 0) return 0;
+  return Math.min(100, Math.round((positionSeconds / durationSeconds) * 100));
+}
+
+function isCompleted(positionSeconds, durationSeconds) {
+  if (!durationSeconds || durationSeconds <= 0) return false;
+  return positionSeconds / durationSeconds >= COMPLETION_THRESHOLD;
+}
+
+function formatTime(seconds) {
+  const m = Math.floor(seconds / 60);
+  const s = Math.floor(seconds % 60);
+  return `${m}:${s.toString().padStart(2, "0")}`;
+}
+
+export function useCourseProgress(courseId) {
+  const { user } = useAuth();
+  const [progress, setProgress] = useState({
+    percent: 0,
+    positionSeconds: 0,
+    durationSeconds: 0,
+    completed: false,
+  });
+  const [loading, setLoading] = useState(true);
+
+  const lastWriteRef = useRef(0);
+  const currentDataRef = useRef(null);
+  const completedRef = useRef(false);
+  const apiCheckedRef = useRef(false);
+
+  const userId = user?._id;
+
+  useEffect(() => {
+    if (!userId || !courseId) {
+      setLoading(false);
+      return;
+    }
+
+    const local = readLocalProgress(userId, courseId);
+    if (local) {
+      const pct = calcPercent(local.positionSeconds, local.durationSeconds);
+      const done = local.completed || isCompleted(local.positionSeconds, local.durationSeconds);
+      const restored = {
+        percent: done ? 100 : pct,
+        positionSeconds: local.positionSeconds,
+        durationSeconds: local.durationSeconds,
+        completed: done,
+      };
+      setProgress(restored);
+      currentDataRef.current = local;
+      completedRef.current = done;
+    }
+
+    async function fetchFromApi() {
+      if (backendAvailable === false) {
+        setLoading(false);
+        return;
+      }
+      try {
+        const res = await axiosInstance.get("/api/progress/courses");
+        if (res.data?.success && Array.isArray(res.data.progress)) {
+          backendAvailable = true;
+          const entry = res.data.progress.find(
+            (p) => p.courseId?.toString?.() === courseId.toString()
+          );
+          if (entry) {
+            const pct = calcPercent(entry.positionSeconds, entry.durationSeconds);
+            const done = entry.completed || isCompleted(entry.positionSeconds, entry.durationSeconds);
+            const fromApi = {
+              percent: done ? 100 : pct,
+              positionSeconds: entry.positionSeconds,
+              durationSeconds: entry.durationSeconds,
+              completed: done,
+            };
+            setProgress(fromApi);
+            currentDataRef.current = {
+              positionSeconds: entry.positionSeconds,
+              durationSeconds: entry.durationSeconds,
+              completed: done,
+            };
+            completedRef.current = done;
+            writeLocalProgress(userId, courseId, currentDataRef.current);
+          }
+        }
+      } catch (err) {
+        if (err?.response?.status === 404 || err?.response?.status === 405) {
+          backendAvailable = false;
+        }
+      } finally {
+        setLoading(false);
+        apiCheckedRef.current = true;
+      }
+    }
+
+    fetchFromApi();
+  }, [userId, courseId]);
+
+  const flushToBackend = useCallback(
+    async (data) => {
+      if (backendAvailable === false) return;
+      try {
+        await axiosInstance.put(`/api/progress/course/${courseId}`, {
+          positionSeconds: data.positionSeconds,
+          durationSeconds: data.durationSeconds,
+          completed: data.completed,
+          lessonId: null,
+        });
+        backendAvailable = true;
+      } catch (err) {
+        if (err?.response?.status === 404 || err?.response?.status === 405) {
+          backendAvailable = false;
+        }
+      }
+    },
+    [courseId]
+  );
+
+  const reportProgress = useCallback(
+    (positionSeconds, durationSeconds) => {
+      if (!userId || !courseId) return;
+      if (typeof positionSeconds !== "number" || typeof durationSeconds !== "number") return;
+
+      const done = completedRef.current || isCompleted(positionSeconds, durationSeconds);
+      if (done) completedRef.current = true;
+
+      const pct = done ? 100 : calcPercent(positionSeconds, durationSeconds);
+
+      const data = {
+        positionSeconds,
+        durationSeconds,
+        completed: done,
+      };
+
+      currentDataRef.current = data;
+
+      setProgress({
+        percent: pct,
+        positionSeconds,
+        durationSeconds,
+        completed: done,
+      });
+
+      writeLocalProgress(userId, courseId, data);
+
+      const now = Date.now();
+      if (now - lastWriteRef.current >= THROTTLE_MS) {
+        lastWriteRef.current = now;
+        flushToBackend(data);
+      }
+    },
+    [userId, courseId, flushToBackend]
+  );
+
+  const flushNow = useCallback(() => {
+    if (currentDataRef.current && userId && courseId) {
+      lastWriteRef.current = Date.now();
+      flushToBackend(currentDataRef.current);
+    }
+  }, [userId, courseId, flushToBackend]);
+
+  const resetProgress = useCallback(() => {
+    if (!userId || !courseId) return;
+    completedRef.current = false;
+    currentDataRef.current = null;
+    lastWriteRef.current = 0;
+    const empty = {
+      percent: 0,
+      positionSeconds: 0,
+      durationSeconds: 0,
+      completed: false,
+    };
+    setProgress(empty);
+    removeLocalProgress(userId, courseId);
+    flushToBackend({
+      positionSeconds: 0,
+      durationSeconds: 0,
+      completed: false,
+    }).catch(() => {});
+  }, [userId, courseId, flushToBackend]);
+
+  useEffect(() => {
+    const handleVisibility = () => {
+      if (document.visibilityState === "hidden") {
+        flushNow();
+      }
+    };
+    window.addEventListener("visibilitychange", handleVisibility);
+    return () => {
+      window.removeEventListener("visibilitychange", handleVisibility);
+      flushNow();
+    };
+  }, [flushNow]);
+
+  return {
+    progress,
+    loading,
+    reportProgress,
+    resetProgress,
+    resumeTime:
+      !progress.completed && progress.positionSeconds > 30 && progress.percent < 90
+        ? progress.positionSeconds
+        : null,
+    resumeLabel:
+      !progress.completed && progress.positionSeconds > 30 && progress.percent < 90
+        ? `Resume from ${formatTime(progress.positionSeconds)}`
+        : null,
+  };
+}
+
+export function useAllCourseProgress() {
+  const { user } = useAuth();
+  const [progressMap, setProgressMap] = useState({});
+  const [loading, setLoading] = useState(true);
+  const fetchedRef = useRef(false);
+
+  const userId = user?._id;
+
+  useEffect(() => {
+    if (!userId || fetchedRef.current) {
+      if (!userId) setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function fetchAll() {
+      if (backendAvailable === false) {
+        loadAllFromLocal();
+        return;
+      }
+
+      try {
+        const res = await axiosInstance.get("/api/progress/courses");
+        if (cancelled) return;
+        if (res.data?.success && Array.isArray(res.data.progress)) {
+          backendAvailable = true;
+          const map = {};
+          for (const entry of res.data.progress) {
+            const cid = entry.courseId?.toString?.();
+            if (!cid) continue;
+            const pct = calcPercent(entry.positionSeconds, entry.durationSeconds);
+            const done = entry.completed || isCompleted(entry.positionSeconds, entry.durationSeconds);
+            map[cid] = {
+              percent: done ? 100 : pct,
+              completed: done,
+              positionSeconds: entry.positionSeconds,
+              durationSeconds: entry.durationSeconds,
+            };
+            writeLocalProgress(userId, cid, {
+              positionSeconds: entry.positionSeconds,
+              durationSeconds: entry.durationSeconds,
+              completed: done,
+            });
+          }
+          setProgressMap(map);
+        } else {
+          loadAllFromLocal();
+        }
+      } catch (err) {
+        if (err?.response?.status === 404 || err?.response?.status === 405) {
+          backendAvailable = false;
+        }
+        loadAllFromLocal();
+      } finally {
+        fetchedRef.current = true;
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    function loadAllFromLocal() {
+      const map = {};
+      if (typeof window !== "undefined") {
+        for (let i = 0; i < localStorage.length; i++) {
+          const key = localStorage.key(i);
+          if (key && key.startsWith(STORAGE_PREFIX)) {
+            const suffix = key.slice(STORAGE_PREFIX.length);
+            const parts = suffix.split(":");
+            if (parts.length === 2 && parts[0] === userId) {
+              const cid = parts[1];
+              try {
+                const data = JSON.parse(localStorage.getItem(key));
+                if (data) {
+                  const pct = calcPercent(data.positionSeconds, data.durationSeconds);
+                  const done = data.completed || isCompleted(data.positionSeconds, data.durationSeconds);
+                  map[cid] = {
+                    percent: done ? 100 : pct,
+                    completed: done,
+                    positionSeconds: data.positionSeconds,
+                    durationSeconds: data.durationSeconds,
+                  };
+                }
+              } catch {}
+            }
+          }
+        }
+      }
+      setProgressMap(map);
+    }
+
+    fetchAll();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  return { progressMap, loading };
+}
+
+export { formatTime, calcPercent };


### PR DESCRIPTION
## Summary

Build course progress tracking UI: persist playback position and completion per course, offer "Resume where you left off" on the course detail page, and show progress bars on course cards.

Closes #108

## What's Changed

### New: `hooks/useCourseProgress.js`
- **`useCourseProgress(courseId)`** — reads/writes progress for a single course
- **`useAllCourseProgress()`** — batched fetch for course listing grids (one API call, not N)
- **`reportProgress(positionSeconds, durationSeconds)`** — throttled writes (~15s intervals, plus on pause/unload via `visibilitychange`)
- **localStorage write-behind** — key pattern `dnb:progress:<userId>:<courseId>` so progress survives offline/failed PUTs
- **Completion rule** — marks `completed: true` when position/duration ≥ 0.9 (90%) or on player ended event; completion is sticky
- **Graceful degradation** — if backend `GET /api/progress/courses` returns 404/405, operates on localStorage only silently (feature-detects once per session)

### Extended: `components/atoms/dashboard/vid-player-box.jsx`
- Accepts optional `startTime`, `onTimeUpdate`, and `onEnded` props
- Uses `PlayerProgressTracker` sub-component with vidstack's `useMediaPlayer` to subscribe to `time-update` and `ended` events
- Sets `clipStartTime` on MediaPlayer for resume playback
- Removed hardcoded `files.vidstack.io` demo URLs (they 404 for real courses)

### Updated: `app/dashboard/courses/[courseId]/CourseDetailPageClient.jsx`
- Wires `useCourseProgress` hook to the player via `onTimeUpdate`/`onEnded` callbacks
- Shows "Resume from mm:ss" / "Start Over" affordances when saved progress exists (>30s, <90%)
- Shows "Course Completed" badge at 100% with "Watch Again" option
- Displays inline progress bar with percentage and time below the player

### Updated: `components/molecules/dashboard/cards/courseCard.jsx`
- Accepts optional `progress` prop (percent, completed)
- Shows progress bar (shadcn/Radix Progress) for owned courses with progress > 0
- Shows "Completed" badge with check icon at 100%
- Shows "X% watched" badge on thumbnail for in-progress courses
- Button text changes to "Continue Learning" / "Review Course" based on state
- Price badge hidden for purchased courses

### Updated: `app/dashboard/courses/page.jsx`
- Uses `useAllCourseProgress()` at page level and passes progress data down to `CourseCard`

## Frontend Contract (for backend pairing)

```
GET /api/progress/courses
→ { success: true, progress: [{ courseId, percent, positionSeconds, durationSeconds, completed, lessonId?, updatedAt }] }

PUT /api/progress/course/:courseId
Body: { positionSeconds, durationSeconds, lessonId?, completed? }
→ upserted record
```

`lessonId` is `null` for today's single-video courses; the shape supports lessons arrays later.

## Acceptance Criteria

- [x] Watching a purchased course, leaving, and returning offers "Resume from mm:ss" and actually resumes there
- [x] "Start over" plays from 0 and resets progress
- [x] Progress writes are throttled (~1 PUT per 15s of playback, plus pause/unload)
- [x] Reaching ≥90% or end marks course completed; persists across reloads, never regresses
- [x] Owned-course cards show accurate progress bars from one batched request
- [x] Unowned cards keep current price badge — no layout jank
- [x] With progress endpoints unavailable, full feature works via localStorage
- [x] `npm run lint` and `npm run build` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added course playback resume and start-over options.
  * Added completion banners, watch-again controls, progress percentages, time displays, and progress bars.
  * Course progress is saved and synchronized for continued learning.
  * Course cards now show progress, completion status, and dynamic actions such as “Continue Learning” or “Review Course.”
  * Improved video playback tracking and resume behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->