### PR TITLE
[Bug] PaymentModal abandons pending Stellar transactions instead of calling the existing cancelPayment

### DIFF
--- a/components/stellar/PaymentModal.jsx
+++ b/components/stellar/PaymentModal.jsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   Dialog,
   DialogContent,
@@ -31,7 +31,7 @@ export default function PaymentModal({
 }) {
   const { connectedWallet, walletInfo, connectWallet, network, isConnecting } =
     useStellar();
-  const { initializePayment, executePayment, isProcessing } =
+  const { initializePayment, executePayment, cancelPayment, isProcessing } =
     useStellarPayment();
 
   const [step, setStep] = useState("preview"); // preview | confirm | processing | success | error
@@ -39,10 +39,12 @@ export default function PaymentModal({
   const [result, setResult] = useState(null);
   const [error, setError] = useState(null);
   const [showQr, setShowQr] = useState(false);
+  const closingRef = useRef(false);
 
-  // Reset state when modal opens/closes
+  // Reset state when modal opens
   useEffect(() => {
     if (isOpen) {
+      closingRef.current = false;
       setStep("preview");
       setPaymentData(null);
       setResult(null);
@@ -68,12 +70,16 @@ export default function PaymentModal({
 
   const handleConfirm = async () => {
     setStep("processing");
-    const success = await executePayment(paymentData);
+    const outcome = await executePayment(paymentData);
 
-    if (success) {
-      setResult(success);
+    if (outcome.success) {
+      setResult(outcome.data);
       setStep("success");
-      onSuccess?.(success);
+      onSuccess?.(outcome.data);
+    } else if (outcome.cancelled) {
+      await cancelPayment();
+      setPaymentData(null);
+      setStep("preview");
     } else {
       setStep("error");
       setError("Transaction failed. Please try again.");
@@ -81,12 +87,25 @@ export default function PaymentModal({
   };
 
   const handleClose = () => {
+    if (step === "processing" || closingRef.current) return;
+    closingRef.current = true;
+
+    if (paymentData && step !== "success" && step !== "error") {
+      cancelPayment();
+    }
+
     setStep("preview");
     setPaymentData(null);
     setResult(null);
     setError(null);
     setShowQr(false);
     onClose();
+  };
+
+  const handleBack = () => {
+    cancelPayment();
+    setPaymentData(null);
+    setStep("preview");
   };
 
   const sep7Uri = paymentData?.sep7Uri || paymentData?.payment?.sep7Uri;
@@ -102,7 +121,15 @@ export default function PaymentModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent
+        className="sm:max-w-md"
+        onPointerDownOutside={(e) => {
+          if (step === "processing") e.preventDefault();
+        }}
+        onEscapeKeyDown={(e) => {
+          if (step === "processing") e.preventDefault();
+        }}
+      >
         <DialogHeader>
           <DialogTitle>
             {step === "success"
@@ -247,7 +274,7 @@ export default function PaymentModal({
               <Loader2 className="h-12 w-12 animate-spin text-primary" />
               <p className="mt-4 text-muted-foreground">
                 {isProcessing
-                  ? "Processing payment..."
+                  ? "Waiting for wallet confirmation…"
                   : "Preparing transaction..."}
               </p>
               <p className="text-xs text-muted-foreground mt-2">
@@ -319,7 +346,7 @@ export default function PaymentModal({
               <>
                 <Button
                   variant="outline"
-                  onClick={() => setStep("preview")}
+                  onClick={handleBack}
                   className="flex-1"
                 >
                   Back

--- a/hooks/useStellarPayment.js
+++ b/hooks/useStellarPayment.js
@@ -57,7 +57,7 @@ export const useStellarPayment = () => {
     async (paymentData) => {
       if (!paymentData) {
         toast.error("No payment data available");
-        return false;
+        return { success: false };
       }
 
       setIsProcessing(true);
@@ -86,26 +86,26 @@ export const useStellarPayment = () => {
           await refreshBalance();
 
           setCurrentTransaction(null);
-          return res.data;
+          return { success: true, data: res.data };
         } else {
           throw new Error(res.data.message);
         }
       } catch (error) {
         const message = error.response?.data?.message || error.message;
+        const isCancelled = message.includes("rejected") || message.includes("cancelled");
 
-        // Handle specific Stellar errors
         if (message.includes("insufficient") || message.includes("underfunded")) {
           toast.error("Insufficient USDC balance");
         } else if (message.includes("op_no_trust") || message.includes("trustline")) {
           toast.error(
             "You need to add USDC trustline to your wallet first"
           );
-        } else if (message.includes("rejected") || message.includes("cancelled")) {
+        } else if (isCancelled) {
           toast.error("Transaction was cancelled");
         } else {
           toast.error(`Payment failed: ${message}`);
         }
-        return false;
+        return { success: false, cancelled: isCancelled };
       } finally {
         setIsProcessing(false);
       }


### PR DESCRIPTION
## Description

This PR fixes #76 by wiring the existing `cancelPayment()` into `PaymentModal` so pending transactions are properly cleaned up instead of abandoned.

### Changes

**`hooks/useStellarPayment.js`**
- `executePayment` now returns `{ success: true, data }` on success, `{ success: false, cancelled: true }` on wallet rejection, and `{ success: false, cancelled: false }` on other errors. This lets callers distinguish cancellation from failure without breaking the existing API surface (the only caller is `PaymentModal`).

**`components/stellar/PaymentModal.jsx`**
- Destructured `cancelPayment` from `useStellarPayment()`
- **`handleClose`**: calls `cancelPayment()` when closing from a step that has a pending, unsubmitted transaction (confirm/preview); returns early during processing to prevent accidental dismissal; uses `closingRef` guard so it is safe to call multiple times
- **`handleBack`** (new): calls `cancelPayment()`, clears `paymentData`, returns to preview — prevents duplicate orphaned transactions on initiate → back → initiate
- **`handleConfirm`**: on wallet rejection (`outcome.cancelled`), cancels the pending backend transaction and returns to preview instead of leaving the tx dangling in error step
- **`DialogContent`**: added `onPointerDownOutside` and `onEscapeKeyDown` that `preventDefault()` during the processing step, blocking accidental dismissal while a signature or submission is in flight
- Processing step text changed to "Waiting for wallet confirmation…"

### Acceptance Criteria Fulfilled

- [x] Closing the modal from the confirm step issues `DELETE /api/stellar/payment/transactions/:id`
- [x] Opening the modal and completing a purchase still works end-to-end on testnet (executePayment returns { success: true, data })
- [x] While processing, overlay click and Escape do not close the dialog; after success/error they do
- [x] Rejecting the signature in the wallet returns the user to the preview step with no orphaned pending transaction
- [x] No duplicate pending transactions are created by an initiate → back → initiate sequence