### PR TITLE
feat(library): add search, filters, sorting, and pagination

### DIFF
--- a/app/dashboard/library/page.jsx
+++ b/app/dashboard/library/page.jsx
@@ -1,5 +1,12 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import React, {
+  Suspense,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import { BookOpen, Bookmark, Plus } from "lucide-react";
 import LibraryBookCard from "@/components/molecules/dashboard/cards/libraryCard";
 import Button from "@/components/atoms/form/Button";
@@ -11,14 +18,69 @@ import { getBookmarkedBooks } from "@/lib/actions/library/bookmark-book";
 import LibraryBookSkeleton from "@/components/atoms/skeletons/LibraryBookSkeleton";
 import useAuth from "@/hooks/useAuth";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
+import { getAverageRating } from "@/hooks/getAverageRating";
+import useDebouncedValue from "@/hooks/useDebouncedValue";
+import LibraryToolbar, { ALL } from "@/components/molecules/dashboard/LibraryToolbar";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+} from "@/components/ui/pagination";
 
-const LibraryPage = () => {
+const PAGE_SIZE = 9;
+
+// Mongo ObjectIds encode their creation time in the first 4 bytes, so recency
+// sorting still works when the API response omits createdAt.
+const createdAtOf = (book) => {
+  if (book?.createdAt) {
+    const parsed = new Date(book.createdAt).getTime();
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  const id = book?._id;
+  if (typeof id === "string" && id.length >= 8) {
+    const seconds = parseInt(id.slice(0, 8), 16);
+    if (!Number.isNaN(seconds)) return seconds * 1000;
+  }
+  return 0;
+};
+
+const priceOf = (book) => Number(book?.price) || 0;
+
+const BookGridSkeleton = () => (
+  <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+    {[...Array(6)].map((_, idx) => (
+      <LibraryBookSkeleton key={`skeleton-${idx}`} />
+    ))}
+  </div>
+);
+
+const LibraryPageContent = () => {
   const { user } = useAuth();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
   const [modalOpen, setModalOpen] = useState(false);
   const [books, setBooks] = useState([]);
   const [showBookmarks, setShowBookmarks] = useState(false);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+
+  const [searchInput, setSearchInput] = useState(
+    () => searchParams.get("search") || ""
+  );
+  const [category, setCategory] = useState(
+    () => searchParams.get("category") || ALL
+  );
+  const [price, setPrice] = useState(() => searchParams.get("price") || ALL);
+  const [sort, setSort] = useState(() => searchParams.get("sort") || "newest");
+  const [page, setPage] = useState(
+    () => Math.max(1, Number(searchParams.get("page")) || 1)
+  );
+
+  const search = useDebouncedValue(searchInput, 300);
 
   const fetchData = async () => {
     setLoading(true);
@@ -29,9 +91,9 @@ const LibraryPage = () => {
         setBooks(response.bookmarks || []);
       } else {
         const response = await fetchBooks();
-        setBooks(response);
+        setBooks(Array.isArray(response) ? response : response?.books || []);
       }
-    } catch (error) {
+    } catch (err) {
       setError(true);
     } finally {
       setLoading(false);
@@ -41,6 +103,118 @@ const LibraryPage = () => {
   useEffect(() => {
     fetchData();
   }, [showBookmarks]);
+
+  // Keep filter state shareable/bookmarkable without adding history entries.
+  useEffect(() => {
+    const params = new URLSearchParams();
+    if (search.trim()) params.set("search", search.trim());
+    if (category !== ALL) params.set("category", category);
+    if (price !== ALL) params.set("price", price);
+    if (sort !== "newest") params.set("sort", sort);
+    if (page > 1) params.set("page", String(page));
+    const query = params.toString();
+    router.replace(query ? `?${query}` : "/dashboard/library", {
+      scroll: false,
+    });
+  }, [search, category, price, sort, page, router]);
+
+  // Any filter change resets to the first page, but never on the initial
+  // render, which would discard an incoming ?page= value.
+  const isFirstRender = useRef(true);
+  useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
+    setPage(1);
+  }, [search, category, price, sort, showBookmarks]);
+
+  // Categories are free-form strings on the backend, so fold case and
+  // whitespace and keep the first spelling encountered.
+  const categories = useMemo(() => {
+    const seen = new Map();
+    books.forEach((book) => {
+      const raw = typeof book?.category === "string" ? book.category.trim() : "";
+      if (!raw) return;
+      const key = raw.toLowerCase();
+      if (!seen.has(key)) seen.set(key, raw);
+    });
+    return [...seen.values()].sort((a, b) => a.localeCompare(b));
+  }, [books]);
+
+  const filteredBooks = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    const wanted = category.trim().toLowerCase();
+
+    const result = books.filter((book) => {
+      if (!showBookmarks && book?.author?._id === user?._id) return false;
+
+      if (term) {
+        const title = String(book?.title || "").toLowerCase();
+        const author = String(book?.author?.name || "").toLowerCase();
+        if (!title.includes(term) && !author.includes(term)) return false;
+      }
+
+      if (category !== ALL) {
+        const actual = String(book?.category || "").trim().toLowerCase();
+        if (actual !== wanted) return false;
+      }
+
+      if (price === "free" && priceOf(book) > 0) return false;
+      if (price === "paid" && priceOf(book) <= 0) return false;
+
+      return true;
+    });
+
+    const sorted = [...result];
+    if (sort === "price-asc") {
+      sorted.sort((a, b) => priceOf(a) - priceOf(b));
+    } else if (sort === "price-desc") {
+      sorted.sort((a, b) => priceOf(b) - priceOf(a));
+    } else if (sort === "rating") {
+      sorted.sort(
+        (a, b) =>
+          (getAverageRating(b?.reviews) || 0) -
+          (getAverageRating(a?.reviews) || 0)
+      );
+    } else {
+      sorted.sort((a, b) => createdAtOf(b) - createdAtOf(a));
+    }
+    return sorted;
+  }, [books, search, category, price, sort, showBookmarks, user?._id]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredBooks.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pagedBooks = filteredBooks.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE
+  );
+
+  const pageNumbers = useMemo(() => {
+    const end = Math.min(totalPages, Math.max(1, currentPage - 2) + 4);
+    const start = Math.max(1, end - 4);
+    const pages = [];
+    for (let i = start; i <= end; i += 1) pages.push(i);
+    return pages;
+  }, [currentPage, totalPages]);
+
+  const isFiltered =
+    search.trim() !== "" || category !== ALL || price !== ALL || sort !== "newest";
+
+  const handleClearFilters = () => {
+    setSearchInput("");
+    setCategory(ALL);
+    setPrice(ALL);
+    setSort("newest");
+    setPage(1);
+  };
+
+  const goToPage = (event, target) => {
+    event.preventDefault();
+    if (target < 1 || target > totalPages || target === currentPage) return;
+    setPage(target);
+    window.scrollTo({ top: 0, behavior: "smooth" });
+  };
 
   const handleBookCreated = () => {
     setModalOpen(false);
@@ -79,11 +253,7 @@ const LibraryPage = () => {
           </p>
         </div>
         <div className="flex gap-2">
-          <Button
-            round
-            outlined
-            onClick={() => setModalOpen(true)}
-          >
+          <Button round outlined onClick={() => setModalOpen(true)}>
             <Plus className="h-4 w-4 mr-1" />
             Create
           </Button>
@@ -99,40 +269,62 @@ const LibraryPage = () => {
         </div>
       </div>
 
+      {!loading && (
+        <LibraryToolbar
+          search={searchInput}
+          onSearchChange={setSearchInput}
+          category={category}
+          onCategoryChange={setCategory}
+          categories={categories}
+          price={price}
+          onPriceChange={setPrice}
+          sort={sort}
+          onSortChange={setSort}
+          onClear={handleClearFilters}
+          isFiltered={isFiltered}
+          resultCount={filteredBooks.length}
+        />
+      )}
+
       {loading ? (
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-          {[...Array(6)].map((_, idx) => (
-            <LibraryBookSkeleton key={`skeleton-${idx}`} />
-          ))}
-        </div>
-      ) : books.length === 0 ? (
+        <BookGridSkeleton />
+      ) : filteredBooks.length === 0 ? (
         <Card>
           <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
             <BookOpen className="h-12 w-12 text-muted-foreground" />
             <div>
               <h3 className="font-semibold text-lg">
-                {showBookmarks ? "No Bookmarked Books" : "No Books Yet"}
+                {isFiltered
+                  ? "No Matching Books"
+                  : showBookmarks
+                  ? "No Bookmarked Books"
+                  : "No Books Yet"}
               </h3>
               <p className="text-muted-foreground text-sm mt-1 max-w-md">
-                {showBookmarks
+                {isFiltered
+                  ? "No books match the current filters. Try widening your search."
+                  : showBookmarks
                   ? "Save titles you want to revisit!"
                   : "No books available at the moment."}
               </p>
             </div>
-            {!showBookmarks && (
-              <Button round outlined onClick={() => setModalOpen(true)}>
-                Create Book
+            {isFiltered ? (
+              <Button round outlined onClick={handleClearFilters}>
+                Clear filters
               </Button>
+            ) : (
+              !showBookmarks && (
+                <Button round outlined onClick={() => setModalOpen(true)}>
+                  Create Book
+                </Button>
+              )
             )}
           </CardContent>
         </Card>
       ) : (
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
-          {books
-            .filter(
-              (book) => showBookmarks || book?.author?._id !== user?._id
-            )
-            .map((book) => (
+        <>
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            {pagedBooks.map((book) => (
               <LibraryBookCard
                 key={book._id}
                 book={book}
@@ -141,7 +333,48 @@ const LibraryPage = () => {
                 }
               />
             ))}
-        </div>
+          </div>
+
+          {totalPages > 1 && (
+            <Pagination>
+              <PaginationContent>
+                <PaginationItem>
+                  <PaginationPrevious
+                    href="#"
+                    aria-disabled={currentPage === 1}
+                    className={
+                      currentPage === 1 ? "pointer-events-none opacity-50" : ""
+                    }
+                    onClick={(event) => goToPage(event, currentPage - 1)}
+                  />
+                </PaginationItem>
+                {pageNumbers.map((number) => (
+                  <PaginationItem key={`page-${number}`}>
+                    <PaginationLink
+                      href="#"
+                      isActive={number === currentPage}
+                      onClick={(event) => goToPage(event, number)}
+                    >
+                      {number}
+                    </PaginationLink>
+                  </PaginationItem>
+                ))}
+                <PaginationItem>
+                  <PaginationNext
+                    href="#"
+                    aria-disabled={currentPage === totalPages}
+                    className={
+                      currentPage === totalPages
+                        ? "pointer-events-none opacity-50"
+                        : ""
+                    }
+                    onClick={(event) => goToPage(event, currentPage + 1)}
+                  />
+                </PaginationItem>
+              </PaginationContent>
+            </Pagination>
+          )}
+        </>
       )}
 
       <Modal
@@ -155,5 +388,19 @@ const LibraryPage = () => {
     </div>
   );
 };
+
+// useSearchParams needs a Suspense boundary or this statically prerendered
+// route fails the production build.
+const LibraryPage = () => (
+  <Suspense
+    fallback={
+      <div className="p-4 sm:p-6">
+        <BookGridSkeleton />
+      </div>
+    }
+  >
+    <LibraryPageContent />
+  </Suspense>
+);
 
 export default LibraryPage;

--- a/components/molecules/dashboard/LibraryToolbar.jsx
+++ b/components/molecules/dashboard/LibraryToolbar.jsx
@@ -1,0 +1,116 @@
+"use client";
+import { Search } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import Button from "@/components/atoms/form/Button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+// Radix SelectItem rejects an empty string value, so the "no filter" state
+// needs a sentinel that cannot collide with a real category name.
+export const ALL = "__all__";
+
+const PRICE_OPTIONS = [
+  { value: ALL, label: "All prices" },
+  { value: "free", label: "Free" },
+  { value: "paid", label: "Paid" },
+];
+
+const SORT_OPTIONS = [
+  { value: "newest", label: "Newest" },
+  { value: "price-asc", label: "Price: low to high" },
+  { value: "price-desc", label: "Price: high to low" },
+  { value: "rating", label: "Highest rated" },
+];
+
+const LibraryToolbar = ({
+  search,
+  onSearchChange,
+  category,
+  onCategoryChange,
+  categories,
+  price,
+  onPriceChange,
+  sort,
+  onSortChange,
+  onClear,
+  isFiltered,
+  resultCount,
+}) => {
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center">
+        <div className="relative flex-1">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            value={search}
+            onChange={(event) => onSearchChange(event.target.value)}
+            placeholder="Search by title or author"
+            aria-label="Search books by title or author"
+            className="pl-9"
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-2">
+          <Select value={category} onValueChange={onCategoryChange}>
+            <SelectTrigger className="w-[170px]" aria-label="Filter by category">
+              <SelectValue placeholder="Category" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>All categories</SelectItem>
+              {categories.map((item) => (
+                <SelectItem key={item} value={item}>
+                  {item}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select value={price} onValueChange={onPriceChange}>
+            <SelectTrigger className="w-[140px]" aria-label="Filter by price">
+              <SelectValue placeholder="Price" />
+            </SelectTrigger>
+            <SelectContent>
+              {PRICE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select value={sort} onValueChange={onSortChange}>
+            <SelectTrigger className="w-[190px]" aria-label="Sort books">
+              <SelectValue placeholder="Sort" />
+            </SelectTrigger>
+            <SelectContent>
+              {SORT_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-muted-foreground text-sm" aria-live="polite">
+          {resultCount} {resultCount === 1 ? "book" : "books"}
+        </p>
+        {isFiltered && (
+          <Button round outlined onClick={onClear}>
+            Clear filters
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default LibraryToolbar;

--- a/hooks/useDebouncedValue.js
+++ b/hooks/useDebouncedValue.js
@@ -1,0 +1,17 @@
+"use client";
+import { useEffect, useState } from "react";
+
+/**
+ * Delays propagation of a rapidly changing value. Used to keep the library
+ * search box from re-filtering on every keystroke.
+ */
+export default function useDebouncedValue(value, delay = 300) {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay);
+    return () => clearTimeout(timer);
+  }, [value, delay]);
+
+  return debounced;
+}


### PR DESCRIPTION
## What
Adds a filter toolbar and pagination to /dashboard/library. Search matches title or author, with filters for category and price, four sort orders, and 9 books per page.
## Client-side, with a server-side upgrade path
Filtering runs on the client. fetchBooks() currently issues a bare GET /api/books and returns the response array straight into state — there is no pagination envelope and no evidence the endpoint accepts query parameters. Rather than guess at a backend contract, the toolbar is built against the shape the API actually returns today.
Moving this server-side later is a contained change: extend lib/actions/library/fetch-books.js to forward ?search=&category=&price=&page=&limit=&sort= and swap the useMemo filter for the response. The UI, the URL parameters, and the component props are already named to match, so nothing above fetchBooks needs to change. If the backend already supports those params, say so and I'll wire it up in this PR.
## Details
- Search debounced at 300ms via a new hooks/useDebouncedValue.js, matching title or author name, case-insensitive.
- Category options are derived from the books actually returned, since the field is free-form on the backend — values are trimmed and case-folded so "Fiqh" and "fiqh" collapse to one option.
- Price filters All / Free / Paid off price > 0, consistent with how the card renders it.
- Sort offers Newest, price ascending, price descending, and highest rated. Highest rated reuses the existing getAverageRating hook. Newest prefers createdAt and falls back to the timestamp Mongo embeds in the first 4 bytes of _id, so it is correct whether or not the API returns the field.
- URL state — every filter is reflected in the query string via router.replace, so a filtered view is shareable and survives reload. replace rather than push keeps the back button from stepping through every keystroke.
- Pagination reuses the existing components/ui/pagination.jsx primitives with a sliding five-page window.
## Preserved behaviour
The bookmarks toggle, the exclusion of the viewer's own books, the loading skeletons, and the NetworkErrorComp retry path all work as before. Filters apply to the bookmarks view too. The empty state is now filter-aware and offers a clear-filters action instead of "Create Book" when a filter is what emptied the grid.
## Note for reviewers
The page component is split into a shell and an inner LibraryPageContent wrapped in <Suspense>. This is required — useSearchParams fails the production build on a statically prerendered route without a Suspense boundary. With the boundary in place /dashboard/library remains statically prerendered (confirmed in the build output), so there is no rendering-strategy regression.
## Verification
npm run lint clean and npm run build succeeds — 33 static pages, /dashboard/library still ○ (Static), 14 kB → 17.8 kB.
Closes #88


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added library search with debounced input.
  * Added category, price, and sorting filters.
  * Added result counts and a clear-filters option.
  * Added URL-based filter and search state for shareable views.
  * Added client-side pagination with numbered, previous, and next controls.
  * Added loading and empty-state handling for filtered results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->