### PR TITLE
docs: align contributing note with assign-first workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This repository participates in the **[Stellar Drips Wave](https://www.drips.net
 
 - All pull requests target the **`dev`** branch (`main` is releases only)
 - CI (lint + build) must pass before review
-- One contributor per issue — comment to claim it first
+- One contributor per issue — request it through the campaign (Drips Wave / GrantFox OSS); the maintainer assigns it. Please don't open a PR for an issue you haven't been assigned.
 
 Read **[CONTRIBUTING.md](CONTRIBUTING.md)** for the full workflow, coding standards, and Wave rules.
 


### PR DESCRIPTION
Small README hygiene: aligns the Drips Wave contributing note with the assign-first workflow (contributors are assigned via the campaign, not by commenting to claim).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to require issue assignment through Drips Wave / GrantFox OSS before starting work.
  * Replaced the previous comment-to-claim process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->