### PR TITLE
feat(auth): add Sign in with Stellar SEP-10 wallet login #101

### DIFF
--- a/components/organisms/auth/login-form.jsx
+++ b/components/organisms/auth/login-form.jsx
@@ -1,13 +1,17 @@
 "use client";
 
 import { login } from "@/hooks/useAuth";
+import { useStellarAuth } from "@/hooks/useStellarAuth";
 import Button from "@/components/atoms/form/Button";
 import { Input } from "@/components/ui/input";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { toast } from "sonner";
 import Link from "next/link";
 import React from "react";
-import { useRouter } from "next/navigation";
 import Modal from "@/components/molecules/Modal";
 import ForgetPassword from "./forget-password";
 import { useForm } from "react-hook-form";
@@ -21,6 +25,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { Wallet } from "lucide-react";
 
 const loginSchema = z.object({
   email: z.string().min(1, "Email is required").email("Invalid email address"),
@@ -28,13 +33,24 @@ const loginSchema = z.object({
 });
 
 export function LoginForm({ className, ...props }) {
-  const router = useRouter();
   const [modalOpen, setModalOpen] = React.useState(false);
+  const {
+    loginWithStellar,
+    isPending: isStellarPending,
+    stellarAuthAvailable,
+    kitInitialized,
+  } = useStellarAuth();
 
   const form = useForm({
     resolver: zodResolver(loginSchema),
     defaultValues: { email: "", password: "" },
   });
+
+  const stellarDisabled =
+    isStellarPending ||
+    form.formState.isSubmitting ||
+    !kitInitialized ||
+    stellarAuthAvailable === false;
 
   const handleForgetPassword = (e) => {
     e.preventDefault();
@@ -48,10 +64,41 @@ export function LoginForm({ className, ...props }) {
       setTimeout(() => {
         window.location.href = "/dashboard";
       }, 500);
-    } catch (error) {
+    } catch {
       // login() already shows toast on failure
     }
   };
+
+  const handleStellarLogin = async () => {
+    try {
+      const result = await loginWithStellar();
+      if (result && !result.unregistered) {
+        setTimeout(() => {
+          window.location.href = "/dashboard";
+        }, 500);
+      }
+    } catch {
+      // loginWithStellar already toasts failures
+    }
+  };
+
+  const stellarButton = (
+    <Button
+      type="button"
+      wide
+      outlined
+      loading={isStellarPending}
+      loaderColor="black"
+      loaderSize={24}
+      disabled={stellarDisabled}
+      onClick={handleStellarLogin}
+      className="gap-2 border-accent text-foreground hover:bg-accent/10"
+      childrenClassName="gap-2"
+    >
+      <Wallet className="h-4 w-4" aria-hidden />
+      Sign in with Stellar
+    </Button>
+  );
 
   return (
     <>
@@ -59,6 +106,7 @@ export function LoginForm({ className, ...props }) {
         <form
           className={cn("flex flex-col gap-6", className)}
           onSubmit={form.handleSubmit(handleSubmit)}
+          {...props}
         >
           <div className="flex flex-col items-center gap-2 text-center">
             <h1 className="text-2xl sm:text-4xl font-bold font-stretch-125%">
@@ -69,30 +117,50 @@ export function LoginForm({ className, ...props }) {
             </p>
           </div>
           <div className="grid gap-4">
-            <FormField control={form.control} name="email" render={({ field }) => (
-              <FormItem>
-                <FormLabel>Email</FormLabel>
-                <FormControl><Input type="email" placeholder="you@example.com" {...field} /></FormControl>
-                <FormMessage />
-              </FormItem>
-            )} />
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="you@example.com"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-            <FormField control={form.control} name="password" render={({ field }) => (
-              <FormItem>
-                <div className="flex items-center">
-                  <FormLabel>Password</FormLabel>
-                  <a
-                    href="#"
-                    onClick={handleForgetPassword}
-                    className="ml-auto inline-block text-sm underline-offset-4 hover:underline"
-                  >
-                    Forgot your password?
-                  </a>
-                </div>
-                <FormControl><Input type="password" placeholder="********" {...field} /></FormControl>
-                <FormMessage />
-              </FormItem>
-            )} />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <div className="flex items-center">
+                    <FormLabel>Password</FormLabel>
+                    <a
+                      href="#"
+                      onClick={handleForgetPassword}
+                      className="ml-auto inline-block text-sm underline-offset-4 hover:underline"
+                    >
+                      Forgot your password?
+                    </a>
+                  </div>
+                  <FormControl>
+                    <Input
+                      type="password"
+                      placeholder="********"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
             <Button
               className="bg-accent hover:bg-highlight animate-in-out duration-300"
@@ -101,13 +169,38 @@ export function LoginForm({ className, ...props }) {
               loaderColor="white"
               loaderSize={24}
               type="submit"
-              disabled={form.formState.isSubmitting}
+              disabled={form.formState.isSubmitting || isStellarPending}
             >
               Login
             </Button>
 
+            <div className="relative my-1">
+              <div className="absolute inset-0 flex items-center">
+                <span className="w-full border-t border-border" />
+              </div>
+              <div className="relative flex justify-center text-xs uppercase">
+                <span className="bg-background px-2 text-muted-foreground">
+                  or
+                </span>
+              </div>
+            </div>
+
+            {stellarAuthAvailable === false ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="w-full inline-flex">{stellarButton}</span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs text-center">
+                  Sign in with Stellar is not available yet — the SEP-10
+                  challenge endpoint is not deployed on this API.
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              stellarButton
+            )}
+
             <div className="text-center text-sm">
-              Don't have an account?{" "}
+              Don&apos;t have an account?{" "}
               <Link href="/signup" className="underline underline-offset-4">
                 Sign Up
               </Link>

--- a/components/stellar/StellarProvider.jsx
+++ b/components/stellar/StellarProvider.jsx
@@ -85,7 +85,25 @@ export default function StellarProvider({ children }) {
     checkStoredWallet();
   }, [user?._id]);
 
-  // Connect wallet using the auth modal
+  /**
+   * Open the wallet picker and return the selected public key.
+   * No logged-in user required — used by Sign in with Stellar (SEP-10).
+   */
+  const selectWallet = useCallback(async () => {
+    if (!kitInitialized) {
+      throw new Error("Wallet kit not initialized. Please refresh the page.");
+    }
+
+    const { address } = await StellarWalletsKit.authModal();
+
+    if (!address) {
+      throw new Error("Failed to get wallet address");
+    }
+
+    return address;
+  }, [kitInitialized]);
+
+  // Connect wallet using the auth modal (requires an authenticated session)
   const connectWallet = useCallback(async () => {
     if (!kitInitialized) {
       toast.error("Wallet kit not initialized. Please refresh the page.");
@@ -99,12 +117,7 @@ export default function StellarProvider({ children }) {
 
     setIsConnecting(true);
     try {
-      // Open the authentication modal which returns the address when successful
-      const { address } = await StellarWalletsKit.authModal();
-
-      if (!address) {
-        throw new Error("Failed to get wallet address");
-      }
+      const address = await selectWallet();
 
       // Save to backend
       const res = await axiosInstance.post("/api/stellar/wallet/connect", {
@@ -134,7 +147,7 @@ export default function StellarProvider({ children }) {
     } finally {
       setIsConnecting(false);
     }
-  }, [kitInitialized, user, refreshUser]);
+  }, [kitInitialized, user, refreshUser, selectWallet]);
 
   // Disconnect wallet
   const disconnectWallet = useCallback(async () => {
@@ -195,6 +208,7 @@ export default function StellarProvider({ children }) {
     walletInfo,
     isConnecting,
     isLoading,
+    selectWallet,
     connectWallet,
     disconnectWallet,
     refreshBalance,

--- a/hooks/useAuth.js
+++ b/hooks/useAuth.js
@@ -6,6 +6,25 @@ import axiosInstance from "@/lib/config/axios.config";
 
 const COOKIE_OPTIONS = { expires: 1, path: "/" };
 
+/**
+ * Persist auth session cookies and sync AuthProvider state.
+ * Shared by email/password login, signup, and Sign in with Stellar.
+ */
+export const persistSession = (token, user) => {
+  if (!token || !user) {
+    throw new Error("Missing token or user for session persistence");
+  }
+
+  if (user.id && !user._id) user._id = user.id;
+
+  Cookies.set("authToken", token, COOKIE_OPTIONS);
+  Cookies.set("userInfo", JSON.stringify(user), COOKIE_OPTIONS);
+
+  __triggerAuthUpdate(user);
+
+  return user;
+};
+
 export const useAuth = () => {
   return useAuthContext();
 };
@@ -17,12 +36,7 @@ export const login = async (email, password) => {
       password,
     });
     const { token, user } = res.data;
-    if (user.id && !user._id) user._id = user.id;
-
-    Cookies.set("authToken", token, COOKIE_OPTIONS);
-    Cookies.set("userInfo", JSON.stringify(user), COOKIE_OPTIONS);
-
-    __triggerAuthUpdate(user);
+    persistSession(token, user);
 
     toast.success("Login successful");
     return user;
@@ -49,12 +63,7 @@ export const signup = async (name, email, password, role) => {
     });
 
     const { token, user } = res.data;
-    if (user.id && !user._id) user._id = user.id;
-
-    Cookies.set("authToken", token, COOKIE_OPTIONS);
-    Cookies.set("userInfo", JSON.stringify(user), COOKIE_OPTIONS);
-
-    __triggerAuthUpdate(user);
+    persistSession(token, user);
 
     toast.success("Signup successful! Redirecting to dashboard...");
     return user;

--- a/hooks/useStellarAuth.js
+++ b/hooks/useStellarAuth.js
@@ -1,0 +1,211 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import axiosInstance from "@/lib/config/axios.config";
+import { useStellar } from "@/components/stellar/StellarProvider";
+import { persistSession } from "@/hooks/useAuth";
+
+/**
+ * Frontend SEP-10 client for "Sign in with Stellar".
+ *
+ * Contract assumption (paired with dnb-backend #25 / frontend #101):
+ * - GET  /api/auth/stellar/challenge?account=G… → { transaction, networkPassphrase }
+ *   (also accepts snake_case network_passphrase)
+ * - POST /api/auth/stellar/verify { transaction } → { token, user } for linked wallets
+ * - Unregistered wallets: HTTP 404/409, OR 200 with { registered: false, accountProven }
+ * - Feature not deployed: challenge returns 404/503 → button disabled with tooltip
+ *
+ * No challenge XDR is submitted to Horizon from this client — only challenge + verify HTTP calls.
+ */
+
+const CHALLENGE_PATH = "/api/auth/stellar/challenge";
+const VERIFY_PATH = "/api/auth/stellar/verify";
+
+const isModalClosedError = (error) =>
+  error?.code === -1 ||
+  (typeof error?.message === "string" &&
+    /closed|cancel(l)?ed|reject(ed)?/i.test(error.message));
+
+const isExpiredChallengeError = (error) => {
+  const message =
+    error?.response?.data?.message ||
+    error?.response?.data?.error ||
+    error?.message ||
+    "";
+  return /expir|time.?bound|challenge.*(invalid|expired)/i.test(
+    String(message)
+  );
+};
+
+const isUnregisteredWallet = (error, data) => {
+  if (data && data.registered === false) return true;
+  const status = error?.response?.status;
+  return status === 404 || status === 409;
+};
+
+const getNetworkPassphrase = (payload = {}) =>
+  payload.networkPassphrase || payload.network_passphrase;
+
+const fetchChallenge = async (account) => {
+  const res = await axiosInstance.get(CHALLENGE_PATH, {
+    params: { account },
+  });
+  const transaction = res.data?.transaction;
+  const networkPassphrase = getNetworkPassphrase(res.data);
+
+  if (!transaction || !networkPassphrase) {
+    throw new Error("Invalid challenge response from server");
+  }
+
+  return { transaction, networkPassphrase };
+};
+
+const verifyChallenge = async (signedXdr) => {
+  const res = await axiosInstance.post(VERIFY_PATH, {
+    transaction: signedXdr,
+  });
+  return res.data;
+};
+
+export function useStellarAuth() {
+  const { kitInitialized, selectWallet, signTransaction } = useStellar();
+  const [isPending, setIsPending] = useState(false);
+  const [stellarAuthAvailable, setStellarAuthAvailable] = useState(null);
+  const [availabilityChecked, setAvailabilityChecked] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const probe = async () => {
+      try {
+        // Missing account should yield 400 when the route exists.
+        const res = await axiosInstance.get(CHALLENGE_PATH, {
+          validateStatus: () => true,
+        });
+
+        if (cancelled) return;
+
+        if (res.status === 404 || res.status === 503) {
+          setStellarAuthAvailable(false);
+        } else {
+          setStellarAuthAvailable(true);
+        }
+      } catch (error) {
+        if (cancelled) return;
+        const status = error?.response?.status;
+        if (status === 404 || status === 503) {
+          setStellarAuthAvailable(false);
+        } else if (status) {
+          // Any other HTTP response means the route is reachable
+          setStellarAuthAvailable(true);
+        } else {
+          // Network / unknown — keep enabled so the user can still try
+          setStellarAuthAvailable(true);
+        }
+      } finally {
+        if (!cancelled) setAvailabilityChecked(true);
+      }
+    };
+
+    probe();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const loginWithStellar = useCallback(async () => {
+    if (!kitInitialized) {
+      toast.error("Wallet kit not initialized. Please refresh the page.");
+      return null;
+    }
+
+    if (stellarAuthAvailable === false) {
+      toast.error(
+        "Sign in with Stellar is not available yet. Please use email login."
+      );
+      return null;
+    }
+
+    setIsPending(true);
+
+    try {
+      const address = await selectWallet();
+
+      const attemptVerify = async (allowRetry) => {
+        const { transaction, networkPassphrase } = await fetchChallenge(address);
+        const signedXdr = await signTransaction(transaction, networkPassphrase);
+
+        try {
+          return await verifyChallenge(signedXdr);
+        } catch (verifyError) {
+          if (allowRetry && isExpiredChallengeError(verifyError)) {
+            // SEP-10 challenges are short-lived — re-fetch and retry once
+            return attemptVerify(false);
+          }
+          throw verifyError;
+        }
+      };
+
+      const data = await attemptVerify(true);
+
+      if (data?.registered === false) {
+        toast.error(
+          "This wallet is not linked to a Deen Bridge account yet. Sign up with email, then link your wallet from the dashboard."
+        );
+        return { unregistered: true, account: data.accountProven || address };
+      }
+
+      const { token, user } = data || {};
+      if (!token || !user) {
+        throw new Error("Invalid verify response from server");
+      }
+
+      persistSession(token, user);
+      toast.success("Signed in with Stellar");
+      return user;
+    } catch (error) {
+      if (isModalClosedError(error)) {
+        toast.message("Wallet connection cancelled");
+        return null;
+      }
+
+      if (isUnregisteredWallet(error)) {
+        toast.error(
+          "This wallet is not linked to a Deen Bridge account yet. Sign up with email, then link your wallet from the dashboard."
+        );
+        return { unregistered: true };
+      }
+
+      if (error?.response?.status === 503 || error?.response?.status === 404) {
+        setStellarAuthAvailable(false);
+        toast.error(
+          "Sign in with Stellar is not available on the server yet. Please use email login."
+        );
+        return null;
+      }
+
+      const message =
+        error?.response?.data?.message ||
+        error?.response?.data?.error ||
+        error?.message ||
+        "Sign in with Stellar failed. Please try again.";
+
+      console.error("Stellar auth error:", error);
+      toast.error(message);
+      throw error;
+    } finally {
+      setIsPending(false);
+    }
+  }, [kitInitialized, selectWallet, signTransaction, stellarAuthAvailable]);
+
+  return {
+    loginWithStellar,
+    isPending,
+    stellarAuthAvailable,
+    availabilityChecked,
+    kitInitialized,
+  };
+}
+
+export default useStellarAuth;

--- a/lib/config/axios.config.js
+++ b/lib/config/axios.config.js
@@ -69,10 +69,11 @@ axiosInstance.interceptors.response.use(
       });
     }
 
-    // Handle 401 - attempt token refresh (skip for login/register/refresh endpoints)
+    // Handle 401 - attempt token refresh (skip for login/register/refresh/stellar-auth endpoints)
     const isAuthRoute = originalRequest.url?.includes("/api/auth/login") ||
       originalRequest.url?.includes("/api/auth/register") ||
-      originalRequest.url?.includes("/api/auth/refresh");
+      originalRequest.url?.includes("/api/auth/refresh") ||
+      originalRequest.url?.includes("/api/auth/stellar/");
 
     if (error.response?.status === 401 && !originalRequest._retry && !isAuthRoute) {
       if (isRefreshing) {


### PR DESCRIPTION
## Overview

This PR adds **Sign in with Stellar** as an alternative login path using the SEP-10 challenge/response protocol: the frontend opens a wallet picker (without requiring an existing session), fetches a challenge transaction, signs it via Stellar Wallets Kit, and exchanges the signed XDR for the same `authToken` / `userInfo` cookie session used by email/password login.

## Related Issue

Closes #101

Paired backend: [Deen-Bridge/dnb-backend#25](https://github.com/Deen-Bridge/dnb-backend/issues/25)

## Changes

### 🔐 SEP-10 client flow

* **[ADD]** `hooks/useStellarAuth.js`
  * `loginWithStellar()`: `selectWallet()` → `GET /api/auth/stellar/challenge` → `signTransaction` → `POST /api/auth/stellar/verify` → `persistSession`
  * Handles modal cancel (`error.code === -1`), signature rejection, expired challenge (re-fetch + retry once), and wrong-network passphrase errors via `sonner` toasts
  * Probes challenge availability on mount; disables the button when the endpoint returns `404`/`503`
  * Unregistered wallets (`404`/`409` or `{ registered: false }`) show a clear “sign up + link wallet from dashboard” path — no silent account creation

* **[MODIFY]** `hooks/useAuth.js`
  * Extracts shared `persistSession(token, user)` helper (`_id` normalization + cookies + AuthProvider sync) used by login, signup, and Stellar auth

* **[MODIFY]** `components/stellar/StellarProvider.jsx`
  * Exposes `selectWallet()` with **no** `user._id` guard so SEP-10 works in a fresh browser profile
  * `connectWallet` still requires login and now reuses `selectWallet()`

* **[MODIFY]** `components/organisms/auth/login-form.jsx`
  * “or” divider + **Sign in with Stellar** button (wallet icon, pending state)
  * Tooltip when SEP-10 backend is not deployed yet

* **[MODIFY]** `lib/config/axios.config.js`
  * Skips token-refresh retry on `/api/auth/stellar/*` routes

## Contract assumptions (document for reviewers)

| Surface | Assumption |
| --- | --- |
| Challenge | `GET /api/auth/stellar/challenge?account=G…` → `{ transaction, networkPassphrase }` (also accepts `network_passphrase`) |
| Verify | `POST /api/auth/stellar/verify` `{ transaction }` → `{ token, user }` matching password login shape |
| Unregistered | `404`/`409`, or `200` with `{ registered: false, accountProven }` — frontend directs user to email signup + dashboard wallet link |
| Feature flag | Challenge `404`/`503` → button disabled with tooltip (graceful degradation) |
| Network | Challenge XDR is **never** submitted to Horizon from the frontend |

> Note: backend issue #25 currently drafts routes under `/api/stellar/auth`. This frontend follows issue #101’s `/api/auth/stellar/*` paths — please align the backend mount (or we can add a thin alias) before E2E on a live API.

## Verification Results

```
npm run lint
✅ passed (only pre-existing anonymous-default-export warnings)

npm run build
✅ passed — `/login` route built successfully

Static acceptance checks
✅ persistSession shared by login/signup/stellar
✅ selectWallet has no user._id precondition; connectWallet still gated
✅ challenge + verify paths only (no Horizon submit)
✅ modal close / unregistered / expired-retry / 503 degrade paths present
✅ Sign in with Stellar UI + or divider + unavailable tooltip
```

| Acceptance Criteria | Status |
| --- | --- |
| Login page shows “Sign in with Stellar” alongside email/password | ✅ |
| Full Freighter testnet flow → `/dashboard` with identical cookies | ⏳ Requires live SEP-10 backend (#25) + Freighter |
| No network submission of challenge XDR (only `/challenge` + `/verify`) | ✅ by design (no submit calls in client) |
| Modal close / signature reject → toast, no unhandled rejections | ✅ |
| Works without prior `user._id` session | ✅ `selectWallet()` ungated |
| Unregistered wallet shows agreed UX | ✅ signup + dashboard link messaging |
| `npm run lint` and `npm run build` pass | ✅ |


Made with [Cursor](https://cursor.com)