### PR TITLE
fix(modal): reimplement Modal over Radix Dialog for full accessibility

### DIFF
--- a/components/atoms/dashboard/Notybell.jsx
+++ b/components/atoms/dashboard/Notybell.jsx
@@ -1,9 +1,9 @@
 // components/atoms/dashboard/Notybell.jsx
 "use client";
 
-import React, { useState, useEffect } from "react";
-import { Bell, CheckCircle, MessageCircle, Calendar, X } from "lucide-react";
-import { motion, AnimatePresence } from "framer-motion";
+import { useState, useEffect } from "react";
+import { Bell, CheckCircle, MessageCircle, Calendar } from "lucide-react";
+import { motion } from "framer-motion";
 import Modal from "@/components/molecules/Modal";
 
 const mockNotifications = [
@@ -55,42 +55,38 @@ export default function Notybell() {
                 <span className="absolute top-1 right-1 h-2 w-2 rounded-full bg-red-500"></span>
             </div>
 
-            <AnimatePresence>
-                {open && (
-                    <Modal
-                        isOpen={open}
-                        onClose={() => setOpen(false)}
-                        title="Notifications"
-                        className="max-w-md w-full"
-                    >
-                        <div className="space-y-4">
-                            {notes.map((n) => (
-                                <motion.div
-                                    key={n.id}
-                                    initial={{ opacity: 0, y: -10 }}
-                                    animate={{ opacity: 1, y: 0 }}
-                                    exit={{ opacity: 0, y: -10 }}
-                                    transition={{ duration: 0.3 }}
-                                    className="flex justify-center items-start gap-3 p-3 bg-white/10 backdrop-blur-md rounded-xl hover:bg-white/20 transition"
-                                >
-                                    <div className="flex-shrink-0 pt-4">{iconMap[n.type]}</div>
-                                    <div className="flex-1">
-                                        <h4 className="font-semibold">{n.title}</h4>
-                                        <p className="text-sm ">{n.description}</p>
-                                    </div>
-                                    <span className="text-xs ">{n.time}</span>
-                                </motion.div>
-                            ))}
+            <Modal
+                isOpen={open}
+                onClose={() => setOpen(false)}
+                title="Notifications"
+                className="max-w-md w-full"
+            >
+                <div className="space-y-4">
+                    {notes.map((n) => (
+                        <motion.div
+                            key={n.id}
+                            initial={{ opacity: 0, y: -10 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            exit={{ opacity: 0, y: -10 }}
+                            transition={{ duration: 0.3 }}
+                            className="flex justify-center items-start gap-3 p-3 bg-white/10 backdrop-blur-md rounded-xl hover:bg-white/20 transition"
+                        >
+                            <div className="flex-shrink-0 pt-4">{iconMap[n.type]}</div>
+                            <div className="flex-1">
+                                <h4 className="font-semibold">{n.title}</h4>
+                                <p className="text-sm ">{n.description}</p>
+                            </div>
+                            <span className="text-xs ">{n.time}</span>
+                        </motion.div>
+                    ))}
 
-                            {notes.length === 0 && (
-                                <p className="text-center text-sm text-white/70">
-                                    You’re all caught up!
-                                </p>
-                            )}
-                        </div>
-                    </Modal>
-                )}
-            </AnimatePresence>
+                    {notes.length === 0 && (
+                        <p className="text-center text-sm text-white/70">
+                            You’re all caught up!
+                        </p>
+                    )}
+                </div>
+            </Modal>
         </>
     );
 }

--- a/components/molecules/Modal.js
+++ b/components/molecules/Modal.js
@@ -1,42 +1,33 @@
 "use client";
-import React, { useEffect } from "react";
-import ReactDOM from "react-dom";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
 
-const Modal = ({ isOpen, onClose, children, title }) => {
-  useEffect(() => {
-    const handleKeyDown = (event) => {
-      if (event.key === "Escape" && isOpen && onClose) {
-        onClose();
-      }
-    };
-
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [isOpen, onClose]);
-
-  if (!isOpen) return null;
-
-  const modalContent = (
-    <div className="fixed inset-0 bg-[rgb(0,0,0,0.25)] flex items-center justify-center z-50 w-full p-0 sm:p-6">
-      <div className="bg-white rounded-lg sm:w-fit sm:h-fit shadow-lg overscroll-y-auto overflow-y-auto flex flex-col max-h-screen">
-        <div className="flex justify-between items-center mb-2 px-4 sm:px-8 py-2 bg-accent ">
-          <h2 className="text-lg sm:text-2xl font-bold text-white">{title}</h2>
-          <button
-            onClick={onClose}
-            className="text-white hover:text-gray-200 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-accent focus:ring-white"
+const Modal = ({ isOpen, onClose, children, title, className }) => (
+  <DialogPrimitive.Root open={isOpen} onOpenChange={(open) => !open && onClose?.()}>
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Overlay className="fixed inset-0 z-50 bg-[rgb(0,0,0,0.25)] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+      <DialogPrimitive.Content
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 w-full max-h-screen max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] flex flex-col bg-white rounded-lg shadow-lg sm:w-fit sm:h-fit data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 duration-200",
+          className
+        )}
+      >
+        <div className="flex justify-between items-center mb-2 px-4 sm:px-8 py-2 bg-accent rounded-t-lg">
+          <DialogPrimitive.Title className="text-lg sm:text-2xl font-bold text-white">
+            {title}
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Close
+            aria-label="Close"
+            className="text-white hover:text-gray-200 transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-accent focus:ring-white rounded-sm"
           >
             <X size={25} />
-          </button>
+          </DialogPrimitive.Close>
         </div>
         <div className="p-4 sm:p-6 flex-1 overflow-y-auto">{children}</div>
-      </div>
-    </div>
-  );
-
-  return ReactDOM.createPortal(modalContent, document.body);
-};
+      </DialogPrimitive.Content>
+    </DialogPrimitive.Portal>
+  </DialogPrimitive.Root>
+);
 
 export default Modal;


### PR DESCRIPTION
- replace hand-rolled portal Modal with Radix Dialog primitives
- add role=dialog, aria-modal, and aria-labelledby via DialogPrimitive
- inherit Radix focus trap, focus restore, and scroll lock
- overlay click and Escape close now work as expected
- add aria-label=Close to the close button
- honor className prop on the content container (fixes Notybell sizing)
- remove AnimatePresence wrapper from Notybell (Radix handles lifecycle)
- clean up unused imports
- preserve existing visual style (bg-accent header, scrollable body)
- lint and build pass cleanly

Close #82 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notification modal behavior and transitions.
  * Enhanced modal accessibility with labeled controls and a dedicated close button.
  * Improved modal close handling, including Escape-key and overlay interactions.

* **Enhancements**
  * Added support for custom modal styling.
  * Preserved notification animations and empty-state messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->