### PR TITLE
fix: error handling, role reset, and loading UX in TransactionHistory

### DIFF
--- a/components/stellar/TransactionHistory.jsx
+++ b/components/stellar/TransactionHistory.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -24,6 +24,8 @@ import {
   ChevronRight,
   BookOpen,
   GraduationCap,
+  AlertCircle,
+  RefreshCw,
 } from "lucide-react";
 import useStellarPayment from "@/hooks/useStellarPayment";
 
@@ -46,9 +48,11 @@ export default function TransactionHistory() {
   });
   const [role, setRole] = useState("buyer");
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
 
-  const fetchTransactions = async () => {
+  const fetchTransactions = useCallback(async () => {
     setIsLoading(true);
+    setError(null);
     const result = await getTransactionHistory({
       role,
       page: pagination.page,
@@ -57,13 +61,20 @@ export default function TransactionHistory() {
     if (result.success) {
       setTransactions(result.transactions);
       setPagination(result.pagination);
+    } else {
+      setError(result.error || "Failed to fetch transactions");
     }
     setIsLoading(false);
-  };
+  }, [role, pagination.page, pagination.limit, getTransactionHistory]);
 
   useEffect(() => {
     fetchTransactions();
-  }, [role, pagination.page]);
+  }, [fetchTransactions]);
+
+  const handleRoleChange = (newRole) => {
+    setRole(newRole);
+    setPagination((prev) => ({ ...prev, page: 1 }));
+  };
 
   const truncateAddress = (addr) => {
     if (!addr) return "";
@@ -80,28 +91,12 @@ export default function TransactionHistory() {
     });
   };
 
-  if (isLoading) {
-    return (
-      <div className="space-y-4">
-        <div className="flex justify-between items-center">
-          <Skeleton className="h-10 w-32" />
-          <Skeleton className="h-10 w-40" />
-        </div>
-        <div className="space-y-2">
-          {[...Array(5)].map((_, i) => (
-            <Skeleton key={i} className="h-16 w-full" />
-          ))}
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div className="space-y-4">
-      {/* Header */}
+      {/* Header - always mounted */}
       <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <h2 className="text-xl font-semibold">Transaction History</h2>
-        <Select value={role} onValueChange={setRole}>
+        <Select value={role} onValueChange={handleRoleChange}>
           <SelectTrigger className="w-[180px]">
             <SelectValue placeholder="Select role" />
           </SelectTrigger>
@@ -112,8 +107,36 @@ export default function TransactionHistory() {
         </Select>
       </div>
 
+      {/* Error State */}
+      {error && (
+        <div className="text-center py-12 border rounded-lg bg-red-50 border-red-200">
+          <AlertCircle className="h-8 w-8 text-red-500 mx-auto mb-2" />
+          <p className="text-red-600 font-medium">Failed to load transactions</p>
+          <p className="text-sm text-red-500 mt-1">{error}</p>
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-4"
+            onClick={fetchTransactions}
+            disabled={isLoading}
+          >
+            <RefreshCw className={`h-4 w-4 mr-2 ${isLoading ? "animate-spin" : ""}`} />
+            Try Again
+          </Button>
+        </div>
+      )}
+
+      {/* Loading skeleton - only table area */}
+      {isLoading && !error && (
+        <div className="space-y-2">
+          {[...Array(5)].map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full" />
+          ))}
+        </div>
+      )}
+
       {/* Empty State */}
-      {transactions.length === 0 ? (
+      {!isLoading && !error && transactions.length === 0 && (
         <div className="text-center py-12 border rounded-lg">
           <p className="text-muted-foreground">No transactions found</p>
           <p className="text-sm text-muted-foreground mt-1">
@@ -122,9 +145,11 @@ export default function TransactionHistory() {
               : "You haven't received any payments yet"}
           </p>
         </div>
-      ) : (
+      )}
+
+      {/* Table */}
+      {!isLoading && !error && transactions.length > 0 && (
         <>
-          {/* Table */}
           <div className="border rounded-lg overflow-hidden">
             <Table>
               <TableHeader>
@@ -222,7 +247,7 @@ export default function TransactionHistory() {
                   onClick={() =>
                     setPagination((p) => ({ ...p, page: p.page - 1 }))
                   }
-                  disabled={pagination.page <= 1}
+                  disabled={pagination.page <= 1 || isLoading}
                 >
                   <ChevronLeft className="h-4 w-4" />
                   Previous
@@ -233,7 +258,7 @@ export default function TransactionHistory() {
                   onClick={() =>
                     setPagination((p) => ({ ...p, page: p.page + 1 }))
                   }
-                  disabled={pagination.page >= pagination.pages}
+                  disabled={pagination.page >= pagination.pages || isLoading}
                 >
                   Next
                   <ChevronRight className="h-4 w-4" />

--- a/hooks/useStellarPayment.js
+++ b/hooks/useStellarPayment.js
@@ -141,7 +141,7 @@ export const useStellarPayment = () => {
         return res.data;
       } catch (error) {
         console.error("Failed to fetch transactions:", error);
-        return { success: false, transactions: [], pagination: {} };
+        return { success: false, transactions: [], pagination: {}, error: error.response?.data?.message || error.message };
       }
     },
     []


### PR DESCRIPTION
- Error vs empty state: getTransactionHistory now returns error message; TransactionHistory tracks error state and renders an inline error card with 'Try Again' button instead of misleading 'No transactions found'
- Role page reset: handleRoleChange resets pagination to page 1 so switching buyer/creator always fetches the first page
- Header always mounted: role select and title stay interactive during loading; only the table area skeletons; pagination buttons disabled while fetch is in flight
- exhaustive-deps: fetchTransactions wrapped in useCallback with proper deps; effect depends only on fetchTransactions

Close #77 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added clear error messaging when transaction history cannot be loaded.
  * Preserved the transaction history header and role selector during loading and error states.
  * Improved loading, empty, and populated table states for clearer feedback.
  * Disabled pagination controls while transaction data is loading.
  * Reset pagination to the first page when the selected role changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->