### PR TITLE
feat: redesign product UI with dark-mode tokens and wire real account…

### DIFF
--- a/app/(pages)/educators/[profileid]/EducatorPageClient.jsx
+++ b/app/(pages)/educators/[profileid]/EducatorPageClient.jsx
@@ -26,6 +26,11 @@ import Navbar from "@/components/molecules/ladingpage/Navbar";
 import { Copy, Share2, Users, BookOpen, GraduationCap, Star } from "lucide-react";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 import Button from "@/components/atoms/form/Button";
 
 export default function PublicEducatorPage({ params }) {
@@ -171,11 +176,16 @@ export default function PublicEducatorPage({ params }) {
             onShare={handleShare}
             isOwnProfile={currentUser?._id === profileid}
           />
-          <div className="max-w-4xl mx-auto px-4 py-16 text-center">
-            <BookOpen className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-            <h3 className="text-lg font-semibold mb-2">No public content yet</h3>
-            <p className="text-muted-foreground">
-              This educator hasn&apos;t published any courses, books, or spaces yet.
+          <div className="mx-auto max-w-4xl px-4 py-20 text-center">
+            <div className="mx-auto mb-4 flex size-14 items-center justify-center rounded-2xl border border-white/10 bg-white/5">
+              <BookOpen className="h-7 w-7 text-secondary" />
+            </div>
+            <h3 className={cn(poppins_600, "mb-2 text-lg text-ink-inverse")}>
+              No public content yet
+            </h3>
+            <p className={cn(poppins_400, "text-ink-inverse-muted")}>
+              This educator hasn&apos;t published any courses, books, or spaces
+              yet.
             </p>
           </div>
         </main>
@@ -217,22 +227,30 @@ export default function PublicEducatorPage({ params }) {
         />
 
         {tabs.length > 1 && (
-          <div className="max-w-6xl mx-auto px-4 sm:px-6 mt-6">
-            <div className="flex gap-2 border-b border-border pb-0">
+          <div className="mx-auto mt-8 max-w-6xl px-4 sm:px-6">
+            <div className="inline-flex flex-wrap gap-1 rounded-full border border-white/10 bg-white/5 p-1 backdrop-blur">
               {tabs.map((tab) => (
                 <button
                   key={tab.key}
                   onClick={() => setActiveTab(tab.key)}
                   className={cn(
-                    "flex items-center gap-2 px-4 py-3 text-sm font-medium border-b-2 transition-colors",
+                    poppins_500,
+                    "flex items-center gap-2 rounded-full px-4 py-2 text-sm transition-colors",
                     activeTab === tab.key
-                      ? "border-accent text-accent"
-                      : "border-transparent text-muted-foreground hover:text-foreground"
+                      ? "bg-white text-basic"
+                      : "text-ink-inverse-muted hover:text-ink-inverse"
                   )}
                 >
                   <tab.icon className="h-4 w-4" />
                   {tab.label}
-                  <span className="text-xs bg-muted px-1.5 py-0.5 rounded-full">
+                  <span
+                    className={cn(
+                      "rounded-full px-1.5 py-0.5 text-xs",
+                      activeTab === tab.key
+                        ? "bg-basic/10 text-basic"
+                        : "bg-white/10 text-ink-inverse-muted"
+                    )}
+                  >
                     {tab.count}
                   </span>
                 </button>

--- a/app/account/notifications/page.jsx
+++ b/app/account/notifications/page.jsx
@@ -1,613 +1,299 @@
-"use client"
+"use client";
 
-import Image from "next/image"
-import { MoreHorizontal } from "lucide-react"
-
-import { Badge } from "@/components/ui/badge"
-import { Button } from "@/components/ui/button"
+import { useState, useEffect, useCallback } from "react";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+  MoreHorizontal,
+  Bell,
+  ArrowRightToLine,
+  ArrowLeftToLine,
+  CheckCheck,
+  Loader2,
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuLabel,
   DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
+} from "@/components/ui/dropdown-menu";
+import { formatDistanceToNow } from "date-fns";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import {
-  Table,
-  TableBody,
-  TableCell,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from "@/components/ui/table"
-import { ArrowRightToLine } from "lucide-react"
-import { ArrowLeftToLine } from "lucide-react"
-export default function Component() {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+import {
+  fetchNotifications,
+  markNotificationAsRead,
+  markAllNotificationsAsRead,
+  deleteNotification,
+} from "@/lib/actions/notifications";
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
+
+const PAGE_SIZE = 10;
+
+const notifTitle = (n) => n.title || n.message || n.body || "Notification";
+const notifBody = (n) =>
+  n.title ? n.message || n.body || "" : n.title ? "" : n.body || "";
+const isUnread = (n) => !(n.read ?? n.isRead ?? false);
+const notifTime = (n) => {
+  const d = n.createdAt || n.created_at;
+  if (!d) return "";
+  try {
+    return formatDistanceToNow(new Date(d), { addSuffix: true });
+  } catch {
+    return "";
+  }
+};
+
+export default function NotificationsPage() {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [total, setTotal] = useState(0);
+  const [unread, setUnread] = useState(0);
+
+  const load = useCallback(async (targetPage) => {
+    setLoading(true);
+    const res = await fetchNotifications(targetPage, PAGE_SIZE);
+    if (res.success) {
+      setItems(res.notifications);
+      setTotalPages(res.totalPages || 1);
+      setTotal(res.total || res.notifications.length);
+      setUnread(res.unread || 0);
+      setPage(res.page || targetPage);
+    } else {
+      setItems([]);
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load(1);
+  }, [load]);
+
+  const handleMarkRead = async (id) => {
+    setItems((prev) =>
+      prev.map((n) => ((n._id || n.id) === id ? { ...n, read: true } : n))
+    );
+    setUnread((u) => Math.max(0, u - 1));
+    const res = await markNotificationAsRead(id);
+    if (!res.success) toast.error("Couldn't mark as read");
+  };
+
+  const handleMarkAll = async () => {
+    setItems((prev) => prev.map((n) => ({ ...n, read: true })));
+    setUnread(0);
+    const res = await markAllNotificationsAsRead();
+    if (res.success) toast.success("All marked as read");
+    else toast.error("Couldn't mark all as read");
+  };
+
+  const handleDelete = async (id) => {
+    const prev = items;
+    setItems((p) => p.filter((n) => (n._id || n.id) !== id));
+    const res = await deleteNotification(id);
+    if (!res.success) {
+      setItems(prev);
+      toast.error("Couldn't delete notification");
+    }
+  };
+
+  const rangeStart = total === 0 ? 0 : (page - 1) * PAGE_SIZE + 1;
+  const rangeEnd = Math.min(page * PAGE_SIZE, total);
+
   return (
-    <div className="m-5 p-5">
-
-
-      <Card className="p-5">
-        <CardHeader>
-          <CardTitle>Notifications</CardTitle>
-          <CardDescription>
-            View notifications to stay updated
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead className="hidden w-[100px] sm:table-cell">
-                  <span className="sr-only">Image</span>
-                </TableHead>
-                <TableHead>Name</TableHead>
-                <TableHead className="hidden md:table-cell">Price</TableHead>
-                <TableHead className="hidden md:table-cell">
-                  Total Sales
-                </TableHead>
-                <TableHead className="hidden md:table-cell">Created at</TableHead>
-                <TableHead>
-                  <span className="sr-only">Actions</span>
-                </TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">
-                  Laser Lemonade Machine
-                </TableCell>
-                <TableCell className="hidden md:table-cell">$499.99</TableCell>
-                <TableCell className="hidden md:table-cell">25</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2023-07-12 10:42 AM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">
-                  Hypernova Headphones
-                </TableCell>
-
-                <TableCell className="hidden md:table-cell">$129.99</TableCell>
-                <TableCell className="hidden md:table-cell">100</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2023-10-18 03:21 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">AeroGlow Desk Lamp</TableCell>
-
-                <TableCell className="hidden md:table-cell">$39.99</TableCell>
-                <TableCell className="hidden md:table-cell">50</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2023-11-29 08:15 AM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">
-                  TechTonic Energy Drink
-                </TableCell>
-                <TableCell className="hidden md:table-cell">$2.99</TableCell>
-                <TableCell className="hidden md:table-cell">0</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2023-12-25 11:59 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">
-                  Gamer Gear Pro Controller
-                </TableCell>
-
-                <TableCell className="hidden md:table-cell">$59.99</TableCell>
-                <TableCell className="hidden md:table-cell">75</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-01-01 12:00 AM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell className="hidden sm:table-cell">
-                  <Image
-                    alt="Product image"
-                    className="aspect-square rounded-md object-cover"
-                    height="64"
-                    src="/images/mosque.png"
-                    width="64"
-                  />
-                </TableCell>
-                <TableCell className="font-medium">Luminous VR Headset</TableCell>
-
-                <TableCell className="hidden md:table-cell">$199.99</TableCell>
-                <TableCell className="hidden md:table-cell">30</TableCell>
-                <TableCell className="hidden md:table-cell">
-                  2024-02-14 02:14 PM
-                </TableCell>
-                <TableCell>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button aria-haspopup="true" size="icon" variant="ghost">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Toggle menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuLabel>Actions</DropdownMenuLabel>
-                      <DropdownMenuItem>Edit</DropdownMenuItem>
-                      <DropdownMenuItem>Delete</DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </CardContent>
-        <CardFooter className="flex justify-between items-center">
-            <div className="text-xs text-muted-foreground">
-              Showing <strong>1-10</strong> of <strong>32</strong>
+    <div className="min-h-full bg-surface p-3 sm:p-6">
+      <div className="mx-auto max-w-5xl space-y-6">
+        {/* Header */}
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+              <Bell className="h-5 w-5 text-accent" />
             </div>
-          <div className="flex text-xs text-muted-foreground gap-4">
-              <ArrowLeftToLine className="hover:text-brand-text"  size={17}/>
-              <ArrowRightToLine className="hover:text-brand-text"  size={17}/>
+            <div>
+              <h1
+                className={cn(
+                  poppins_600,
+                  "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+                )}
+              >
+                Notifications
+              </h1>
+              <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                {unread > 0
+                  ? `${unread} unread`
+                  : "You're all caught up"}
+              </p>
             </div>
-        </CardFooter>
-      </Card>
+          </div>
+          {unread > 0 && (
+            <button
+              onClick={handleMarkAll}
+              className={cn(
+                poppins_500,
+                "inline-flex items-center gap-1.5 rounded-full border border-accent/15 bg-surface px-4 py-2 text-sm text-ink transition-colors hover:border-secondary/40 hover:text-accent"
+              )}
+            >
+              <CheckCheck className="h-4 w-4 text-accent" />
+              Mark all read
+            </button>
+          )}
+        </div>
+
+        {/* List */}
+        <Panel className="overflow-hidden">
+          <div className="border-b border-accent/10 p-5 sm:p-6">
+            <h2 className={cn(poppins_600, "text-lg text-ink")}>
+              Recent activity
+            </h2>
+            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+              Your latest updates from across DeenBridge
+            </p>
+          </div>
+
+          {loading ? (
+            <div className="flex items-center justify-center py-16">
+              <Loader2 className="h-6 w-6 animate-spin text-accent" />
+            </div>
+          ) : items.length === 0 ? (
+            <div className="px-6 py-16 text-center">
+              <div className="mx-auto mb-3 flex size-12 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+                <Bell className="h-6 w-6 text-accent" />
+              </div>
+              <p className={cn(poppins_500, "text-ink")}>No notifications yet</p>
+              <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+                Updates about courses, messages, and spaces will show up here.
+              </p>
+            </div>
+          ) : (
+            <ul className="divide-y divide-accent/10">
+              {items.map((n) => {
+                const id = n._id || n.id;
+                const unreadRow = isUnread(n);
+                return (
+                  <li
+                    key={id}
+                    className={cn(
+                      "flex items-start gap-3 p-4 transition-colors hover:bg-secondary/5 sm:px-6",
+                      unreadRow && "bg-secondary/[0.04]"
+                    )}
+                  >
+                    <div className="relative mt-0.5">
+                      <div className="flex size-9 items-center justify-center rounded-xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+                        <Bell className="h-4 w-4 text-accent" />
+                      </div>
+                      {unreadRow && (
+                        <span className="absolute -right-0.5 -top-0.5 size-2.5 rounded-full border-2 border-surface-raised bg-secondary" />
+                      )}
+                    </div>
+
+                    <div className="min-w-0 flex-1">
+                      <p
+                        className={cn(
+                          unreadRow ? poppins_600 : poppins_500,
+                          "text-sm text-ink"
+                        )}
+                      >
+                        {notifTitle(n)}
+                      </p>
+                      {notifBody(n) && (
+                        <p
+                          className={cn(
+                            poppins_400,
+                            "mt-0.5 line-clamp-2 text-sm text-ink-muted"
+                          )}
+                        >
+                          {notifBody(n)}
+                        </p>
+                      )}
+                      <p
+                        className={cn(
+                          poppins_400,
+                          "mt-1 text-xs text-ink-muted/80"
+                        )}
+                      >
+                        {notifTime(n)}
+                      </p>
+                    </div>
+
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <button
+                          aria-haspopup="true"
+                          className="rounded-lg p-1.5 text-ink-muted transition-colors hover:bg-accent/10 hover:text-ink"
+                        >
+                          <MoreHorizontal className="h-4 w-4" />
+                          <span className="sr-only">Actions</span>
+                        </button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                        {unreadRow && (
+                          <DropdownMenuItem onClick={() => handleMarkRead(id)}>
+                            Mark as read
+                          </DropdownMenuItem>
+                        )}
+                        <DropdownMenuItem
+                          className="text-red-600"
+                          onClick={() => handleDelete(id)}
+                        >
+                          Delete
+                        </DropdownMenuItem>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {!loading && items.length > 0 && (
+            <div className="flex items-center justify-between gap-3 border-t border-accent/10 p-4 sm:px-6">
+              <div className={cn(poppins_400, "text-xs text-ink-muted")}>
+                Showing{" "}
+                <strong className={cn(poppins_600, "text-ink")}>
+                  {rangeStart}-{rangeEnd}
+                </strong>{" "}
+                of <strong className={cn(poppins_600, "text-ink")}>{total}</strong>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  aria-label="Previous page"
+                  disabled={page <= 1}
+                  onClick={() => load(page - 1)}
+                  className="flex size-8 items-center justify-center rounded-lg border border-accent/15 bg-surface text-ink-muted transition-colors hover:border-secondary/40 hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <ArrowLeftToLine size={16} />
+                </button>
+                <button
+                  type="button"
+                  aria-label="Next page"
+                  disabled={page >= totalPages}
+                  onClick={() => load(page + 1)}
+                  className="flex size-8 items-center justify-center rounded-lg border border-accent/15 bg-surface text-ink-muted transition-colors hover:border-secondary/40 hover:text-ink disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  <ArrowRightToLine size={16} />
+                </button>
+              </div>
+            </div>
+          )}
+        </Panel>
+      </div>
     </div>
-  )
+  );
 }

--- a/app/account/profile/[profileid]/page.jsx
+++ b/app/account/profile/[profileid]/page.jsx
@@ -10,6 +10,8 @@ import NotFoundComp from "@/components/molecules/errors/NotFound";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
 import Loader from "@/components/molecules/loaders/rootLoader";
 import { ExternalLink } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { poppins_500 } from "@/lib/config/font.config";
 const page = ({ params }) => {
   const { profileid } = use(params);
   const [selectedTab, setSelectedTab] = useState("courses");
@@ -54,21 +56,28 @@ const page = ({ params }) => {
   }
 
   return (
-    <>
-      <div className="min-h-screen bg-muted p-2 sm:p-4">
-        <ProfileHeader avatar={user?.avatar} />
-        <ProfileUserInfo user={user} />
-        <Link
-          href={`/educators/${profileid}`}
-          className="inline-flex items-center gap-1.5 text-sm text-accent hover:underline mb-4 mx-2 sm:mx-4"
-        >
-          <ExternalLink className="h-3.5 w-3.5" />
-          View public page
-        </Link>
+    <div className="min-h-full bg-surface p-3 sm:p-6">
+      <div className="mx-auto max-w-5xl space-y-4">
+        <div className="overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
+          <ProfileHeader avatar={user?.avatar} />
+          <ProfileUserInfo user={user} />
+          <div className="px-4 pb-5 sm:px-6">
+            <Link
+              href={`/educators/${profileid}`}
+              className={cn(
+                poppins_500,
+                "inline-flex items-center gap-1.5 text-sm text-secondary transition-colors hover:text-highlight hover:underline"
+              )}
+            >
+              <ExternalLink className="h-3.5 w-3.5" />
+              View public page
+            </Link>
+          </div>
+        </div>
         <ProfileTabs selectedTab={selectedTab} onChange={setSelectedTab} />
         <ProfileContent selectedTab={selectedTab} profileId={user?._id} />
       </div>
-    </>
+    </div>
   );
 };
 export default page;

--- a/app/account/security/page.jsx
+++ b/app/account/security/page.jsx
@@ -1,881 +1,370 @@
-"use client"
+"use client";
 
+import { useState, useEffect, useCallback } from "react";
 import {
-  Area,
-  AreaChart,
-  Bar,
-  BarChart,
-  CartesianGrid,
-  Label,
-  LabelList,
-  Line,
-  LineChart,
-  PolarAngleAxis,
-  RadialBar,
-  RadialBarChart,
-  Rectangle,
-  ReferenceLine,
-  XAxis,
-  YAxis,
-} from "recharts"
-
+  ShieldCheck,
+  KeyRound,
+  Smartphone,
+  Monitor,
+  Loader2,
+  Eye,
+  EyeOff,
+  LogOut,
+  Check,
+  Fingerprint,
+  Clock,
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card"
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+import Button from "@/components/atoms/form/Button";
+import { changePassword } from "@/lib/actions/auth/changePassword";
 import {
-  ChartContainer,
-  ChartTooltip,
-  ChartTooltipContent,
-} from "@/components/ui/chart"
-import { Separator } from "@/components/ui/separator"
+  getSessions,
+  revokeSession,
+  revokeOtherSessions,
+} from "@/lib/actions/auth/sessions";
 
-export const description = "A collection of health charts."
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
 
-export default function Charts() {
+const CardHead = ({ icon: Icon, title, desc }) => (
+  <div className="flex items-start gap-3 border-b border-accent/10 p-5 sm:p-6">
+    <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+      <Icon className="h-5 w-5 text-accent" />
+    </div>
+    <div>
+      <h2 className={cn(poppins_600, "text-lg text-ink")}>{title}</h2>
+      <p className={cn(poppins_400, "mt-0.5 text-sm text-ink-muted")}>{desc}</p>
+    </div>
+  </div>
+);
+
+const PasswordField = ({ id, label, value, onChange, placeholder }) => {
+  const [show, setShow] = useState(false);
   return (
-    <div className="chart-wrapper mx-auto flex max-w-6xl flex-col flex-wrap items-start justify-center gap-6 p-6 sm:flex-row sm:p-8">
-      <div className="grid w-full gap-6 sm:grid-cols-2 lg:max-w-[22rem] lg:grid-cols-1 xl:max-w-[25rem]">
-        <Card
-          className="lg:max-w-md" x-chunk="charts-01-chunk-0"
+    <div className="space-y-1.5">
+      <label htmlFor={id} className={cn(poppins_500, "text-sm text-ink")}>
+        {label}
+      </label>
+      <div className="relative">
+        <input
+          id={id}
+          type={show ? "text" : "password"}
+          value={value}
+          onChange={onChange}
+          placeholder={placeholder}
+          className={cn(
+            poppins_400,
+            "w-full rounded-xl border border-accent/15 bg-surface py-2.5 pl-4 pr-11 text-sm text-ink outline-none transition-colors placeholder:text-ink-muted/60 focus:border-secondary focus:ring-2 focus:ring-secondary/20"
+          )}
+        />
+        <button
+          type="button"
+          onClick={() => setShow((s) => !s)}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-ink-muted hover:text-ink"
+          aria-label={show ? "Hide password" : "Show password"}
         >
-          <CardHeader className="space-y-0 pb-2">
-            <CardDescription>Today</CardDescription>
-            <CardTitle className="text-4xl tabular-nums">
-              12,584{" "}
-              <span className="font-sans text-sm font-normal tracking-normal text-muted-foreground">
-                steps
-              </span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <ChartContainer
-              config={{
-                steps: {
-                  label: "Steps",
-                  color: "hsl(var(--chart-1))",
-                },
-              }}
-            >
-              <BarChart
-                accessibilityLayer
-                margin={{
-                  left: -4,
-                  right: -4,
-                }}
-                data={[
-                  {
-                    date: "2024-01-01",
-                    steps: 2000,
-                  },
-                  {
-                    date: "2024-01-02",
-                    steps: 2100,
-                  },
-                  {
-                    date: "2024-01-03",
-                    steps: 2200,
-                  },
-                  {
-                    date: "2024-01-04",
-                    steps: 1300,
-                  },
-                  {
-                    date: "2024-01-05",
-                    steps: 1400,
-                  },
-                  {
-                    date: "2024-01-06",
-                    steps: 2500,
-                  },
-                  {
-                    date: "2024-01-07",
-                    steps: 1600,
-                  },
-                ]}
-              >
-                <Bar
-                  dataKey="steps"
-                  fill="var(--color-accent)"
-                  radius={5}
-                  fillOpacity={0.6}
-                  activeBar={<Rectangle fillOpacity={0.8} />}
-                />
-                <XAxis
-                  dataKey="date"
-                  tickLine={false}
-                  axisLine={false}
-                  tickMargin={4}
-                  tickFormatter={(value) => {
-                    return new Date(value).toLocaleDateString("en-US", {
-                      weekday: "short",
-                    })
-                  }}
-                />
-                <ChartTooltip
-                  defaultIndex={2}
-                  content={
-                    <ChartTooltipContent
-                      hideIndicator
-                      labelFormatter={(value) => {
-                        return new Date(value).toLocaleDateString("en-US", {
-                          day: "numeric",
-                          month: "long",
-                          year: "numeric",
-                        })
-                      }}
-                    />
-                  }
-                  cursor={false}
-                />
-                <ReferenceLine
-                  y={1200}
-                  stroke="var(--color-accent)"
-                  strokeDasharray="3 3"
-                  strokeWidth={1}
-                >
-                  <Label
-                    position="insideBottomLeft"
-                    value="Average Steps"
-                    offset={10}
-                    fill="var(--color-accent)"
-                  />
-                  <Label
-                    position="insideTopLeft"
-                    value="12,343"
-                    className="text-lg"
-                    fill="var(--color-accent))"
-                    offset={10}
-                    startOffset={100}
-                  />
-                </ReferenceLine>
-              </BarChart>
-            </ChartContainer>
-          </CardContent>
-          <CardFooter className="flex-col items-start gap-1">
-            <CardDescription>
-              Over the past 7 days, you have walked{" "}
-              <span className="font-medium text-foreground">53,305</span> steps.
-            </CardDescription>
-            <CardDescription>
-              You need{" "}
-              <span className="font-medium text-foreground">12,584</span> more
-              steps to reach your goal.
-            </CardDescription>
-          </CardFooter>
-        </Card>
-        <Card className="flex flex-col lg:max-w-md">
-          <CardHeader className="flex flex-row items-center gap-4 space-y-0 pb-2 [&>div]:flex-1">
-            <div>
-              <CardDescription>Resting HR</CardDescription>
-              <CardTitle className="flex items-baseline gap-1 text-4xl tabular-nums">
-                62
-                <span className="text-sm font-normal tracking-normal text-muted-foreground">
-                  bpm
-                </span>
-              </CardTitle>
-            </div>
-            <div>
-              <CardDescription>Variability</CardDescription>
-              <CardTitle className="flex items-baseline gap-1 text-4xl tabular-nums">
-                35
-                <span className="text-sm font-normal tracking-normal text-muted-foreground">
-                  ms
-                </span>
-              </CardTitle>
-            </div>
-          </CardHeader>
-          <CardContent className="flex flex-1 items-center">
-            <ChartContainer
-              config={{
-                resting: {
-                  label: "Resting",
-                  color: "hsl(var(--chart-1))",
-                },
-              }}
-              className="w-full"
-            >
-              <LineChart
-                accessibilityLayer
-                margin={{
-                  left: 14,
-                  right: 14,
-                  top: 10,
-                }}
-                data={[
-                  {
-                    date: "2024-01-01",
-                    resting: 62,
-                  },
-                  {
-                    date: "2024-01-02",
-                    resting: 72,
-                  },
-                  {
-                    date: "2024-01-03",
-                    resting: 35,
-                  },
-                  {
-                    date: "2024-01-04",
-                    resting: 62,
-                  },
-                  {
-                    date: "2024-01-05",
-                    resting: 52,
-                  },
-                  {
-                    date: "2024-01-06",
-                    resting: 62,
-                  },
-                  {
-                    date: "2024-01-07",
-                    resting: 70,
-                  },
-                ]}
-              >
-                <CartesianGrid
-                  strokeDasharray="4 4"
-                  vertical={false}
-                  stroke="hsl(var(--muted-foreground))"
-                  strokeOpacity={0.5}
-                />
-                <YAxis hide domain={["dataMin - 10", "dataMax + 10"]} />
-                <XAxis
-                  dataKey="date"
-                  tickLine={false}
-                  axisLine={false}
-                  tickMargin={8}
-                  tickFormatter={(value) => {
-                    return new Date(value).toLocaleDateString("en-US", {
-                      weekday: "short",
-                    })
-                  }}
-                />
-                <Line
-                  dataKey="resting"
-                  type="natural"
-                  fill="var(--color-resting)"
-                  stroke="var(--color-resting)"
-                  strokeWidth={2}
-                  dot={false}
-                  activeDot={{
-                    fill: "var(--color-resting)",
-                    stroke: "var(--color-resting)",
-                    r: 4,
-                  }}
-                />
-                <ChartTooltip
-                  content={
-                    <ChartTooltipContent
-                      indicator="line"
-                      labelFormatter={(value) => {
-                        return new Date(value).toLocaleDateString("en-US", {
-                          day: "numeric",
-                          month: "long",
-                          year: "numeric",
-                        })
-                      }}
-                    />
-                  }
-                  cursor={false}
-                />
-              </LineChart>
-            </ChartContainer>
-          </CardContent>
-        </Card>
-      </div>
-      <div className="grid w-full flex-1 gap-6 lg:max-w-[20rem]">
-        <Card
-          className="max-w-xs" x-chunk="charts-01-chunk-2"
-        >
-          <CardHeader>
-            <CardTitle>Progress</CardTitle>
-            <CardDescription>
-              You're average more steps a day this year than last year.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="grid gap-4">
-            <div className="grid auto-rows-min gap-2">
-              <div className="flex items-baseline gap-1 text-2xl font-bold tabular-nums leading-none">
-                12,453
-                <span className="text-sm font-normal text-muted-foreground">
-                  steps/day
-                </span>
-              </div>
-              <ChartContainer
-                config={{
-                  steps: {
-                    label: "Steps",
-                    color: "hsl(var(--chart-1))",
-                  },
-                }}
-                className="aspect-auto h-[32px] w-full"
-              >
-                <BarChart
-                  accessibilityLayer
-                  layout="vertical"
-                  margin={{
-                    left: 0,
-                    top: 0,
-                    right: 0,
-                    bottom: 0,
-                  }}
-                  data={[
-                    {
-                      date: "2024",
-                      steps: 12435,
-                    },
-                  ]}
-                >
-                  <Bar
-                    dataKey="steps"
-                    fill="var(--color-accent)"
-                    radius={4}
-                    barSize={32}
-                  >
-                    <LabelList
-                      position="insideLeft"
-                      dataKey="date"
-                      offset={8}
-                      fontSize={12}
-                      fill="white"
-                    />
-                  </Bar>
-                  <YAxis dataKey="date" type="category" tickCount={1} hide />
-                  <XAxis dataKey="steps" type="number" hide />
-                </BarChart>
-              </ChartContainer>
-            </div>
-            <div className="grid auto-rows-min gap-2">
-              <div className="flex items-baseline gap-1 text-2xl font-bold tabular-nums leading-none">
-                10,103
-                <span className="text-sm font-normal text-muted-foreground">
-                  steps/day
-                </span>
-              </div>
-              <ChartContainer
-                config={{
-                  steps: {
-                    label: "Steps",
-                    color: "hsl(var(--muted))",
-                  },
-                }}
-                className="aspect-auto h-[32px] w-full"
-              >
-                <BarChart
-                  accessibilityLayer
-                  layout="vertical"
-                  margin={{
-                    left: 0,
-                    top: 0,
-                    right: 0,
-                    bottom: 0,
-                  }}
-                  data={[
-                    {
-                      date: "2023",
-                      steps: 10103,
-                    },
-                  ]}
-                >
-                  <Bar
-                    dataKey="steps"
-                    fill="var(--color-accent)"
-                    radius={4}
-                    barSize={32}
-                  >
-                    <LabelList
-                      position="insideLeft"
-                      dataKey="date"
-                      offset={8}
-                      fontSize={12}
-                      fill="hsl(var(--muted-foreground))"
-                    />
-                  </Bar>
-                  <YAxis dataKey="date" type="category" tickCount={1} hide />
-                  <XAxis dataKey="steps" type="number" hide />
-                </BarChart>
-              </ChartContainer>
-            </div>
-          </CardContent>
-        </Card>
-        <Card
-          className="max-w-xs" x-chunk="charts-01-chunk-3"
-        >
-          <CardHeader className="p-4 pb-0">
-            <CardTitle>Walking Distance</CardTitle>
-            <CardDescription>
-              Over the last 7 days, your distance walked and run was 12.5 miles
-              per day.
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-row items-baseline gap-4 p-4 pt-0">
-            <div className="flex items-baseline gap-1 text-3xl font-bold tabular-nums leading-none">
-              12.5
-              <span className="text-sm font-normal text-muted-foreground">
-                miles/day
-              </span>
-            </div>
-            <ChartContainer
-              config={{
-                steps: {
-                  label: "Steps",
-                  color: "hsl(var(--chart-1))",
-                },
-              }}
-              className="ml-auto w-[72px]"
-            >
-              <BarChart
-                accessibilityLayer
-                margin={{
-                  left: 0,
-                  right: 0,
-                  top: 0,
-                  bottom: 0,
-                }}
-                data={[
-                  {
-                    date: "2024-01-01",
-                    steps: 2000,
-                  },
-                  {
-                    date: "2024-01-02",
-                    steps: 2100,
-                  },
-                  {
-                    date: "2024-01-03",
-                    steps: 2200,
-                  },
-                  {
-                    date: "2024-01-04",
-                    steps: 1300,
-                  },
-                  {
-                    date: "2024-01-05",
-                    steps: 1400,
-                  },
-                  {
-                    date: "2024-01-06",
-                    steps: 2500,
-                  },
-                  {
-                    date: "2024-01-07",
-                    steps: 1600,
-                  },
-                ]}
-              >
-                <Bar
-                  dataKey="steps"
-                  fill="var(--color-accent)"
-                  radius={2}
-                  fillOpacity={0.2}
-                  activeIndex={6}
-                  activeBar={<Rectangle fillOpacity={0.8} />}
-                />
-                <XAxis
-                  dataKey="date"
-                  tickLine={false}
-                  axisLine={false}
-                  tickMargin={4}
-                  hide
-                />
-              </BarChart>
-            </ChartContainer>
-          </CardContent>
-        </Card>
-        <Card
-          className="max-w-xs" x-chunk="charts-01-chunk-4"
-        >
-          <CardContent className="flex gap-4 p-4 pb-2">
-            <ChartContainer
-              config={{
-                move: {
-                  label: "Move",
-                  color: "hsl(var(--chart-1))",
-                },
-                stand: {
-                  label: "Stand",
-                  color: "hsl(var(--chart-2))",
-                },
-                exercise: {
-                  label: "Exercise",
-                  color: "hsl(var(--chart-3))",
-                },
-              }}
-              className="h-[140px] w-full"
-            >
-              <BarChart
-                margin={{
-                  left: 0,
-                  right: 0,
-                  top: 0,
-                  bottom: 10,
-                }}
-                data={[
-                  {
-                    activity: "stand",
-                    value: (8 / 12) * 100,
-                    label: "8/12 hr",
-                    fill: "var(--color-accent)",
-                  },
-                  {
-                    activity: "exercise",
-                    value: (46 / 60) * 100,
-                    label: "46/60 min",
-                    fill: "var(--color-accent)",
-                  },
-                  {
-                    activity: "move",
-                    value: (245 / 360) * 100,
-                    label: "245/360 kcal",
-                    fill: "var(--color-accent)",
-                  },
-                ]}
-                layout="vertical"
-                barSize={32}
-                barGap={2}
-              >
-                <XAxis type="number" dataKey="value" hide />
-                <YAxis
-                  dataKey="activity"
-                  type="category"
-                  tickLine={false}
-                  tickMargin={4}
-                  axisLine={false}
-                  className="capitalize"
-                />
-                <Bar dataKey="value" radius={5}>
-                  <LabelList
-                    position="insideLeft"
-                    dataKey="label"
-                    fill="white"
-                    offset={8}
-                    fontSize={12}
-                  />
-                </Bar>
-              </BarChart>
-            </ChartContainer>
-          </CardContent>
-          <CardFooter className="flex flex-row border-t p-4">
-            <div className="flex w-full items-center gap-2">
-              <div className="grid flex-1 auto-rows-min gap-0.5">
-                <div className="text-xs text-muted-foreground">Move</div>
-                <div className="flex items-baseline gap-1 text-2xl font-bold tabular-nums leading-none">
-                  562
-                  <span className="text-sm font-normal text-muted-foreground">
-                    kcal
-                  </span>
-                </div>
-              </div>
-              <Separator orientation="vertical" className="mx-2 h-10 w-px" />
-              <div className="grid flex-1 auto-rows-min gap-0.5">
-                <div className="text-xs text-muted-foreground">Exercise</div>
-                <div className="flex items-baseline gap-1 text-2xl font-bold tabular-nums leading-none">
-                  73
-                  <span className="text-sm font-normal text-muted-foreground">
-                    min
-                  </span>
-                </div>
-              </div>
-              <Separator orientation="vertical" className="mx-2 h-10 w-px" />
-              <div className="grid flex-1 auto-rows-min gap-0.5">
-                <div className="text-xs text-muted-foreground">Stand</div>
-                <div className="flex items-baseline gap-1 text-2xl font-bold tabular-nums leading-none">
-                  14
-                  <span className="text-sm font-normal text-muted-foreground">
-                    hr
-                  </span>
-                </div>
-              </div>
-            </div>
-          </CardFooter>
-        </Card>
-      </div>
-      <div className="grid w-full flex-1 gap-6">
-        <Card
-          className="max-w-xs" x-chunk="charts-01-chunk-5"
-        >
-          <CardContent className="flex gap-4 p-4">
-            <div className="grid items-center gap-2">
-              <div className="grid flex-1 auto-rows-min gap-0.5">
-                <div className="text-sm text-muted-foreground">Move</div>
-                <div className="flex items-baseline gap-1 text-xl font-bold tabular-nums leading-none">
-                  562/600
-                  <span className="text-sm font-normal text-muted-foreground">
-                    kcal
-                  </span>
-                </div>
-              </div>
-              <div className="grid flex-1 auto-rows-min gap-0.5">
-                <div className="text-sm text-muted-foreground">Exercise</div>
-                <div className="flex items-baseline gap-1 text-xl font-bold tabular-nums leading-none">
-                  73/120
-                  <span className="text-sm font-normal text-muted-foreground">
-                    min
-                  </span>
-                </div>
-              </div>
-              <div className="grid flex-1 auto-rows-min gap-0.5">
-                <div className="text-sm text-muted-foreground">Stand</div>
-                <div className="flex items-baseline gap-1 text-xl font-bold tabular-nums leading-none">
-                  8/12
-                  <span className="text-sm font-normal text-muted-foreground">
-                    hr
-                  </span>
-                </div>
-              </div>
-            </div>
-            <ChartContainer
-              config={{
-                move: {
-                  label: "Move",
-                  color: "hsl(var(--chart-1))",
-                },
-                exercise: {
-                  label: "Exercise",
-                  color: "hsl(var(--chart-2))",
-                },
-                stand: {
-                  label: "Stand",
-                  color: "hsl(var(--chart-3))",
-                },
-              }}
-              className="mx-auto aspect-square w-full max-w-[80%]"
-            >
-              <RadialBarChart
-                margin={{
-                  left: -10,
-                  right: -10,
-                  top: -10,
-                  bottom: -10,
-                }}
-                data={[
-                  {
-                    activity: "stand",
-                    value: (8 / 12) * 100,
-                    fill: "var(--color-accent)",
-                  },
-                  {
-                    activity: "exercise",
-                    value: (46 / 60) * 100,
-                    fill: "var(--color-accent)",
-                  },
-                  {
-                    activity: "move",
-                    value: (245 / 360) * 100,
-                    fill: "var(--color-accent)",
-                  },
-                ]}
-                innerRadius="20%"
-                barSize={24}
-                startAngle={90}
-                endAngle={450}
-              >
-                <PolarAngleAxis
-                  type="number"
-                  domain={[0, 100]}
-                  dataKey="value"
-                  tick={false}
-                />
-                <RadialBar dataKey="value" background cornerRadius={5} />
-              </RadialBarChart>
-            </ChartContainer>
-          </CardContent>
-        </Card>
-        <Card
-          className="max-w-xs" x-chunk="charts-01-chunk-6"
-        >
-          <CardHeader className="p-4 pb-0">
-            <CardTitle>Active Energy</CardTitle>
-            <CardDescription>
-              You're burning an average of 754 calories per day. Good job!
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="flex flex-row items-baseline gap-4 p-4 pt-2">
-            <div className="flex items-baseline gap-2 text-3xl font-bold tabular-nums leading-none">
-              1,254
-              <span className="text-sm font-normal text-muted-foreground">
-                kcal/day
-              </span>
-            </div>
-            <ChartContainer
-              config={{
-                calories: {
-                  label: "Calories",
-                  color: "hsl(var(--chart-1))",
-                },
-              }}
-              className="ml-auto w-[64px]"
-            >
-              <BarChart
-                accessibilityLayer
-                margin={{
-                  left: 0,
-                  right: 0,
-                  top: 0,
-                  bottom: 0,
-                }}
-                data={[
-                  {
-                    date: "2024-01-01",
-                    calories: 354,
-                  },
-                  {
-                    date: "2024-01-02",
-                    calories: 514,
-                  },
-                  {
-                    date: "2024-01-03",
-                    calories: 345,
-                  },
-                  {
-                    date: "2024-01-04",
-                    calories: 734,
-                  },
-                  {
-                    date: "2024-01-05",
-                    calories: 645,
-                  },
-                  {
-                    date: "2024-01-06",
-                    calories: 456,
-                  },
-                  {
-                    date: "2024-01-07",
-                    calories: 345,
-                  },
-                ]}
-              >
-                <Bar
-                  dataKey="calories"
-                  fill="var(--color-accent)"
-                  radius={2}
-                  fillOpacity={0.2}
-                  activeIndex={6}
-                  activeBar={<Rectangle fillOpacity={0.8} />}
-                />
-                <XAxis
-                  dataKey="date"
-                  tickLine={false}
-                  axisLine={false}
-                  tickMargin={4}
-                  hide
-                />
-              </BarChart>
-            </ChartContainer>
-          </CardContent>
-        </Card>
-        <Card
-          className="max-w-xs" x-chunk="charts-01-chunk-7"
-        >
-          <CardHeader className="space-y-0 pb-0">
-            <CardDescription>Time in Bed</CardDescription>
-            <CardTitle className="flex items-baseline gap-1 text-4xl tabular-nums">
-              8
-              <span className="font-sans text-sm font-normal tracking-normal text-muted-foreground">
-                hr
-              </span>
-              35
-              <span className="font-sans text-sm font-normal tracking-normal text-muted-foreground">
-                min
-              </span>
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="p-0">
-            <ChartContainer
-              config={{
-                time: {
-                  label: "Time",
-                  color: "hsl(var(--chart-2))",
-                },
-              }}
-            >
-              <AreaChart
-                accessibilityLayer
-                data={[
-                  {
-                    date: "2024-01-01",
-                    time: 8.5,
-                  },
-                  {
-                    date: "2024-01-02",
-                    time: 7.2,
-                  },
-                  {
-                    date: "2024-01-03",
-                    time: 8.1,
-                  },
-                  {
-                    date: "2024-01-04",
-                    time: 6.2,
-                  },
-                  {
-                    date: "2024-01-05",
-                    time: 5.2,
-                  },
-                  {
-                    date: "2024-01-06",
-                    time: 8.1,
-                  },
-                  {
-                    date: "2024-01-07",
-                    time: 7.0,
-                  },
-                ]}
-                margin={{
-                  left: 0,
-                  right: 0,
-                  top: 0,
-                  bottom: 0,
-                }}
-              >
-                <XAxis dataKey="date" hide />
-                <YAxis domain={["dataMin - 5", "dataMax + 2"]} hide />
-                <defs>
-                  <linearGradient id="fillTime" x1="0" y1="0" x2="0" y2="1">
-                    <stop
-                      offset="5%"
-                      stopColor="var(--color-accent)"
-                      stopOpacity={0.8}
-                    />
-                    <stop
-                      offset="95%"
-                      stopColor="var(--color-accent)"
-                      stopOpacity={0.1}
-                    />
-                  </linearGradient>
-                </defs>
-                <Area
-                  dataKey="time"
-                  type="natural"
-                  fill="url(#fillTime)"
-                  fillOpacity={0.4}
-                  stroke="var(--color-accent)"
-                />
-                <ChartTooltip
-                  cursor={false}
-                  content={<ChartTooltipContent hideLabel />}
-                  formatter={(value) => (
-                    <div className="flex min-w-[120px] items-center text-xs text-muted-foreground">
-                      Time in bed
-                      <div className="ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums text-foreground">
-                        {value}
-                        <span className="font-normal text-muted-foreground">
-                          hr
-                        </span>
-                      </div>
-                    </div>
-                  )}
-                />
-              </AreaChart>
-            </ChartContainer>
-          </CardContent>
-        </Card>
+          {show ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+        </button>
       </div>
     </div>
-  )
+  );
+};
+
+const deviceIcon = (ua = "") =>
+  /mobile|android|iphone|ipad/i.test(ua) ? Smartphone : Monitor;
+
+export default function SecurityPage() {
+  // ── password ──
+  const [pw, setPw] = useState({ current: "", next: "", confirm: "" });
+  const [pwLoading, setPwLoading] = useState(false);
+
+  // ── sessions ──
+  const [sessions, setSessions] = useState([]);
+  const [sessionsLoading, setSessionsLoading] = useState(true);
+  const [revoking, setRevoking] = useState(null);
+
+  const loadSessions = useCallback(async () => {
+    setSessionsLoading(true);
+    const res = await getSessions();
+    setSessions(res.success ? res.sessions : []);
+    setSessionsLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadSessions();
+  }, [loadSessions]);
+
+  const handleChangePassword = async (e) => {
+    e.preventDefault();
+    if (!pw.current || !pw.next) {
+      toast.error("Enter your current and new password");
+      return;
+    }
+    if (pw.next !== pw.confirm) {
+      toast.error("New passwords do not match");
+      return;
+    }
+    if (pw.next.length < 8) {
+      toast.error("New password must be at least 8 characters");
+      return;
+    }
+    setPwLoading(true);
+    const res = await changePassword({
+      currentPassword: pw.current,
+      newPassword: pw.next,
+    });
+    if (res.success) {
+      toast.success(res.message);
+      setPw({ current: "", next: "", confirm: "" });
+      loadSessions(); // other sessions were signed out
+    } else {
+      toast.error(res.message);
+    }
+    setPwLoading(false);
+  };
+
+  const handleRevoke = async (id) => {
+    setRevoking(id);
+    const res = await revokeSession(id);
+    if (res.success) {
+      setSessions((prev) => prev.filter((s) => s.id !== id));
+      toast.success("Device signed out");
+    } else {
+      toast.error("Couldn't sign out that device");
+    }
+    setRevoking(null);
+  };
+
+  const handleRevokeOthers = async () => {
+    const res = await revokeOtherSessions();
+    if (res.success) {
+      setSessions((prev) => prev.filter((s) => s.isCurrent));
+      toast.success("Signed out of all other devices");
+    } else {
+      toast.error("Couldn't sign out other devices");
+    }
+  };
+
+  const otherCount = sessions.filter((s) => !s.isCurrent).length;
+
+  return (
+    <div className="min-h-full bg-surface p-3 sm:p-6">
+      <div className="mx-auto max-w-5xl space-y-6">
+        {/* Header */}
+        <div className="flex items-center gap-3">
+          <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+            <ShieldCheck className="h-5 w-5 text-accent" />
+          </div>
+          <div>
+            <h1
+              className={cn(
+                poppins_600,
+                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+              )}
+            >
+              Security
+            </h1>
+            <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+              Keep your account safe — password, 2FA, and active devices
+            </p>
+          </div>
+        </div>
+
+        {/* Change password */}
+        <Panel>
+          <CardHead
+            icon={KeyRound}
+            title="Change password"
+            desc="Use a strong, unique password. Changing it signs out your other devices."
+          />
+          <form onSubmit={handleChangePassword} className="space-y-4 p-5 sm:p-6">
+            <PasswordField
+              id="current"
+              label="Current password"
+              value={pw.current}
+              onChange={(e) => setPw((p) => ({ ...p, current: e.target.value }))}
+              placeholder="Enter current password"
+            />
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <PasswordField
+                id="next"
+                label="New password"
+                value={pw.next}
+                onChange={(e) => setPw((p) => ({ ...p, next: e.target.value }))}
+                placeholder="At least 8 characters"
+              />
+              <PasswordField
+                id="confirm"
+                label="Confirm new password"
+                value={pw.confirm}
+                onChange={(e) =>
+                  setPw((p) => ({ ...p, confirm: e.target.value }))
+                }
+                placeholder="Re-enter new password"
+              />
+            </div>
+            <div className="flex justify-end">
+              <Button
+                round
+                type="submit"
+                disabled={pwLoading}
+                className={cn(poppins_500, "bg-accent px-6 text-sm text-white hover:bg-highlight")}
+              >
+                {pwLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                    Updating…
+                  </>
+                ) : (
+                  "Update password"
+                )}
+              </Button>
+            </div>
+          </form>
+        </Panel>
+
+        {/* Two-factor */}
+        <Panel>
+          <CardHead
+            icon={Fingerprint}
+            title="Two-factor authentication"
+            desc="Add a second step at sign-in for stronger protection."
+          />
+          <div className="flex flex-wrap items-center justify-between gap-3 p-5 sm:p-6">
+            <div className="flex items-center gap-2">
+              <span
+                className={cn(
+                  poppins_500,
+                  "inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-xs text-amber-700"
+                )}
+              >
+                Not enabled
+              </span>
+              <span className={cn(poppins_400, "text-sm text-ink-muted")}>
+                Coming soon — authenticator-app (TOTP) support.
+              </span>
+            </div>
+            <Button round disabled className="px-5 text-sm opacity-60">
+              Enable 2FA
+            </Button>
+          </div>
+        </Panel>
+
+        {/* Active sessions */}
+        <Panel className="overflow-hidden">
+          <div className="flex flex-wrap items-start justify-between gap-3 border-b border-accent/10 p-5 sm:p-6">
+            <div className="flex items-start gap-3">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+                <Monitor className="h-5 w-5 text-accent" />
+              </div>
+              <div>
+                <h2 className={cn(poppins_600, "text-lg text-ink")}>
+                  Active devices &amp; sessions
+                </h2>
+                <p className={cn(poppins_400, "mt-0.5 text-sm text-ink-muted")}>
+                  Devices currently signed in to your account
+                </p>
+              </div>
+            </div>
+            {otherCount > 0 && (
+              <button
+                onClick={handleRevokeOthers}
+                className={cn(
+                  poppins_500,
+                  "inline-flex items-center gap-1.5 rounded-full border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-600 transition-colors hover:bg-red-100"
+                )}
+              >
+                <LogOut className="h-4 w-4" />
+                Sign out others
+              </button>
+            )}
+          </div>
+
+          {sessionsLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-6 w-6 animate-spin text-accent" />
+            </div>
+          ) : sessions.length === 0 ? (
+            <p className={cn(poppins_400, "px-6 py-10 text-center text-sm text-ink-muted")}>
+              No active sessions found.
+            </p>
+          ) : (
+            <ul className="divide-y divide-accent/10">
+              {sessions.map((s) => {
+                const Icon = deviceIcon(s.device?.userAgent);
+                return (
+                  <li key={s.id} className="flex items-center gap-3 p-4 sm:px-6">
+                    <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-surface">
+                      <Icon className="h-5 w-5 text-ink-muted" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <p className={cn(poppins_500, "text-sm text-ink")}>
+                          {s.device?.label || "Unknown device"}
+                        </p>
+                        {s.isCurrent && (
+                          <span
+                            className={cn(
+                              poppins_500,
+                              "inline-flex items-center gap-1 rounded-full bg-secondary/10 px-2 py-0.5 text-[11px] text-secondary"
+                            )}
+                          >
+                            <Check className="h-3 w-3" />
+                            This device
+                          </span>
+                        )}
+                      </div>
+                      <p
+                        className={cn(
+                          poppins_400,
+                          "mt-0.5 flex items-center gap-1.5 text-xs text-ink-muted"
+                        )}
+                      >
+                        {s.device?.ip && <span>{s.device.ip}</span>}
+                        {s.lastUsedAt && (
+                          <>
+                            <Clock className="h-3 w-3" />
+                            {formatDistanceToNow(new Date(s.lastUsedAt), {
+                              addSuffix: true,
+                            })}
+                          </>
+                        )}
+                      </p>
+                    </div>
+                    {!s.isCurrent && (
+                      <button
+                        onClick={() => handleRevoke(s.id)}
+                        disabled={revoking === s.id}
+                        className={cn(
+                          poppins_500,
+                          "shrink-0 rounded-lg border border-accent/15 px-3 py-1.5 text-xs text-ink-muted transition-colors hover:border-red-200 hover:bg-red-50 hover:text-red-600 disabled:opacity-50"
+                        )}
+                      >
+                        {revoking === s.id ? "…" : "Sign out"}
+                      </button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </Panel>
+      </div>
+    </div>
+  );
 }

--- a/app/account/settings/page.jsx
+++ b/app/account/settings/page.jsx
@@ -2,15 +2,9 @@
 import React, { useState, useEffect } from "react";
 import { useTheme } from "next-themes";
 import { useAuth } from "@/hooks/useAuth";
+import { updateUser } from "@/lib/actions/users/updateUser";
 import { useAppearance } from "@/components/providers/AppearanceProvider";
 import { ACCENT_PALETTES, FONT_SIZES } from "@/lib/config/appearance.config";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -20,7 +14,6 @@ import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
-import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   User,
   Mail,
@@ -40,6 +33,68 @@ import {
   Smartphone,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+
+/* ── design-system building blocks ── */
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised p-6 shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
+
+const CardHead = ({ icon: Icon, title, description, danger }) => (
+  <div className="mb-6 flex items-start gap-3">
+    <div
+      className={cn(
+        "flex size-10 shrink-0 items-center justify-center rounded-xl border",
+        danger
+          ? "border-red-200 bg-red-50"
+          : "border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10"
+      )}
+    >
+      <Icon className={cn("h-5 w-5", danger ? "text-red-600" : "text-accent")} />
+    </div>
+    <div>
+      <h2 className={cn(poppins_600, "text-lg text-ink")}>{title}</h2>
+      {description && (
+        <p className={cn(poppins_400, "mt-0.5 text-sm text-ink-muted")}>
+          {description}
+        </p>
+      )}
+    </div>
+  </div>
+);
+
+const ToggleRow = ({ icon: Icon, title, description, checked, onCheckedChange }) => (
+  <div className="flex items-center justify-between gap-4 rounded-xl border border-accent/10 bg-surface p-4 transition-colors hover:border-secondary/30">
+    <div className="flex items-center gap-3">
+      <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-secondary/15 to-highlight/10">
+        <Icon className="h-4 w-4 text-accent" />
+      </div>
+      <div>
+        <Label className={cn(poppins_500, "text-ink")}>{title}</Label>
+        <p className={cn(poppins_400, "text-sm text-ink-muted")}>{description}</p>
+      </div>
+    </div>
+    <Switch checked={checked} onCheckedChange={onCheckedChange} />
+  </div>
+);
+
+const FieldLabel = ({ htmlFor, children }) => (
+  <Label htmlFor={htmlFor} className={cn(poppins_500, "text-sm text-ink")}>
+    {children}
+  </Label>
+);
 
 const SettingsPage = () => {
   const { user } = useAuth();
@@ -84,6 +139,22 @@ const SettingsPage = () => {
     language: user?.language || "",
     interests: user?.interests || [],
   });
+
+  // Keep the profile form in sync once the authenticated user loads.
+  useEffect(() => {
+    if (!user) return;
+    setProfile({
+      avatar: user.avatar || "",
+      name: user.name || "",
+      username: user.username || "",
+      bio: user.bio || "",
+      country: user.country || "",
+      age: user.age || "",
+      gender: user.gender || "",
+      language: user.language || "",
+      interests: user.interests || [],
+    });
+  }, [user]);
 
   // Account state
   const [account, setAccount] = useState({
@@ -147,9 +218,20 @@ const SettingsPage = () => {
 
   const handleProfileSave = async (e) => {
     e.preventDefault();
+    if (!user?._id) {
+      showMessage("error", "You must be signed in to update your profile.");
+      return;
+    }
     setIsLoading(true);
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-    showMessage("success", "Profile updated successfully!");
+    const res = await updateUser(user._id, profile);
+    if (res?.success) {
+      showMessage("success", "Profile updated successfully!");
+    } else {
+      showMessage(
+        "error",
+        res?.message || "Failed to update profile. Please try again."
+      );
+    }
     setIsLoading(false);
   };
 
@@ -196,53 +278,78 @@ const SettingsPage = () => {
     }
   };
 
+  const SubmitButton = ({ savingLabel, label }) => (
+    <Button type="submit" disabled={isLoading} className="w-full sm:w-auto">
+      {isLoading ? (
+        <>
+          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
+          {savingLabel}
+        </>
+      ) : (
+        <>
+          <Save className="h-4 w-4 mr-2" /> {label}
+        </>
+      )}
+    </Button>
+  );
+
   return (
-    <div className="min-h-screen bg-background p-4 md:p-8">
-      <div className="max-w-4xl mx-auto">
+    <div className="min-h-screen bg-surface p-3 sm:p-6">
+      <div className="mx-auto max-w-5xl">
         {/* Header */}
         <div className="mb-8">
-          <div className="flex items-center gap-4 mb-4">
-            <div className="p-3 bg-accent/10 rounded-xl">
-              <Settings className="h-8 w-8 text-brand-text" />
+          <div className="flex items-center gap-3">
+            <div className="flex size-12 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+              <Settings className="h-6 w-6 text-accent" />
             </div>
             <div>
-              <h1 className={cn("text-4xl font-bold text-brand-text")}>Settings</h1>
-              <p className="text-muted-foreground mt-1">
+              <h1
+                className={cn(
+                  poppins_600,
+                  "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent sm:text-3xl"
+                )}
+              >
+                Settings
+              </h1>
+              <p className={cn(poppins_400, "text-sm text-ink-muted")}>
                 Manage your account preferences and privacy
               </p>
             </div>
           </div>
+
           {message.text && (
-            <Alert
+            <div
               className={cn(
-                "mb-4",
+                "mt-6 flex items-center gap-2 rounded-xl border p-4",
                 message.type === "success"
-                  ? "border-green-200 bg-green-50 dark:border-green-900 dark:bg-green-950"
-                  : "border-destructive/30 bg-destructive/10"
+                  ? "border-secondary/20 bg-secondary/5"
+                  : "border-red-200 bg-red-50"
               )}
             >
               {message.type === "success" ? (
-                <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-400" />
+                <CheckCircle className="h-4 w-4 shrink-0 text-secondary" />
               ) : (
-                <AlertCircle className="h-4 w-4 text-destructive" />
+                <AlertCircle className="h-4 w-4 shrink-0 text-red-600" />
               )}
-              <AlertDescription
+              <span
                 className={cn(
-                  message.type === "success"
-                    ? "text-green-800 dark:text-green-200"
-                    : "text-destructive"
+                  poppins_500,
+                  "text-sm",
+                  message.type === "success" ? "text-secondary" : "text-red-600"
                 )}
               >
                 {message.text}
-              </AlertDescription>
-            </Alert>
+              </span>
+            </div>
           )}
 
           {installable && (
-            <div className="mb-4 flex items-center justify-between rounded-xl border border-accent/20 bg-accent/5 p-4">
+            <div className="mt-4 flex flex-col gap-3 rounded-xl border border-secondary/20 bg-secondary/5 p-4 sm:flex-row sm:items-center sm:justify-between">
               <div className="flex items-center gap-3">
-                <Smartphone className="h-5 w-5 text-brand-text" />
-                <p className="text-sm font-medium text-foreground">
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-secondary/15 to-highlight/10">
+                  <Smartphone className="h-4 w-4 text-accent" />
+                </div>
+                <p className={cn(poppins_500, "text-sm text-ink")}>
                   Install DeenBridge for quick access
                 </p>
               </div>
@@ -261,12 +368,13 @@ const SettingsPage = () => {
             </div>
           )}
         </div>
+
         <Tabs
           value={activeTab}
           onValueChange={setActiveTab}
           className="space-y-6"
         >
-          <TabsList className="grid w-full grid-cols-6 bg-card/70 backdrop-blur-sm border border-border shadow-lg">
+          <TabsList className="grid h-auto w-full grid-cols-3 gap-1 rounded-2xl border border-accent/10 bg-surface-raised p-1.5 shadow-sm">
             <TabsTrigger value="profile" className="flex items-center gap-2">
               <User className="h-4 w-4" /> Profile
             </TabsTrigger>
@@ -279,709 +387,515 @@ const SettingsPage = () => {
             >
               <Bell className="h-4 w-4" /> Notifications
             </TabsTrigger>
-            <TabsTrigger value="privacy" className="flex items-center gap-2">
-              <Shield className="h-4 w-4" /> Privacy
-            </TabsTrigger>
-            <TabsTrigger value="theme" className="flex items-center gap-2">
-              <Palette className="h-4 w-4" /> Theme
-            </TabsTrigger>
-            <TabsTrigger value="danger" className="flex items-center gap-2">
-              <Trash2 className="h-4 w-4" /> Danger
-            </TabsTrigger>
           </TabsList>
 
           {/* Profile Tab */}
           <TabsContent value="profile" className="space-y-6">
-            <Card className="bg-card/70 backdrop-blur-sm border border-border shadow-xl">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <User className="h-5 w-5" /> Profile Information
-                </CardTitle>
-                <CardDescription>
-                  Update your personal information and profile details
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleProfileSave} className="space-y-6">
-                  {/* Avatar Section */}
-                  <div className="flex items-center gap-6">
-                    <div className="relative">
-                      <Avatar className="h-24 w-24 border-4 border-white shadow-lg">
-                        <AvatarImage src={profile.avatar || user?.avatar} />
-                        <AvatarFallback className="text-2xl bg-accent text-white">
-                          {profile.name?.charAt(0) ||
-                            user?.name?.charAt(0) ||
-                            "U"}
-                        </AvatarFallback>
-                      </Avatar>
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline"
-                        className="absolute -bottom-2 left-1/2 -translate-x-1/2 w-8 h-8 rounded-full p-0"
-                      >
-                        <Camera className="h-4 w-4" />
-                      </Button>
-                    </div>
-                    <div>
-                      <h3 className="font-semibold text-lg">
-                        {profile.name || user?.name}
-                      </h3>
-                      <p className="text-muted-foreground">
-                        @{profile.username || user?.username}
-                      </p>
-                      <Badge className="mt-2 bg-accent text-white">
-                        {user?.role || "Member"}
-                      </Badge>
-                    </div>
+            <Panel>
+              <CardHead
+                icon={User}
+                title="Profile Information"
+                description="Update your personal information and profile details"
+              />
+              <form onSubmit={handleProfileSave} className="space-y-6">
+                {/* Avatar Section */}
+                <div className="flex flex-col items-center gap-6 sm:flex-row sm:items-center">
+                  <div className="relative">
+                    <Avatar className="h-24 w-24 border-4 border-surface-raised shadow-md">
+                      <AvatarImage src={profile.avatar || user?.avatar} />
+                      <AvatarFallback className="bg-accent text-2xl text-white">
+                        {profile.name?.charAt(0) ||
+                          user?.name?.charAt(0) ||
+                          "U"}
+                      </AvatarFallback>
+                    </Avatar>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      className="absolute -bottom-2 left-1/2 h-8 w-8 -translate-x-1/2 rounded-full p-0"
+                    >
+                      <Camera className="h-4 w-4" />
+                    </Button>
                   </div>
-                  <Separator />
-                  {/* Form Fields */}
-                  <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                    <div className="space-y-2">
-                      <Label htmlFor="name">Full Name</Label>
-                      <Input
-                        id="name"
-                        name="name"
-                        value={profile.name}
-                        onChange={handleProfileChange}
-                        placeholder="Enter your full name"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="username">Username</Label>
-                      <Input
-                        id="username"
-                        name="username"
-                        value={profile.username}
-                        onChange={handleProfileChange}
-                        placeholder="Choose a username"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="country">Country</Label>
-                      <Input
-                        id="country"
-                        name="country"
-                        value={profile.country}
-                        onChange={handleProfileChange}
-                        placeholder="Your country"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="age">Age</Label>
-                      <Input
-                        id="age"
-                        name="age"
-                        type="number"
-                        value={profile.age}
-                        onChange={handleProfileChange}
-                        placeholder="Your age"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="gender">Gender</Label>
-                      <Input
-                        id="gender"
-                        name="gender"
-                        value={profile.gender}
-                        onChange={handleProfileChange}
-                        placeholder="Your gender"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="language">Language</Label>
-                      <Input
-                        id="language"
-                        name="language"
-                        value={profile.language}
-                        onChange={handleProfileChange}
-                        placeholder="Preferred language"
-                      />
-                    </div>
+                  <div className="text-center sm:text-left">
+                    <h3 className={cn(poppins_600, "text-lg text-ink")}>
+                      {profile.name || user?.name}
+                    </h3>
+                    <p className={cn(poppins_400, "text-ink-muted")}>
+                      @{profile.username || user?.username}
+                    </p>
+                    <Badge className="mt-2 bg-accent text-white">
+                      {user?.role || "Member"}
+                    </Badge>
                   </div>
+                </div>
+                <Separator className="bg-accent/10" />
+                {/* Form Fields */}
+                <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                   <div className="space-y-2">
-                    <Label htmlFor="bio">Bio</Label>
-                    <Textarea
-                      id="bio"
-                      name="bio"
-                      value={profile.bio}
+                    <FieldLabel htmlFor="name">Full Name</FieldLabel>
+                    <Input
+                      id="name"
+                      name="name"
+                      value={profile.name}
                       onChange={handleProfileChange}
-                      placeholder="Tell us about yourself..."
-                      rows={4}
+                      placeholder="Enter your full name"
                     />
                   </div>
-                  <Button
-                    type="submit"
-                    disabled={isLoading}
-                    className="w-full sm:w-auto"
-                  >
-                    {isLoading ? (
-                      <>
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                        Saving...
-                      </>
-                    ) : (
-                      <>
-                        <Save className="h-4 w-4 mr-2" /> Save Profile
-                      </>
-                    )}
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
+                  <div className="space-y-2">
+                    <FieldLabel htmlFor="username">Username</FieldLabel>
+                    <Input
+                      id="username"
+                      name="username"
+                      value={profile.username}
+                      onChange={handleProfileChange}
+                      placeholder="Choose a username"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <FieldLabel htmlFor="country">Country</FieldLabel>
+                    <Input
+                      id="country"
+                      name="country"
+                      value={profile.country}
+                      onChange={handleProfileChange}
+                      placeholder="Your country"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <FieldLabel htmlFor="age">Age</FieldLabel>
+                    <Input
+                      id="age"
+                      name="age"
+                      type="number"
+                      value={profile.age}
+                      onChange={handleProfileChange}
+                      placeholder="Your age"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <FieldLabel htmlFor="gender">Gender</FieldLabel>
+                    <Input
+                      id="gender"
+                      name="gender"
+                      value={profile.gender}
+                      onChange={handleProfileChange}
+                      placeholder="Your gender"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <FieldLabel htmlFor="language">Language</FieldLabel>
+                    <Input
+                      id="language"
+                      name="language"
+                      value={profile.language}
+                      onChange={handleProfileChange}
+                      placeholder="Preferred language"
+                    />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <FieldLabel htmlFor="bio">Bio</FieldLabel>
+                  <Textarea
+                    id="bio"
+                    name="bio"
+                    value={profile.bio}
+                    onChange={handleProfileChange}
+                    placeholder="Tell us about yourself..."
+                    rows={4}
+                  />
+                </div>
+                <SubmitButton savingLabel="Saving..." label="Save Profile" />
+              </form>
+            </Panel>
           </TabsContent>
 
           {/* Account Tab */}
           <TabsContent value="account" className="space-y-6">
-            <Card className="bg-card/70 backdrop-blur-sm border border-border shadow-xl">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Lock className="h-5 w-5" /> Account Security
-                </CardTitle>
-                <CardDescription>
-                  Manage your email and password settings
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleAccountSave} className="space-y-6">
+            <Panel>
+              <CardHead
+                icon={Lock}
+                title="Account Security"
+                description="Manage your email and password settings"
+              />
+              <form onSubmit={handleAccountSave} className="space-y-6">
+                <div className="space-y-2">
+                  <FieldLabel htmlFor="email">Email Address</FieldLabel>
+                  <div className="relative">
+                    <Mail className="absolute left-3 top-3 h-4 w-4 text-ink-muted" />
+                    <Input
+                      id="email"
+                      name="email"
+                      type="email"
+                      value={account.email}
+                      onChange={handleAccountChange}
+                      placeholder="your.email@example.com"
+                      className="pl-10"
+                    />
+                  </div>
+                </div>
+                <Separator className="bg-accent/10" />
+                <div className="space-y-4">
+                  <h4 className={cn(poppins_600, "text-base text-ink")}>
+                    Change Password
+                  </h4>
                   <div className="space-y-2">
-                    <Label htmlFor="email">Email Address</Label>
+                    <FieldLabel htmlFor="currentPassword">
+                      Current Password
+                    </FieldLabel>
                     <div className="relative">
-                      <Mail className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+                      <Lock className="absolute left-3 top-3 h-4 w-4 text-ink-muted" />
                       <Input
-                        id="email"
-                        name="email"
-                        type="email"
-                        value={account.email}
+                        id="currentPassword"
+                        name="currentPassword"
+                        type={showPassword ? "text" : "password"}
+                        value={account.currentPassword}
                         onChange={handleAccountChange}
-                        placeholder="your.email@example.com"
-                        className="pl-10"
+                        placeholder="Enter current password"
+                        className="pl-10 pr-10"
                       />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                        onClick={() => setShowPassword(!showPassword)}
+                      >
+                        {showPassword ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </Button>
                     </div>
                   </div>
-                  <Separator />
-                  <div className="space-y-4">
-                    <h4 className="font-semibold text-lg">Change Password</h4>
-                    <div className="space-y-2">
-                      <Label htmlFor="currentPassword">Current Password</Label>
-                      <div className="relative">
-                        <Lock className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-                        <Input
-                          id="currentPassword"
-                          name="currentPassword"
-                          type={showPassword ? "text" : "password"}
-                          value={account.currentPassword}
-                          onChange={handleAccountChange}
-                          placeholder="Enter current password"
-                          className="pl-10 pr-10"
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                          onClick={() => setShowPassword(!showPassword)}
-                        >
-                          {showPassword ? (
-                            <EyeOff className="h-4 w-4" />
-                          ) : (
-                            <Eye className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="newPassword">New Password</Label>
-                      <div className="relative">
-                        <Lock className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
-                        <Input
-                          id="newPassword"
-                          name="newPassword"
-                          type={showNewPassword ? "text" : "password"}
-                          value={account.newPassword}
-                          onChange={handleAccountChange}
-                          placeholder="Enter new password"
-                          className="pl-10 pr-10"
-                        />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
-                          onClick={() => setShowNewPassword(!showNewPassword)}
-                        >
-                          {showNewPassword ? (
-                            <EyeOff className="h-4 w-4" />
-                          ) : (
-                            <Eye className="h-4 w-4" />
-                          )}
-                        </Button>
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor="confirmPassword">
-                        Confirm New Password
-                      </Label>
+                  <div className="space-y-2">
+                    <FieldLabel htmlFor="newPassword">New Password</FieldLabel>
+                    <div className="relative">
+                      <Lock className="absolute left-3 top-3 h-4 w-4 text-ink-muted" />
                       <Input
-                        id="confirmPassword"
-                        name="confirmPassword"
-                        type="password"
-                        value={account.confirmPassword}
+                        id="newPassword"
+                        name="newPassword"
+                        type={showNewPassword ? "text" : "password"}
+                        value={account.newPassword}
                         onChange={handleAccountChange}
-                        placeholder="Confirm new password"
+                        placeholder="Enter new password"
+                        className="pl-10 pr-10"
                       />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        className="absolute right-0 top-0 h-full px-3 py-2 hover:bg-transparent"
+                        onClick={() => setShowNewPassword(!showNewPassword)}
+                      >
+                        {showNewPassword ? (
+                          <EyeOff className="h-4 w-4" />
+                        ) : (
+                          <Eye className="h-4 w-4" />
+                        )}
+                      </Button>
                     </div>
                   </div>
+                  <div className="space-y-2">
+                    <FieldLabel htmlFor="confirmPassword">
+                      Confirm New Password
+                    </FieldLabel>
+                    <Input
+                      id="confirmPassword"
+                      name="confirmPassword"
+                      type="password"
+                      value={account.confirmPassword}
+                      onChange={handleAccountChange}
+                      placeholder="Confirm new password"
+                    />
+                  </div>
+                </div>
+                <SubmitButton
+                  savingLabel="Updating..."
+                  label="Update Account"
+                />
+              </form>
+            </Panel>
+
+            {/* Danger zone — lives under Account */}
+            <Panel className="border-red-200">
+              <CardHead
+                icon={Trash2}
+                title="Danger Zone"
+                description="Irreversible and destructive actions"
+                danger
+              />
+              <div className="p-5 sm:p-6">
+                <div className="rounded-xl border border-red-200 bg-red-50 p-4">
+                  <h4 className={cn(poppins_600, "mb-2 text-red-700")}>
+                    Delete Account
+                  </h4>
+                  <p className={cn(poppins_400, "mb-4 text-sm text-red-600")}>
+                    Once you delete your account, there is no going back. Please
+                    be certain.
+                  </p>
                   <Button
-                    type="submit"
-                    disabled={isLoading}
-                    className="w-full sm:w-auto"
+                    variant="destructive"
+                    onClick={handleDeleteAccount}
+                    className="bg-red-600 hover:bg-red-700"
                   >
-                    {isLoading ? (
-                      <>
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                        Updating...
-                      </>
-                    ) : (
-                      <>
-                        <Save className="h-4 w-4 mr-2" /> Update Account
-                      </>
-                    )}
+                    <Trash2 className="mr-2 h-4 w-4" /> Delete Account
                   </Button>
-                </form>
-              </CardContent>
-            </Card>
+                </div>
+              </div>
+            </Panel>
           </TabsContent>
 
           {/* Notifications Tab */}
           <TabsContent value="notifications" className="space-y-6">
-            <Card className="bg-card/70 backdrop-blur-sm border border-border shadow-xl">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Bell className="h-5 w-5" /> Notification Preferences
-                </CardTitle>
-                <CardDescription>
-                  Choose how you want to be notified about activities
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleNotificationSave} className="space-y-6">
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <Mail className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">
-                            Email Notifications
-                          </Label>
-                          <p className="text-sm text-muted-foreground">
-                            Receive updates via email
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={notifications.email}
-                        onCheckedChange={() =>
-                          handleNotificationChange("email")
-                        }
-                      />
-                    </div>
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <Smartphone className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">
-                            Push Notifications
-                          </Label>
-                          <p className="text-sm text-muted-foreground">
-                            Get instant notifications
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={notifications.push}
-                        onCheckedChange={() => handleNotificationChange("push")}
-                      />
-                    </div>
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <Bell className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">
-                            Course Updates
-                          </Label>
-                          <p className="text-sm text-muted-foreground">
-                            New courses and updates
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={notifications.courseUpdates}
-                        onCheckedChange={() =>
-                          handleNotificationChange("courseUpdates")
-                        }
-                      />
-                    </div>
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <Mail className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">
-                            Message Notifications
-                          </Label>
-                          <p className="text-sm text-muted-foreground">
-                            New messages and replies
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={notifications.messageNotifications}
-                        onCheckedChange={() =>
-                          handleNotificationChange("messageNotifications")
-                        }
-                      />
-                    </div>
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <Globe className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">
-                            Space Reminders
-                          </Label>
-                          <p className="text-sm text-muted-foreground">
-                            Upcoming space sessions
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={notifications.spaceReminders}
-                        onCheckedChange={() =>
-                          handleNotificationChange("spaceReminders")
-                        }
-                      />
-                    </div>
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <Mail className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">Newsletter</Label>
-                          <p className="text-sm text-muted-foreground">
-                            Weekly updates and insights
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={notifications.newsletter}
-                        onCheckedChange={() =>
-                          handleNotificationChange("newsletter")
-                        }
-                      />
-                    </div>
-                  </div>
-                  <Button
-                    type="submit"
-                    disabled={isLoading}
-                    className="w-full sm:w-auto"
-                  >
-                    {isLoading ? (
-                      <>
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                        Saving...
-                      </>
-                    ) : (
-                      <>
-                        <Save className="h-4 w-4 mr-2" /> Save Preferences
-                      </>
-                    )}
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
+            <Panel>
+              <CardHead
+                icon={Bell}
+                title="Notification Preferences"
+                description="Choose how you want to be notified about activities"
+              />
+              <form onSubmit={handleNotificationSave} className="space-y-6">
+                <div className="space-y-3">
+                  <ToggleRow
+                    icon={Mail}
+                    title="Email Notifications"
+                    description="Receive updates via email"
+                    checked={notifications.email}
+                    onCheckedChange={() => handleNotificationChange("email")}
+                  />
+                  <ToggleRow
+                    icon={Smartphone}
+                    title="Push Notifications"
+                    description="Get instant notifications"
+                    checked={notifications.push}
+                    onCheckedChange={() => handleNotificationChange("push")}
+                  />
+                  <ToggleRow
+                    icon={Bell}
+                    title="Course Updates"
+                    description="New courses and updates"
+                    checked={notifications.courseUpdates}
+                    onCheckedChange={() =>
+                      handleNotificationChange("courseUpdates")
+                    }
+                  />
+                  <ToggleRow
+                    icon={Mail}
+                    title="Message Notifications"
+                    description="New messages and replies"
+                    checked={notifications.messageNotifications}
+                    onCheckedChange={() =>
+                      handleNotificationChange("messageNotifications")
+                    }
+                  />
+                  <ToggleRow
+                    icon={Globe}
+                    title="Space Reminders"
+                    description="Upcoming space sessions"
+                    checked={notifications.spaceReminders}
+                    onCheckedChange={() =>
+                      handleNotificationChange("spaceReminders")
+                    }
+                  />
+                  <ToggleRow
+                    icon={Mail}
+                    title="Newsletter"
+                    description="Weekly updates and insights"
+                    checked={notifications.newsletter}
+                    onCheckedChange={() =>
+                      handleNotificationChange("newsletter")
+                    }
+                  />
+                </div>
+                <SubmitButton
+                  savingLabel="Saving..."
+                  label="Save Preferences"
+                />
+              </form>
+            </Panel>
           </TabsContent>
 
           {/* Privacy Tab */}
           <TabsContent value="privacy" className="space-y-6">
-            <Card className="bg-card/70 backdrop-blur-sm border border-border shadow-xl">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Shield className="h-5 w-5" /> Privacy Settings
-                </CardTitle>
-                <CardDescription>
-                  Control who can see your information and activity
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handlePrivacySave} className="space-y-6">
-                  <div className="space-y-4">
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <User className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">
-                            Profile Visibility
-                          </Label>
-                          <p className="text-sm text-muted-foreground">
-                            Allow others to view your profile
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={privacy.profileVisible}
-                        onCheckedChange={() =>
-                          handlePrivacyChange("profileVisible")
-                        }
-                      />
-                    </div>
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <Globe className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">Online Status</Label>
-                          <p className="text-sm text-muted-foreground">
-                            Show when you're online
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={privacy.showOnline}
-                        onCheckedChange={() =>
-                          handlePrivacyChange("showOnline")
-                        }
-                      />
-                    </div>
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <Mail className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">
-                            Allow Messages
-                          </Label>
-                          <p className="text-sm text-muted-foreground">
-                            Let others send you messages
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={privacy.allowMessages}
-                        onCheckedChange={() =>
-                          handlePrivacyChange("allowMessages")
-                        }
-                      />
-                    </div>
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <Mail className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">Show Email</Label>
-                          <p className="text-sm text-muted-foreground">
-                            Display email on profile
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={privacy.showEmail}
-                        onCheckedChange={() => handlePrivacyChange("showEmail")}
-                      />
-                    </div>
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <User className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">Show Age</Label>
-                          <p className="text-sm text-muted-foreground">
-                            Display age on profile
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={privacy.showAge}
-                        onCheckedChange={() => handlePrivacyChange("showAge")}
-                      />
-                    </div>
-                    <div className="flex items-center justify-between p-4 bg-muted/30 rounded-lg">
-                      <div className="flex items-center gap-3">
-                        <Palette className="h-5 w-5" />
-                        <div>
-                          <Label className="font-semibold">
-                            Show Interests
-                          </Label>
-                          <p className="text-sm text-muted-foreground">
-                            Display interests on profile
-                          </p>
-                        </div>
-                      </div>
-                      <Switch
-                        checked={privacy.showInterests}
-                        onCheckedChange={() =>
-                          handlePrivacyChange("showInterests")
-                        }
-                      />
-                    </div>
-                  </div>
-                  <Button
-                    type="submit"
-                    disabled={isLoading}
-                    className="w-full sm:w-auto"
-                  >
-                    {isLoading ? (
-                      <>
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                        Saving...
-                      </>
-                    ) : (
-                      <>
-                        <Save className="h-4 w-4 mr-2" /> Save Privacy Settings
-                      </>
-                    )}
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
+            <Panel>
+              <CardHead
+                icon={Shield}
+                title="Privacy Settings"
+                description="Control who can see your information and activity"
+              />
+              <form onSubmit={handlePrivacySave} className="space-y-6">
+                <div className="space-y-3">
+                  <ToggleRow
+                    icon={User}
+                    title="Profile Visibility"
+                    description="Allow others to view your profile"
+                    checked={privacy.profileVisible}
+                    onCheckedChange={() =>
+                      handlePrivacyChange("profileVisible")
+                    }
+                  />
+                  <ToggleRow
+                    icon={Globe}
+                    title="Online Status"
+                    description="Show when you're online"
+                    checked={privacy.showOnline}
+                    onCheckedChange={() => handlePrivacyChange("showOnline")}
+                  />
+                  <ToggleRow
+                    icon={Mail}
+                    title="Allow Messages"
+                    description="Let others send you messages"
+                    checked={privacy.allowMessages}
+                    onCheckedChange={() => handlePrivacyChange("allowMessages")}
+                  />
+                  <ToggleRow
+                    icon={Mail}
+                    title="Show Email"
+                    description="Display email on profile"
+                    checked={privacy.showEmail}
+                    onCheckedChange={() => handlePrivacyChange("showEmail")}
+                  />
+                  <ToggleRow
+                    icon={User}
+                    title="Show Age"
+                    description="Display age on profile"
+                    checked={privacy.showAge}
+                    onCheckedChange={() => handlePrivacyChange("showAge")}
+                  />
+                  <ToggleRow
+                    icon={Palette}
+                    title="Show Interests"
+                    description="Display interests on profile"
+                    checked={privacy.showInterests}
+                    onCheckedChange={() => handlePrivacyChange("showInterests")}
+                  />
+                </div>
+                <SubmitButton
+                  savingLabel="Saving..."
+                  label="Save Privacy Settings"
+                />
+              </form>
+            </Panel>
           </TabsContent>
 
           {/* Theme Tab */}
           <TabsContent value="theme" className="space-y-6">
-            <Card className="bg-card/70 backdrop-blur-sm border border-border shadow-xl">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Palette className="h-5 w-5" /> Theme & Appearance
-                </CardTitle>
-                <CardDescription>
-                  Customize your interface appearance and preferences
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <form onSubmit={handleThemeSave} className="space-y-6">
-                  <div className="space-y-4">
-                    <div className="space-y-2">
-                      <Label>Theme Mode</Label>
-                      <div className="grid grid-cols-3 gap-3">
-                        {["light", "dark", "auto"].map((mode) => (
-                          <Button
-                            key={mode}
-                            type="button"
-                            variant={
-                              mounted && selectedMode === mode
-                                ? "default"
-                                : "outline"
-                            }
-                            className="capitalize"
-                            aria-pressed={mounted && selectedMode === mode}
-                            onClick={() => handleModeChange(mode)}
-                          >
-                            {mode}
-                          </Button>
-                        ))}
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label>Accent Color</Label>
-                      <div className="grid grid-cols-5 gap-3">
-                        {Object.entries(ACCENT_PALETTES).map(
-                          ([color, palette]) => (
-                            <Button
-                              key={color}
-                              type="button"
-                              variant="outline"
-                              className={cn(
-                                "h-12 w-12 rounded-full p-0",
-                                mounted &&
-                                  accent === color &&
-                                  "ring-2 ring-ring ring-offset-2"
-                              )}
-                              style={{ backgroundColor: palette.surface }}
-                              aria-label={`Accent color ${color}`}
-                              aria-pressed={mounted && accent === color}
-                              onClick={() => setAccent(color)}
-                            >
-                              {mounted && accent === color && (
-                                <CheckCircle className="h-5 w-5 text-white mx-auto" />
-                              )}
-                            </Button>
-                          )
-                        )}
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <Label>Font Size</Label>
-                      <div className="grid grid-cols-3 gap-3">
-                        {Object.keys(FONT_SIZES).map((size) => (
-                          <Button
-                            key={size}
-                            type="button"
-                            variant={
-                              mounted && fontSize === size
-                                ? "default"
-                                : "outline"
-                            }
-                            className="capitalize"
-                            aria-pressed={mounted && fontSize === size}
-                            onClick={() => setFontSize(size)}
-                          >
-                            {size}
-                          </Button>
-                        ))}
-                      </div>
-                      <p className="text-sm text-muted-foreground">
-                        Scales most of the interface. Some elements keep a fixed
-                        size and won't change.
-                      </p>
+            <Panel>
+              <CardHead
+                icon={Palette}
+                title="Theme & Appearance"
+                description="Customize your interface appearance and preferences"
+              />
+              <form onSubmit={handleThemeSave} className="space-y-6">
+                <div className="space-y-6">
+                  <div className="space-y-3">
+                    <FieldLabel>Theme Mode</FieldLabel>
+                    <div className="grid grid-cols-3 gap-3">
+                      {["light", "dark", "auto"].map((mode) => (
+                        <Button
+                          key={mode}
+                          type="button"
+                          variant={
+                            mounted && selectedMode === mode
+                              ? "default"
+                              : "outline"
+                          }
+                          className="capitalize"
+                          aria-pressed={mounted && selectedMode === mode}
+                          onClick={() => handleModeChange(mode)}
+                        >
+                          {mode}
+                        </Button>
+                      ))}
                     </div>
                   </div>
-                  <Button
-                    type="submit"
-                    disabled={isLoading}
-                    className="w-full sm:w-auto"
-                  >
-                    {isLoading ? (
-                      <>
-                        <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2"></div>
-                        Saving...
-                      </>
-                    ) : (
-                      <>
-                        <Save className="h-4 w-4 mr-2" /> Save Theme
-                      </>
-                    )}
-                  </Button>
-                </form>
-              </CardContent>
-            </Card>
+                  <div className="space-y-3">
+                    <FieldLabel>Accent Color</FieldLabel>
+                    <div className="grid grid-cols-5 gap-3">
+                      {Object.entries(ACCENT_PALETTES).map(
+                        ([color, palette]) => (
+                          <Button
+                            key={color}
+                            type="button"
+                            variant="outline"
+                            className={cn(
+                              "h-12 w-12 rounded-full p-0",
+                              mounted &&
+                                accent === color &&
+                                "ring-2 ring-accent ring-offset-2"
+                            )}
+                            style={{ backgroundColor: palette.surface }}
+                            aria-label={`Accent color ${color}`}
+                            aria-pressed={mounted && accent === color}
+                            onClick={() => setAccent(color)}
+                          >
+                            {mounted && accent === color && (
+                              <CheckCircle className="mx-auto h-5 w-5 text-white" />
+                            )}
+                          </Button>
+                        )
+                      )}
+                    </div>
+                  </div>
+                  <div className="space-y-3">
+                    <FieldLabel>Font Size</FieldLabel>
+                    <div className="grid grid-cols-3 gap-3">
+                      {Object.keys(FONT_SIZES).map((size) => (
+                        <Button
+                          key={size}
+                          type="button"
+                          variant={
+                            mounted && fontSize === size
+                              ? "default"
+                              : "outline"
+                          }
+                          className="capitalize"
+                          aria-pressed={mounted && fontSize === size}
+                          onClick={() => setFontSize(size)}
+                        >
+                          {size}
+                        </Button>
+                      ))}
+                    </div>
+                    <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                      Scales most of the interface. Some elements keep a fixed
+                      size and won't change.
+                    </p>
+                  </div>
+                </div>
+                <SubmitButton savingLabel="Saving..." label="Save Theme" />
+              </form>
+            </Panel>
           </TabsContent>
 
           {/* Danger Tab */}
           <TabsContent value="danger" className="space-y-6">
-            <Card className="bg-card/70 backdrop-blur-sm border border-destructive/30 shadow-xl">
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Trash2 className="h-5 w-5" /> Danger Zone
-                </CardTitle>
-                <CardDescription>
-                  Irreversible and destructive actions
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-6">
-                  <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
-                    <h4 className="font-semibold text-red-800 mb-2">
-                      Delete Account
-                    </h4>
-                    <p className="text-sm text-red-700 mb-4">
-                      Once you delete your account, there is no going back.
-                      Please be certain.
-                    </p>
-                    <Button
-                      variant="destructive"
-                      onClick={handleDeleteAccount}
-                      className="bg-red-600 hover:bg-red-700"
-                    >
-                      <Trash2 className="h-4 w-4 mr-2" /> Delete Account
-                    </Button>
-                  </div>
-                </div>
-              </CardContent>
-            </Card>
+            <Panel className="border-red-200">
+              <CardHead
+                icon={Trash2}
+                title="Danger Zone"
+                description="Irreversible and destructive actions"
+                danger
+              />
+              <div className="rounded-xl border border-red-200 bg-red-50 p-4">
+                <h4 className={cn(poppins_600, "mb-2 text-red-700")}>
+                  Delete Account
+                </h4>
+                <p className={cn(poppins_400, "mb-4 text-sm text-red-600")}>
+                  Once you delete your account, there is no going back. Please
+                  be certain.
+                </p>
+                <Button
+                  variant="destructive"
+                  onClick={handleDeleteAccount}
+                  className="bg-red-600 hover:bg-red-700"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" /> Delete Account
+                </Button>
+              </div>
+            </Panel>
           </TabsContent>
         </Tabs>
       </div>

--- a/app/account/support/page.jsx
+++ b/app/account/support/page.jsx
@@ -5,6 +5,88 @@ import Button from "@/components/atoms/form/Button";
 import { Textarea } from "@/components/ui/textarea";
 import FileInput from "@/components/atoms/form/FileInput";
 import DashTabs from "@/components/atoms/dashboard/DashTabs";
+import {
+  LifeBuoy,
+  Ticket,
+  MessageSquareText,
+  Paperclip,
+  Mail,
+  BookOpen,
+  Clock,
+  ShieldCheck,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+
+/* ── building blocks (design-system consistent) ── */
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
+
+const CardHeader = ({ icon: Icon, title, description }) => (
+  <div className="flex items-start gap-3">
+    {Icon && (
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+        <Icon className="h-5 w-5 text-accent" />
+      </div>
+    )}
+    <div>
+      <h2 className={cn(poppins_600, "text-lg text-ink")}>{title}</h2>
+      {description && (
+        <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+          {description}
+        </p>
+      )}
+    </div>
+  </div>
+);
+
+const FieldLabel = ({ htmlFor, children, hint }) => (
+  <span className="mb-1.5 block">
+    <label
+      htmlFor={htmlFor}
+      className={cn(poppins_500, "text-sm text-ink")}
+    >
+      {children}
+    </label>
+    {hint && (
+      <span className={cn(poppins_400, "ml-1 text-xs text-ink-muted")}>
+        {hint}
+      </span>
+    )}
+  </span>
+);
+
+const SUPPORT_CHANNELS = [
+  {
+    icon: Mail,
+    title: "Email us",
+    text: "support@deenbridge.com — we reply within one business day.",
+  },
+  {
+    icon: Clock,
+    title: "Response time",
+    text: "Most tickets are resolved in under 24 hours, insha'Allah.",
+  },
+  {
+    icon: BookOpen,
+    title: "Help center",
+    text: "Browse guides and FAQs for quick answers before opening a ticket.",
+  },
+];
+
 const ReportIssue = () => {
   const [modal, setModal] = useState(false);
   const modalHandler = () => setModal(!modal);
@@ -22,70 +104,169 @@ const ReportIssue = () => {
 
   };
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 ">
+    <div className="min-h-full bg-surface p-4 sm:p-6">
       {/* <DashTabs selectedTab={as}/> */}
-      <div className="flex flex-col gap-2 justify-center items-center">
-        <h3 className="mx-auto text-center text-2xl font-bold mt-6 font-stretch-125%">
-          What are you having issue with ? <br /> Our team, is always available to attend
-          to it
-        </h3>
-        <form
-          onSubmit={handleSubmit}
-          className="mt-12 flex flex-col gap-6 w-[calc(100%_-_100px)] mx-auto"
-        >
-          <label htmlFor="report-subject" className="">
-            <span className="text-base mb-1 font-medium text-wmt-gray-400 block">
-              Subject
-            </span>
-            <Input
-              type="text"
-              id="report-subject"
-              name="report-subject"
-              placeholder="Input subject"
-              onChange={(e) => setSubject(e.target.value)}
-              required
-              className="px-4 py-4 rounded-lg w-full border text-base font-normal border-[#D9DCE0]"
+      <div className="mx-auto max-w-5xl space-y-6">
+        {/* Hero header */}
+        <Panel className="relative overflow-hidden bg-gradient-to-br from-secondary/10 via-surface-raised to-highlight/10 p-6 sm:p-8">
+          <div className="pointer-events-none absolute -right-10 -top-10 h-40 w-40 rounded-full bg-secondary/10 blur-3xl" />
+          <div className="relative flex items-center gap-3">
+            <div className="flex size-12 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+              <LifeBuoy className="h-6 w-6 text-accent" />
+            </div>
+            <div>
+              <h1
+                className={cn(
+                  poppins_600,
+                  "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent sm:text-3xl"
+                )}
+              >
+                Support
+              </h1>
+              <p
+                className={cn(
+                  poppins_400,
+                  "mt-1 max-w-xl text-sm leading-relaxed text-ink-muted"
+                )}
+              >
+                Having an issue? Tell us what happened and our team will attend
+                to it as soon as possible.
+              </p>
+            </div>
+          </div>
+        </Panel>
+
+        {/* Main: form (2/3) + sidebar (1/3) */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          {/* Report a ticket */}
+          <Panel className="p-6 lg:col-span-2">
+            <CardHeader
+              icon={Ticket}
+              title="Report an issue"
+              description="Describe your problem in detail so we can resolve it quickly."
             />
-          </label>
-          <label htmlFor="report-description" className="">
-            <span className="text-base mb-1 font-medium text-wmt-gray-400 block">
-              Description
-            </span>
-            <Textarea
-              name="report-description"
-              id="report-description"
-              placeholder="Explain what is happening here"
-              className="px-4 py-[18px] rounded-lg h-[120px] w-full  outline-none focus:outline-none border text-base font-normal border-[#D9DCE0]"
-              onChange={(e) => setDescription(e.target.value)}
-              required
-            ></Textarea>
-          </label>
-          <label htmlFor="report-file" className="">
-            <span className="text-base mb-1 font-medium text-wmt-gray-400 block">
-              Upload file
-              <span className="text-wmt-gray-500 text-sm">
-                (This will help our team to understand the issue more)
-              </span>
-            </span>
-            <FileInput id="report-file" file={image} onChange={handleImageChange} />
-          </label>
-          <Button
-            wide
-            loading={loading}
-            type="submit"
-            className=" transition delay-75 mt-10 py-3 font-medium flex items-center justify-center rounded-full text-white  "
-          >
-            Create a ticket
-          </Button>
-        </form>
+            <form
+              onSubmit={handleSubmit}
+              className="mt-6 space-y-5"
+            >
+              <div>
+                <FieldLabel htmlFor="report-subject">Subject</FieldLabel>
+                <Input
+                  type="text"
+                  id="report-subject"
+                  name="report-subject"
+                  placeholder="Input subject"
+                  onChange={(e) => setSubject(e.target.value)}
+                  required
+                  className={cn(
+                    poppins_400,
+                    "w-full rounded-xl border border-accent/15 bg-surface px-4 py-3 text-base text-ink outline-none placeholder:text-ink-muted/60 focus:border-secondary focus:ring-2 focus:ring-secondary/20"
+                  )}
+                />
+              </div>
+
+              <div>
+                <FieldLabel htmlFor="report-description">
+                  Description
+                </FieldLabel>
+                <Textarea
+                  name="report-description"
+                  id="report-description"
+                  placeholder="Explain what is happening here"
+                  className={cn(
+                    poppins_400,
+                    "h-[140px] w-full rounded-xl border border-accent/15 bg-surface px-4 py-3 text-base text-ink outline-none placeholder:text-ink-muted/60 focus:border-secondary focus:ring-2 focus:ring-secondary/20"
+                  )}
+                  onChange={(e) => setDescription(e.target.value)}
+                  required
+                ></Textarea>
+              </div>
+
+              <div>
+                <FieldLabel
+                  htmlFor="report-file"
+                  hint="(This will help our team to understand the issue more)"
+                >
+                  Upload file
+                </FieldLabel>
+                <FileInput
+                  id="report-file"
+                  file={image}
+                  onChange={handleImageChange}
+                />
+              </div>
+
+              <div className="border-t border-accent/10 pt-5">
+                <Button
+                  round
+                  wide
+                  loading={loading}
+                  type="submit"
+                  className="py-3"
+                >
+                  Create a ticket
+                </Button>
+              </div>
+            </form>
+          </Panel>
+
+          {/* Sidebar: how to reach us */}
+          <div className="space-y-6">
+            <Panel className="p-6">
+              <CardHeader
+                icon={MessageSquareText}
+                title="Other ways to reach us"
+              />
+              <ul className="mt-5 space-y-4">
+                {SUPPORT_CHANNELS.map((channel) => (
+                  <li key={channel.title} className="flex items-start gap-3">
+                    <div className="flex size-9 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+                      <channel.icon className="h-4 w-4 text-accent" />
+                    </div>
+                    <div>
+                      <p className={cn(poppins_500, "text-sm text-ink")}>
+                        {channel.title}
+                      </p>
+                      <p
+                        className={cn(
+                          poppins_400,
+                          "mt-0.5 text-xs leading-relaxed text-ink-muted"
+                        )}
+                      >
+                        {channel.text}
+                      </p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </Panel>
+
+            <Panel className="p-6">
+              <CardHeader icon={Paperclip} title="Tips for a faster fix" />
+              <ul
+                className={cn(
+                  poppins_400,
+                  "mt-4 space-y-3 text-sm text-ink-muted"
+                )}
+              >
+                <li className="flex items-start gap-2">
+                  <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-secondary" />
+                  Include a clear subject that summarizes the problem.
+                </li>
+                <li className="flex items-start gap-2">
+                  <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-secondary" />
+                  Add the steps that led to the issue in the description.
+                </li>
+                <li className="flex items-start gap-2">
+                  <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-secondary" />
+                  Attach a screenshot so our team can see what you see.
+                </li>
+              </ul>
+            </Panel>
+          </div>
+        </div>
       </div>
-
-      <div>
-        hi
-</div>
-
     </div>
-
   );
 };
 export default ReportIssue;

--- a/app/account/wallet/page.jsx
+++ b/app/account/wallet/page.jsx
@@ -4,11 +4,55 @@ import { useRouter } from "next/navigation";
 import { useStellar } from "@/components/stellar/StellarProvider";
 import WalletConnectButton from "@/components/stellar/WalletConnectButton";
 import TransactionHistory from "@/components/stellar/TransactionHistory";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Wallet, ExternalLink, Info } from "lucide-react";
+import {
+  Wallet,
+  ExternalLink,
+  Info,
+  Coins,
+  Receipt,
+  LifeBuoy,
+  AlertTriangle,
+  ArrowRight,
+} from "lucide-react";
 import useAuth from "@/hooks/useAuth";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+
+/* ── building blocks (design-system consistent) ── */
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
+
+const CardHeading = ({ icon: Icon, title, subtitle }) => (
+  <div className="mb-5 flex items-start gap-3">
+    {Icon && (
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+        <Icon className="h-5 w-5 text-accent" />
+      </div>
+    )}
+    <div>
+      <h2 className={cn(poppins_600, "text-lg text-ink")}>{title}</h2>
+      {subtitle && (
+        <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+          {subtitle}
+        </p>
+      )}
+    </div>
+  </div>
+);
 
 export default function WalletPage() {
   const router = useRouter();
@@ -24,10 +68,12 @@ export default function WalletPage() {
 
   if (authLoading || isLoading) {
     return (
-      <div className="container max-w-4xl mx-auto py-8 px-4 space-y-6">
-        <Skeleton className="h-8 w-48" />
-        <Skeleton className="h-48 w-full" />
-        <Skeleton className="h-64 w-full" />
+      <div className="bg-surface p-4 sm:p-6">
+        <div className="mx-auto max-w-4xl space-y-6">
+          <Skeleton className="h-11 w-64 rounded-2xl" />
+          <Skeleton className="h-48 w-full rounded-2xl" />
+          <Skeleton className="h-64 w-full rounded-2xl" />
+        </div>
       </div>
     );
   }
@@ -46,170 +92,267 @@ export default function WalletPage() {
   };
 
   return (
-    <div className="container max-w-4xl mx-auto py-8 px-4 space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <Wallet className="h-6 w-6" />
-            Stellar Wallet
-          </h1>
-          <p className="text-muted-foreground">
-            Manage your Stellar wallet and view transactions
-          </p>
+    <div className="min-h-full bg-surface p-4 sm:p-6">
+      <div className="mx-auto max-w-5xl space-y-6">
+        {/* ── Header ── */}
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+              <Wallet className="h-5 w-5 text-accent" />
+            </div>
+            <div>
+              <h1
+                className={cn(
+                  poppins_600,
+                  "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+                )}
+              >
+                Stellar Wallet
+              </h1>
+              <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                Manage your Stellar wallet and view transactions
+              </p>
+            </div>
+          </div>
+          <WalletConnectButton />
         </div>
-        <WalletConnectButton />
-      </div>
 
-      {/* Network Info */}
-      <div className="flex items-center gap-2 p-3 bg-muted rounded-lg">
-        <Info className="h-4 w-4 text-muted-foreground" />
-        <span className="text-sm text-muted-foreground">
-          You are connected to Stellar{" "}
-          <Badge variant={network === "mainnet" ? "default" : "secondary"}>
+        {/* ── Network Info ── */}
+        <div className="flex items-center gap-2 rounded-xl border border-accent/10 bg-surface-raised px-4 py-3">
+          <Info className="h-4 w-4 shrink-0 text-ink-muted" />
+          <span className={cn(poppins_400, "text-sm text-ink-muted")}>
+            You are connected to Stellar
+          </span>
+          <span
+            className={cn(
+              poppins_500,
+              "rounded-full border px-3 py-0.5 text-xs capitalize",
+              network === "mainnet"
+                ? "border-secondary/20 bg-secondary/10 text-secondary"
+                : "border-amber-200 bg-amber-100 text-amber-700"
+            )}
+          >
             {network}
-          </Badge>
-        </span>
-      </div>
+          </span>
+        </div>
 
-      {/* Wallet Status Card */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Wallet Status</CardTitle>
-          <CardDescription>
-            {connectedWallet
-              ? "Your wallet is connected and ready to use"
-              : "Connect your Stellar wallet to make payments"}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
+        {/* ── Wallet Status Card ── */}
+        <Panel className="p-6">
+          <CardHeading
+            icon={Coins}
+            title="Wallet Status"
+            subtitle={
+              connectedWallet
+                ? "Your wallet is connected and ready to use"
+                : "Connect your Stellar wallet to make payments"
+            }
+          />
+
           {connectedWallet ? (
             <div className="space-y-4">
               {/* Address */}
-              <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 p-4 bg-muted rounded-lg">
-                <div>
-                  <p className="text-sm text-muted-foreground">Wallet Address</p>
-                  <p className="font-mono text-sm">{truncateAddress(connectedWallet)}</p>
+              <div className="flex flex-col gap-3 rounded-xl border border-accent/10 bg-surface p-4 sm:flex-row sm:items-center sm:justify-between">
+                <div className="min-w-0">
+                  <p className={cn(poppins_400, "text-xs uppercase tracking-wider text-ink-muted")}>
+                    Wallet Address
+                  </p>
+                  <p className={cn(poppins_500, "mt-1 break-all font-mono text-sm text-ink")}>
+                    {truncateAddress(connectedWallet)}
+                  </p>
                 </div>
                 <a
                   href={getExplorerUrl(connectedWallet)}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                  className={cn(
+                    poppins_500,
+                    "inline-flex shrink-0 items-center gap-1 text-sm text-secondary transition-colors hover:text-highlight"
+                  )}
                 >
                   View on Explorer
-                  <ExternalLink className="h-3 w-3" />
+                  <ExternalLink className="h-3.5 w-3.5" />
                 </a>
               </div>
 
               {/* Balances */}
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                <div className="p-4 border rounded-lg">
-                  <p className="text-sm text-muted-foreground">USDC Balance</p>
-                  <p className="text-2xl font-bold text-primary">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="rounded-xl border border-accent/10 bg-surface p-4">
+                  <p className={cn(poppins_400, "text-xs uppercase tracking-wider text-ink-muted")}>
+                    USDC Balance
+                  </p>
+                  <p className={cn(poppins_600, "mt-1 text-3xl text-secondary")}>
                     ${parseFloat(walletInfo?.usdcBalance || 0).toFixed(2)}
                   </p>
                   {!walletInfo?.hasTrustline && (
-                    <p className="text-xs text-orange-500 mt-1">
+                    <p className={cn(poppins_400, "mt-1 text-xs text-amber-600")}>
                       No USDC trustline. Add USDC asset to your wallet.
                     </p>
                   )}
                 </div>
-                <div className="p-4 border rounded-lg">
-                  <p className="text-sm text-muted-foreground">XLM Balance</p>
-                  <p className="text-2xl font-bold">
-                    {parseFloat(walletInfo?.xlmBalance || 0).toFixed(4)} XLM
+                <div className="rounded-xl border border-accent/10 bg-surface p-4">
+                  <p className={cn(poppins_400, "text-xs uppercase tracking-wider text-ink-muted")}>
+                    XLM Balance
+                  </p>
+                  <p className={cn(poppins_600, "mt-1 text-3xl text-ink")}>
+                    {parseFloat(walletInfo?.xlmBalance || 0).toFixed(4)}{" "}
+                    <span className={cn(poppins_500, "text-lg text-ink-muted")}>
+                      XLM
+                    </span>
                   </p>
                 </div>
               </div>
 
               {/* Trustline Warning */}
               {!walletInfo?.hasTrustline && (
-                <div className="p-4 border border-orange-200 bg-orange-50 rounded-lg">
-                  <h4 className="font-medium text-orange-800">USDC Trustline Required</h4>
-                  <p className="text-sm text-orange-700 mt-1">
-                    To send or receive USDC payments, you need to add a USDC trustline to your wallet.
-                    Open your wallet app (like Freighter) and add the USDC asset.
-                  </p>
+                <div className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 p-4">
+                  <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+                  <div>
+                    <h4 className={cn(poppins_600, "text-sm text-amber-800")}>
+                      USDC Trustline Required
+                    </h4>
+                    <p className={cn(poppins_400, "mt-1 text-sm text-amber-700")}>
+                      To send or receive USDC payments, you need to add a USDC
+                      trustline to your wallet. Open your wallet app (like
+                      Freighter) and add the USDC asset.
+                    </p>
+                  </div>
                 </div>
               )}
             </div>
           ) : (
-            <div className="text-center py-8">
-              <Wallet className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-              <h3 className="font-semibold">No Wallet Connected</h3>
-              <p className="text-muted-foreground text-sm mt-1 mb-4">
-                Connect your Stellar wallet to make purchases and receive payments
-              </p>
+            <div className="flex flex-col items-center justify-center gap-4 rounded-xl border border-dashed border-accent/15 py-12 text-center">
+              <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+                <Wallet className="h-7 w-7 text-accent" />
+              </div>
+              <div>
+                <h3 className={cn(poppins_600, "text-lg text-ink")}>
+                  No Wallet Connected
+                </h3>
+                <p className={cn(poppins_400, "mx-auto mt-1 max-w-sm text-sm text-ink-muted")}>
+                  Connect your Stellar wallet to make purchases and receive
+                  payments
+                </p>
+              </div>
               <WalletConnectButton variant="default" />
             </div>
           )}
-        </CardContent>
-      </Card>
+        </Panel>
 
-      {/* Transaction History */}
-      {connectedWallet && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Transactions</CardTitle>
-            <CardDescription>
-              View your payment history as a buyer or creator
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+        {/* ── Transaction History ── */}
+        {connectedWallet && (
+          <Panel className="p-6">
+            <CardHeading
+              icon={Receipt}
+              title="Transactions"
+              subtitle="View your payment history as a buyer or creator"
+            />
             <TransactionHistory />
-          </CardContent>
-        </Card>
-      )}
+          </Panel>
+        )}
 
-      {/* Help Section */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Need Help?</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div>
-            <h4 className="font-medium">Getting Started with Stellar</h4>
-            <p className="text-sm text-muted-foreground">
-              1. Install the{" "}
-              <a
-                href="https://www.freighter.app/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:underline"
-              >
-                Freighter Wallet
-              </a>{" "}
-              browser extension
-            </p>
-            <p className="text-sm text-muted-foreground">
-              2. Create or import a Stellar account
-            </p>
-            <p className="text-sm text-muted-foreground">
-              3. Add USDC trustline in your wallet settings
-            </p>
-            <p className="text-sm text-muted-foreground">
-              4. Fund your wallet with USDC to make purchases
-            </p>
-          </div>
-          {network === "testnet" && (
-            <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
-              <h4 className="font-medium text-blue-800">Testnet Mode</h4>
-              <p className="text-sm text-blue-700">
-                You are on testnet. Get free test XLM from the{" "}
-                <a
-                  href="https://laboratory.stellar.org/#account-creator?network=test"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline"
-                >
-                  Stellar Laboratory
-                </a>
-              </p>
+        {/* ── Help Section ── */}
+        <Panel className="p-6">
+          <CardHeading
+            icon={LifeBuoy}
+            title="Need Help?"
+            subtitle="Get set up with Stellar in a few simple steps"
+          />
+          <div className="space-y-4">
+            <div>
+              <h4 className={cn(poppins_600, "text-sm text-ink")}>
+                Getting Started with Stellar
+              </h4>
+              <ol className="mt-3 space-y-2">
+                <li className="flex items-start gap-3">
+                  <span
+                    className={cn(
+                      poppins_600,
+                      "flex size-6 shrink-0 items-center justify-center rounded-lg border border-accent/10 bg-surface text-xs text-accent"
+                    )}
+                  >
+                    1
+                  </span>
+                  <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                    Install the{" "}
+                    <a
+                      href="https://www.freighter.app/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={cn(poppins_500, "text-secondary hover:text-highlight hover:underline")}
+                    >
+                      Freighter Wallet
+                    </a>{" "}
+                    browser extension
+                  </p>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span
+                    className={cn(
+                      poppins_600,
+                      "flex size-6 shrink-0 items-center justify-center rounded-lg border border-accent/10 bg-surface text-xs text-accent"
+                    )}
+                  >
+                    2
+                  </span>
+                  <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                    Create or import a Stellar account
+                  </p>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span
+                    className={cn(
+                      poppins_600,
+                      "flex size-6 shrink-0 items-center justify-center rounded-lg border border-accent/10 bg-surface text-xs text-accent"
+                    )}
+                  >
+                    3
+                  </span>
+                  <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                    Add USDC trustline in your wallet settings
+                  </p>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span
+                    className={cn(
+                      poppins_600,
+                      "flex size-6 shrink-0 items-center justify-center rounded-lg border border-accent/10 bg-surface text-xs text-accent"
+                    )}
+                  >
+                    4
+                  </span>
+                  <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                    Fund your wallet with USDC to make purchases
+                  </p>
+                </li>
+              </ol>
             </div>
-          )}
-        </CardContent>
-      </Card>
+
+            {network === "testnet" && (
+              <div className="flex items-start gap-3 rounded-xl border border-accent/10 bg-surface p-4">
+                <div className="flex size-9 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+                  <ArrowRight className="h-4 w-4 text-accent" />
+                </div>
+                <div>
+                  <h4 className={cn(poppins_600, "text-sm text-ink")}>
+                    Testnet Mode
+                  </h4>
+                  <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+                    You are on testnet. Get free test XLM from the{" "}
+                    <a
+                      href="https://laboratory.stellar.org/#account-creator?network=test"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className={cn(poppins_500, "text-secondary hover:text-highlight hover:underline")}
+                    >
+                      Stellar Laboratory
+                    </a>
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </Panel>
+      </div>
     </div>
   );
 }

--- a/app/dashboard/ai/layout.js
+++ b/app/dashboard/ai/layout.js
@@ -1,47 +1,69 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
+import { X } from "lucide-react";
 import { AiSidebar } from "@/components/organisms/dashboard/ai/Ai-Sidebar";
-import { usePathname } from "next/navigation";
 
 export default function Layout({ children }) {
   const [currentChatId, setCurrentChatId] = useState(null);
   const [chatData, setChatData] = useState({ messages: [], chatId: null });
-  const pathname = usePathname();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
 
   const handleChatSelect = (chatId, history) => {
     setCurrentChatId(chatId);
     setChatData({ messages: history, chatId });
+    setSidebarOpen(false);
   };
 
   const handleNewChat = () => {
     setCurrentChatId(null);
     setChatData({ messages: [], chatId: null });
+    setSidebarOpen(false);
   };
 
-  return (
-    <div className="w-full h-[calc(100vh-4rem)] flex flex-col overflow-hidden">
-      <div className="flex-1 flex flex-col md:flex-row gap-4 p-2 sm:p-4 h-full">
-        {/* Left Side List - Always visible on desktop, conditional on mobile */}
-        <div
-          className={`bg-muted/50 hidden sm:block rounded-xl p-2 sm:p-4 h-full overflow-y-auto scrollbar-hide transition-all duration-300 md:w-[300px] lg:w-[360px]`}
-        >
-          <AiSidebar
-            onChatSelect={handleChatSelect}
-            currentChatId={currentChatId}
-            onNewChat={handleNewChat}
-          />
-        </div>
+  const sidebar = (
+    <AiSidebar
+      onChatSelect={handleChatSelect}
+      currentChatId={currentChatId}
+      onNewChat={handleNewChat}
+    />
+  );
 
-        {/* Chat Panel (right side) */}
-        <div className=" transition-all duration-300 h-full w-full rounded-xl">
-          {/* Pass chatData to children */}
-          {children &&
-            typeof children === "object" &&
-            React.cloneElement(children, {
-              chatData,
-              onChatUpdate: setCurrentChatId,
-            })}
+  return (
+    <div className="flex h-[calc(100vh-4rem)] overflow-hidden bg-surface">
+      {/* Desktop sidebar */}
+      <aside className="hidden w-72 shrink-0 border-r border-accent/10 bg-surface-raised md:block">
+        {sidebar}
+      </aside>
+
+      {/* Mobile drawer */}
+      {sidebarOpen && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          <div
+            className="absolute inset-0 bg-basic/40 backdrop-blur-sm"
+            onClick={() => setSidebarOpen(false)}
+          />
+          <aside className="absolute left-0 top-0 h-full w-80 max-w-[85%] border-r border-accent/10 bg-surface-raised shadow-2xl">
+            <button
+              onClick={() => setSidebarOpen(false)}
+              className="absolute right-2 top-2 z-10 rounded-lg p-1.5 text-ink-muted transition-colors hover:bg-accent/10 hover:text-accent"
+              aria-label="Close chat history"
+            >
+              <X className="h-5 w-5" />
+            </button>
+            {sidebar}
+          </aside>
         </div>
+      )}
+
+      {/* Chat panel */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        {children &&
+          typeof children === "object" &&
+          React.cloneElement(children, {
+            chatData,
+            onChatUpdate: setCurrentChatId,
+            onOpenSidebar: () => setSidebarOpen(true),
+          })}
       </div>
     </div>
   );

--- a/app/dashboard/ai/page.jsx
+++ b/app/dashboard/ai/page.jsx
@@ -1,7 +1,5 @@
 "use client";
-import { Bot, CornerDownLeft, Mic, Paperclip, ImageIcon } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
-import Button from "@/components/atoms/form/Button";
+import { Bot, CornerDownLeft, Mic, Paperclip, ImageIcon, Menu } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -20,8 +18,84 @@ import { useState, useRef, useEffect } from "react";
 import { toast } from "sonner";
 import ReactMarkdown from "react-markdown";
 import Image from "next/image";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
-export default function Dashboard({ chatData, onChatUpdate }) {
+const markdownComponents = {
+  p: ({ children }) => (
+    <p className={cn(poppins_400, "mb-2 text-sm leading-relaxed text-ink")}>
+      {children}
+    </p>
+  ),
+  h1: ({ children }) => (
+    <h1 className={cn(poppins_600, "mb-2 text-xl text-ink")}>{children}</h1>
+  ),
+  h2: ({ children }) => (
+    <h2 className={cn(poppins_600, "mb-2 text-lg text-ink")}>{children}</h2>
+  ),
+  h3: ({ children }) => (
+    <h3 className={cn(poppins_600, "mb-2 text-base text-ink")}>{children}</h3>
+  ),
+  ul: ({ children }) => (
+    <ul className={cn(poppins_400, "mb-2 list-disc pl-4 text-ink")}>
+      {children}
+    </ul>
+  ),
+  ol: ({ children }) => (
+    <ol className={cn(poppins_400, "mb-2 list-decimal pl-4 text-ink")}>
+      {children}
+    </ol>
+  ),
+  li: ({ children }) => <li className="mb-1">{children}</li>,
+  code: ({ children }) => (
+    <code
+      className={cn(
+        poppins_400,
+        "rounded bg-accent/10 px-1 py-0.5 text-xs text-ink"
+      )}
+    >
+      {children}
+    </code>
+  ),
+  pre: ({ children }) => (
+    <pre
+      className={cn(
+        poppins_400,
+        "mb-2 overflow-x-auto rounded-lg bg-accent/10 p-3 text-xs text-ink"
+      )}
+    >
+      {children}
+    </pre>
+  ),
+};
+
+const SUGGESTIONS = [
+  { emoji: "🕌", question: "What are the 5 pillars of Islam?" },
+  { emoji: "🤲", question: "Explain the importance of Salah" },
+  { emoji: "✨", question: "Tell me about Prophet Muhammad ﷺ" },
+  { emoji: "📖", question: "How do I perform Wudu correctly?" },
+];
+
+const AiAvatar = ({ size = 32 }) => (
+  <span
+    className="flex shrink-0 items-center justify-center overflow-hidden rounded-full"
+    style={{ width: size, height: size }}
+  >
+    <Image
+      src="/images/ai.png"
+      alt="DeenBridge AI"
+      width={size}
+      height={size}
+      className="h-full w-full object-cover"
+    />
+  </span>
+);
+
+export default function Dashboard({ chatData, onChatUpdate, onOpenSidebar }) {
   const { user } = useAuth();
   const [messages, setMessages] = useState([]);
   const [inputMessage, setInputMessage] = useState("");
@@ -127,338 +201,216 @@ export default function Dashboard({ chatData, onChatUpdate }) {
     }
   };
 
+  const isEmpty = messages.length === 0 && !isLoading;
+
   return (
-    <div className="flex flex-col h-full">
-      <div className="relative flex-1 flex flex-col rounded-xl bg-muted/50 p-4 overflow-hidden">
-        <Badge
-          variant="outline"
-          className="absolute right-3 top-3 border-accent"
-        >
-          Output
-        </Badge>
-        <div className="flex-1 overflow-y-auto overscroll-auto mt-6">
-          {/* Welcome Screen - Show when no messages */}
-          {messages.length === 0 && !isLoading && (
-            <div className="flex flex-col items-center justify-center h-full text-center px-4 py-8">
-              {/* AI Image with stunning effects */}
-              <div className="relative mb-8 group">
-                {/* AI Image container */}
-                <div className="relative">
-                  <div className="absolute inset-0 bg-gradient-to-br from-accent/20 to-highlight/20 rounded-full blur-2xl"></div>
-                  <div className="relative bg-gradient-to-br from-background to-muted p-2 rounded-full border-4 border-accent/30 shadow-2xl group-hover:scale-105 transition-transform duration-300">
-                    <Image
-                      src="/images/ai.png"
-                      alt="DeenBridge AI Assistant"
-                      width={140}
-                      height={140}
-                      className="rounded-full"
-                      priority
-                    />
-                  </div>
-                  {/* Floating particles */}
-                  <div className="absolute top-0 right-0 w-3 h-3 bg-accent rounded-full animate-ping"></div>
-                  <div
-                    className="absolute bottom-0 left-0 w-2 h-2 bg-highlight rounded-full animate-ping"
-                    style={{ animationDelay: "0.5s" }}
-                  ></div>
-                </div>
-              </div>
+    <div className="flex h-full flex-col bg-surface">
+      {/* Top bar */}
+      <div className="flex items-center gap-3 border-b border-accent/10 px-3 py-2.5 sm:px-4">
+        {onOpenSidebar && (
+          <button
+            onClick={onOpenSidebar}
+            className="rounded-lg p-2 text-ink-muted transition-colors hover:bg-accent/10 hover:text-accent md:hidden"
+            aria-label="Open chat history"
+          >
+            <Menu className="h-5 w-5" />
+          </button>
+        )}
+        <div className="flex items-center gap-2">
+          <AiAvatar size={28} />
+          <div className="leading-tight">
+            <p className={cn(poppins_600, "text-sm text-ink")}>DeenBridge AI</p>
+            <p className={cn(poppins_400, "text-[11px] text-ink-muted")}>
+              Qur&apos;an &amp; Hadith assistant
+            </p>
+          </div>
+        </div>
+      </div>
 
-              {/* Welcome Text with gradient */}
-              <div className="mb-10 space-y-4 max-w-2xl">
-                <h1 className="text-2xl md:text-3xl font-bold mb-3">
-                  <span className="bg-gradient-to-r from-accent via-highlight to-accent bg-clip-text text-transparent ">
-                    Assalamu Alaikum!
-                  </span>
-                </h1>
-                <p className="text-md md:text-lg text-muted-foreground max-w-xl mx-auto leading-relaxed">
-                  I'm your Islamic AI assistant powered by knowledge of the{" "}
-                  <span className="font-semibold text-accent">Quran</span> and{" "}
-                  <span className="font-semibold text-highlight">Hadith</span>.
-                  How can I help you today?
-                </p>
-
-                {/* AI Features badges */}
-                <div className="flex flex-wrap gap-1 justify-center mt-4">
-                  <span className="px-3 py-1 bg-accent/10 text-highlight text-xs font-medium rounded-full border border-highlight/20">
-                    ✨ AI Powered
-                  </span>
-                  <span className="px-3 py-1 bg-accent/10 text-highlight text-xs font-medium rounded-full border border-highlight/20">
-                    📖 Islamic Knowledge
-                  </span>
-                  <span className="px-3 py-1 bg-accent/10 text-highlight text-xs font-medium rounded-full border border-highlight/20">
-                    🤝 24/7 Available
-                  </span>
-                </div>
-              </div>
-
-              {/* Quick Questions with stunning cards */}
-              <div className="w-full max-w-4xl">
-                <h3 className="text-sm font-semibold text-muted-foreground mb-4 uppercase tracking-wider">
-                  Popular Questions
-                </h3>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                  {[
-                    {
-                      emoji: "🕌",
-                      question: "What are the 5 pillars of Islam?",
-                    },
-                    {
-                      emoji: "🤲",
-                      question: "Explain the importance of Salah",
-                    },
-                    {
-                      emoji: "✨",
-                      question: "Tell me about Prophet Muhammad ﷺ",
-                    }
-                  ].map((item, i) => (
-                    <button
-                      key={i}
-                      onClick={() => setInputMessage(item.question)}
-                      className="group relative p-5 text-left border-2 border-muted/50 rounded-2xl hover:border-accent hover:shadow-lg hover:shadow-accent/20 transition-all duration-300 hover:-translate-y-1 bg-background overflow-hidden"
-                    >
-                      {/* Gradient background on hover */}
-                      <div
-                        className={`absolute inset-0 bg-gradient-to-br from-accent/10 to-highlight/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300`}
-                      ></div>
-
-                      {/* Content */}
-                      <div className="relative flex items-start gap-3">
-                        <span className="text-3xl group-hover:scale-110 transition-transform duration-300">
-                          {item.emoji}
-                        </span>
-                        <span className="text-sm font-medium leading-relaxed flex-1">
-                          {item.question}
-                        </span>
-                      </div>
-
-                      {/* Hover arrow */}
-                      <div className="absolute bottom-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity">
-                        <svg
-                          className="w-4 h-4 text-accent"
-                          fill="none"
-                          stroke="currentColor"
-                          viewBox="0 0 24 24"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            strokeWidth={2}
-                            d="M13 7l5 5m0 0l-5 5m5-5H6"
-                          />
-                        </svg>
-                      </div>
-                    </button>
-                  ))}
-                </div>
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto">
+        {isEmpty ? (
+          <div className="mx-auto flex h-full max-w-2xl flex-col items-center justify-center px-4 py-8 text-center">
+            <div className="relative mb-6">
+              <div className="absolute inset-0 rounded-full bg-gradient-to-br from-secondary/20 to-highlight/20 blur-2xl" />
+              <div className="relative rounded-full border-4 border-accent/20 bg-surface-raised p-2 shadow-xl">
+                <Image
+                  src="/images/ai.png"
+                  alt="DeenBridge AI Assistant"
+                  width={96}
+                  height={96}
+                  className="rounded-full"
+                  priority
+                />
               </div>
             </div>
-          )}
-
-          {/* Messages */}
-          {messages.map((message, index) => (
-            <div
-              key={index}
-              className={`mb-4 flex gap-3 items-start ${
-                message.role === "user" ? "flex-row-reverse" : ""
-              }`}
+            <h1
+              className={cn(
+                poppins_600,
+                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent sm:text-3xl"
+              )}
             >
-              {/* Avatar */}
-              <div className="flex-shrink-0">
-                {message.role === "user" ? (
-                  <Avatar className="h-10 w-10 rounded-lg mt-2">
+              Assalamu Alaikum!
+            </h1>
+            <p
+              className={cn(
+                poppins_400,
+                "mt-3 max-w-md leading-relaxed text-ink-muted"
+              )}
+            >
+              I&apos;m your Islamic AI assistant, grounded in the{" "}
+              <span className={cn(poppins_600, "text-secondary")}>Qur&apos;an</span>{" "}
+              and{" "}
+              <span className={cn(poppins_600, "text-highlight")}>Hadith</span>.
+              How can I help you today?
+            </p>
+
+            <div className="mt-8 grid w-full max-w-xl grid-cols-1 gap-3 sm:grid-cols-2">
+              {SUGGESTIONS.map((item, i) => (
+                <button
+                  key={i}
+                  onClick={() => setInputMessage(item.question)}
+                  className="group flex items-center gap-3 rounded-xl border border-accent/15 bg-surface-raised p-4 text-left transition-all hover:-translate-y-0.5 hover:border-secondary/40 hover:shadow-sm"
+                >
+                  <span className="text-2xl transition-transform group-hover:scale-110">
+                    {item.emoji}
+                  </span>
+                  <span className={cn(poppins_500, "text-sm text-ink")}>
+                    {item.question}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="mx-auto max-w-3xl space-y-6 px-3 py-6 sm:px-4">
+            {messages.map((message, index) =>
+              message.role === "user" ? (
+                <div key={index} className="flex justify-end gap-3">
+                  <div
+                    className={cn(
+                      poppins_400,
+                      "max-w-[85%] whitespace-pre-line rounded-2xl rounded-tr-sm bg-accent/10 px-4 py-2.5 text-sm text-ink"
+                    )}
+                  >
+                    {message.content}
+                  </div>
+                  <Avatar className="mt-0.5 h-8 w-8 shrink-0 rounded-full">
                     <AvatarImage src={user?.avatar} alt={user?.name} />
-                    <AvatarFallback className="bg-accent text-white text-sm">
+                    <AvatarFallback
+                      className={cn(poppins_500, "bg-accent text-xs text-white")}
+                    >
                       {user?.name?.charAt(0) || "U"}
                     </AvatarFallback>
                   </Avatar>
-                ) : (
-                  <div className="w-10 h-10 rounded-full mt-2 overflow-hidden">
-                    <Image
-                      src="/images/ai.png"
-                      alt="AI Assistant"
-                      width={32}
-                      height={32}
-                      className="w-full h-full object-cover"
-                    />
+                </div>
+              ) : (
+                <div key={index} className="flex gap-3">
+                  <AiAvatar size={32} />
+                  <div className="min-w-0 flex-1 pt-0.5">
+                    <ReactMarkdown components={markdownComponents}>
+                      {message.content}
+                    </ReactMarkdown>
                   </div>
-                )}
-              </div>
+                </div>
+              )
+            )}
 
-              {/* Message Content */}
-              <div
-                className={`p-4 rounded-lg max-w-[80%] ${
-                  message.role === "user" ? "bg-accent/10" : "bg-background"
-                }`}
-              >
-                {message.role === "assistant" ? (
-                  <ReactMarkdown
-                    components={{
-                      p: ({ children }) => (
-                        <p className="text-sm mb-2">{children}</p>
-                      ),
-                      h1: ({ children }) => (
-                        <h1 className="text-xl font-bold mb-2">{children}</h1>
-                      ),
-                      h2: ({ children }) => (
-                        <h2 className="text-lg font-bold mb-2">{children}</h2>
-                      ),
-                      h3: ({ children }) => (
-                        <h3 className="text-base font-bold mb-2">
-                          {children}
-                        </h3>
-                      ),
-                      ul: ({ children }) => (
-                        <ul className="list-disc pl-4 mb-2">{children}</ul>
-                      ),
-                      ol: ({ children }) => (
-                        <ol className="list-decimal pl-4 mb-2">{children}</ol>
-                      ),
-                      li: ({ children }) => (
-                        <li className="mb-1">{children}</li>
-                      ),
-                      code: ({ children }) => (
-                        <code className="bg-muted px-1 py-0.5 rounded text-xs">
-                          {children}
-                        </code>
-                      ),
-                      pre: ({ children }) => (
-                        <pre className="bg-muted p-2 rounded text-xs overflow-x-auto mb-2">
-                          {children}
-                        </pre>
-                      ),
-                    }}
-                  >
-                    {message.content}
-                  </ReactMarkdown>
-                ) : (
-                  <p className="text-sm whitespace-pre-line">
-                    {message.content}
-                  </p>
-                )}
-              </div>
-            </div>
-          ))}
-          {isLoading && !streamingContent && (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground bg-accent/10 p-4 rounded-lg w-fit">
-              <Bot className="size-4 animate-bounce" />
-              AI is thinking...
-            </div>
-          )}
-          {isLoading && streamingContent && (
-            <div className="mb-4 flex gap-3 items-start">
-              <div className="w-10 h-10 rounded-full mt-2 overflow-hidden flex-shrink-0">
-                <Image
-                  src="/images/ai.png"
-                  alt="AI Assistant"
-                  width={32}
-                  height={32}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-              <div className="p-4 rounded-lg max-w-[80%] bg-background">
-                <ReactMarkdown
-                  components={{
-                    p: ({ children }) => (
-                      <p className="text-sm mb-2">{children}</p>
-                    ),
-                    h1: ({ children }) => (
-                      <h1 className="text-xl font-bold mb-2">{children}</h1>
-                    ),
-                    h2: ({ children }) => (
-                      <h2 className="text-lg font-bold mb-2">{children}</h2>
-                    ),
-                    h3: ({ children }) => (
-                      <h3 className="text-base font-bold mb-2">{children}</h3>
-                    ),
-                    ul: ({ children }) => (
-                      <ul className="list-disc pl-4 mb-2">{children}</ul>
-                    ),
-                    ol: ({ children }) => (
-                      <ol className="list-decimal pl-4 mb-2">{children}</ol>
-                    ),
-                    li: ({ children }) => (
-                      <li className="mb-1">{children}</li>
-                    ),
-                    code: ({ children }) => (
-                      <code className="bg-muted px-1 py-0.5 rounded text-xs">
-                        {children}
-                      </code>
-                    ),
-                    pre: ({ children }) => (
-                      <pre className="bg-muted p-2 rounded text-xs overflow-x-auto mb-2">
-                        {children}
-                      </pre>
-                    ),
-                  }}
+            {isLoading && !streamingContent && (
+              <div className="flex gap-3">
+                <AiAvatar size={32} />
+                <div
+                  className={cn(
+                    poppins_400,
+                    "flex items-center gap-2 pt-1.5 text-sm text-ink-muted"
+                  )}
                 >
-                  {streamingContent}
-                </ReactMarkdown>
-                <span className="inline-block w-2 h-4 bg-accent animate-pulse" />
+                  <Bot className="size-4 animate-bounce text-accent" />
+                  Thinking…
+                </div>
               </div>
-            </div>
-          )}
-          <div ref={messagesEndRef} />
-        </div>
+            )}
+
+            {isLoading && streamingContent && (
+              <div className="flex gap-3">
+                <AiAvatar size={32} />
+                <div className="min-w-0 flex-1 pt-0.5">
+                  <ReactMarkdown components={markdownComponents}>
+                    {streamingContent}
+                  </ReactMarkdown>
+                  <span className="ml-0.5 inline-block h-4 w-2 animate-pulse bg-accent align-middle" />
+                </div>
+              </div>
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+        )}
+      </div>
+
+      {/* Composer */}
+      <div className="border-t border-accent/10 bg-surface px-3 py-3 sm:px-4">
         <form
           onSubmit={handleSubmit}
-          className="mt-4 overflow-hidden rounded-lg border bg-background focus-within:ring-1 focus-within:ring-accent"
+          className="mx-auto max-w-3xl overflow-hidden rounded-2xl border border-accent/15 bg-surface-raised shadow-sm transition-shadow focus-within:border-secondary focus-within:ring-2 focus-within:ring-secondary/20"
         >
           <Label htmlFor="message" className="sr-only">
             Message
           </Label>
           <Textarea
             id="message"
-            placeholder="Type your message here... (Press Enter to send)"
-            className="min-h-12 resize-none border-0 p-3 shadow-none focus-visible:ring-0"
+            placeholder="Message DeenBridge AI…  (Enter to send, Shift+Enter for newline)"
+            className={cn(
+              poppins_400,
+              "min-h-12 resize-none border-0 bg-transparent p-3 text-ink shadow-none focus-visible:ring-0"
+            )}
             value={inputMessage}
             onChange={(e) => setInputMessage(e.target.value)}
             onKeyDown={handleKeyDown}
             disabled={isLoading}
           />
-          <div className="flex justify-between items-center p-3 pt-0">
-            <div>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button className="p-2 h-auto">
-                    <Paperclip className="size-4" />
-                    <span className="sr-only">Attach file</span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top">Attach File</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button className="p-2 h-auto">
-                    <ImageIcon className="size-4" />
-                    <span className="sr-only">Attach Image</span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top">Attach Image</TooltipContent>
-              </Tooltip>
-
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button className="p-2 h-auto">
-                    <Mic className="size-4" />
-                    <span className="sr-only">Use Microphone</span>
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="top">Use Microphone</TooltipContent>
-              </Tooltip>
+          <div className="flex items-center justify-between px-3 pb-2.5 pt-0">
+            <div className="flex items-center gap-1">
+              {[
+                { icon: Paperclip, label: "Attach File" },
+                { icon: ImageIcon, label: "Attach Image" },
+                { icon: Mic, label: "Use Microphone" },
+              ].map(({ icon: Icon, label }) => (
+                <Tooltip key={label}>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className="rounded-lg p-2 text-ink-muted transition-colors hover:bg-accent/10 hover:text-accent"
+                    >
+                      <Icon className="size-4" />
+                      <span className="sr-only">{label}</span>
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">{label}</TooltipContent>
+                </Tooltip>
+              ))}
             </div>
-            <div>
-              <Button
-                round
-                type="submit"
-                className="text-sm ml-auto gap-1.5 text-white flex justify-end bg-accent hover:bg-highlight"
-                disabled={isLoading || !inputMessage.trim()}
-              >
-                <CornerDownLeft className="size-3.5" />
-              </Button>
-            </div>
+            <button
+              type="submit"
+              disabled={isLoading || !inputMessage.trim()}
+              className={cn(
+                poppins_500,
+                "flex size-9 items-center justify-center rounded-xl bg-accent text-white transition-colors hover:bg-highlight disabled:cursor-not-allowed disabled:opacity-40"
+              )}
+              aria-label="Send message"
+            >
+              <CornerDownLeft className="size-4" />
+            </button>
           </div>
         </form>
+        <p
+          className={cn(
+            poppins_400,
+            "mx-auto mt-2 max-w-3xl text-center text-[11px] text-ink-muted"
+          )}
+        >
+          DeenBridge AI can make mistakes — verify important rulings with a
+          qualified scholar.
+        </p>
       </div>
     </div>
   );

--- a/app/dashboard/courses/[courseId]/CourseDetailPageClient.jsx
+++ b/app/dashboard/courses/[courseId]/CourseDetailPageClient.jsx
@@ -13,9 +13,29 @@ import { useHasCourse, usePurchaseCourse } from "@/hooks/usePurchase";
 import { useCourseProgress, formatTime } from "@/hooks/useCourseProgress";
 import { Progress } from "@/components/ui/progress";
 import { toast } from "sonner";
-import { Wallet, RotateCcw, Play } from "lucide-react";
+import {
+  Wallet,
+  RotateCcw,
+  Play,
+  Star,
+  BookOpen,
+  Tag,
+  Users,
+  MessageSquare,
+  Lock,
+  CheckCircle2,
+  GraduationCap,
+  Clock,
+  BarChart3,
+} from "lucide-react";
 import PaymentModal from "@/components/stellar/PaymentModal";
 import { useStellar } from "@/components/stellar/StellarProvider";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 // Vidstack (@vidstack/react) is a large dependency only needed once a
 // learner actually opens the player, so it's kept out of the initial
@@ -30,6 +50,35 @@ const VidPlayerBox = dynamic(
       </div>
     ),
   }
+);
+
+/* ── building blocks (design-system consistent) ── */
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
+
+const SectionHeading = ({ icon: Icon, title, subtitle }) => (
+  <div className="mb-5 flex items-start gap-3">
+    <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+      <Icon className="h-5 w-5 text-accent" />
+    </div>
+    <div className="pt-0.5">
+      <h2 className={cn(poppins_600, "text-lg text-ink")}>{title}</h2>
+      {subtitle && (
+        <p className={cn(poppins_400, "mt-0.5 text-sm text-ink-muted")}>
+          {subtitle}
+        </p>
+      )}
+    </div>
+  </div>
 );
 
 export default function CourseDetailClient({ course }) {
@@ -136,266 +185,443 @@ export default function CourseDetailClient({ course }) {
   const canAccess =
     hasCourse || purchased || user?._id === course.createdBy?._id;
 
+  const isCreator = user?._id === course.createdBy?._id;
+  const reviewCount = course.reviews?.length || 0;
+  const avgRating = reviewCount
+    ? course.reviews.reduce((sum, r) => sum + (r.rating || 0), 0) / reviewCount
+    : 0;
+  const priceLabel = course.price === 0 ? "Free" : `$${course.price}`;
+
   return (
-    <div className="max-w-full px-2 sm:px-4 py-4">
-      <h2 className="text-3xl font-extrabold mb-6">
-        {canAccess ? "Watch Course" : "Course Preview"}
-      </h2>
-
-      {canAccess ? (
-        <div className="w-full mb-8 rounded-xl">
-          {progress.percent > 0 && !progress.completed && resumeLabel && !useResume && (
-            <div className="mb-4 p-4 bg-accent/10 border border-accent/30 rounded-xl flex flex-col sm:flex-row items-center justify-between gap-3">
-              <div className="flex items-center gap-3">
-                <Play className="h-5 w-5 text-accent" />
-                <div>
-                  <p className="font-semibold text-sm">{resumeLabel}</p>
-                  <Progress value={progress.percent} className="w-48 h-1.5 mt-1" />
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  round
-                  className="bg-accent hover:bg-accent/90 text-white text-sm font-semibold px-4"
-                  onClick={handleResume}
+    <div className="min-h-screen bg-surface px-3 py-5 sm:px-6 sm:py-6">
+      <div className="mx-auto max-w-6xl space-y-6">
+        {/* ── Course header ── */}
+        <Panel className="relative overflow-hidden bg-gradient-to-br from-secondary/10 via-surface-raised to-highlight/10 p-5 sm:p-7">
+          <div className="pointer-events-none absolute -right-10 -top-10 h-40 w-40 rounded-full bg-secondary/10 blur-3xl" />
+          <div className="relative space-y-4">
+            <div className="flex flex-wrap items-center gap-2">
+              {course.category && (
+                <span
+                  className={cn(
+                    poppins_500,
+                    "inline-flex items-center gap-1.5 rounded-full border border-secondary/20 bg-secondary/10 px-3 py-1 text-xs capitalize text-accent"
+                  )}
                 >
-                  <Play className="h-4 w-4 mr-1" />
-                  Resume
-                </Button>
-                <Button
-                  round
-                  outlined
-                  className="text-sm px-4"
-                  onClick={handleStartOver}
-                >
-                  <RotateCcw className="h-4 w-4 mr-1" />
-                  Start Over
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {progress.completed && (
-            <div className="mb-4 p-3 bg-green-50 border border-green-200 rounded-xl flex items-center gap-2">
-              <span className="text-green-600 font-semibold text-sm">
-                ✅ Course Completed
-              </span>
-              <Button
-                round
-                outlined
-                className="text-xs ml-auto px-3 py-1"
-                onClick={handleStartOver}
-              >
-                <RotateCcw className="h-3 w-3 mr-1" />
-                Watch Again
-              </Button>
-            </div>
-          )}
-
-          <div className="w-full aspect-video rounded-xl overflow-hidden">
-            <VidPlayerBox
-              key={playerKey}
-              data={course}
-              startTime={effectiveStartTime}
-              onTimeUpdate={handleTimeUpdate}
-              onEnded={handleEnded}
-            />
-          </div>
-
-          {progress.percent > 0 && (
-            <div className="mt-3">
-              <div className="flex justify-between text-xs text-muted-foreground mb-1">
-                <span>{progress.percent}% complete</span>
-                <span>{formatTime(progress.positionSeconds)} / {formatTime(progress.durationSeconds)}</span>
-              </div>
-              <Progress value={progress.percent} className="h-1.5" />
-            </div>
-          )}
-        </div>
-      ) : (
-        <div className="w-full aspect-video mb-8 relative rounded-xl overflow-hidden">
-          <div className="absolute inset-0 bg-gradient-to-br from-accent/20 to-highlight/20 backdrop-blur-sm z-10 flex items-center justify-center">
-            <div className="text-center space-y-4 p-8 bg-background/90 rounded-xl shadow-2xl">
-              <h3 className="text-2xl font-bold">🔒 Course Locked</h3>
-              <p className="text-muted-foreground">
-                Purchase this course to unlock full access
-              </p>
-              <div className="text-4xl font-bold text-brand-text">
-                {course.price === 0 ? "Free" : `$${course.price}`}
-              </div>
-            </div>
-          </div>
-          <img
-            src={course.thumbnail || "/images/dnb.png"}
-            alt={course.title}
-            className="w-full h-full object-cover blur-sm"
-          />
-        </div>
-      )}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 px-2 sm:px-10">
-        <div className="lg:col-span-2 space-y-4">
-          <h3 className="text-4xl font-semibold">{course.title}</h3>
-          <p className="text-muted-foreground leading-relaxed">{course.description}</p>
-          <Link
-            href={`/account/profile/${course.createdBy?._id}`}
-            className="flex items-center gap-2"
-          >
-            <Avatar className="h-10 w-10 rounded-lg">
-              <AvatarImage
-                src={course.createdBy?.avatar || "/images/img1.jpeg"}
-              />
-              <AvatarFallback>
-                {course.createdBy?.name?.charAt(0) || "A"}
-              </AvatarFallback>
-            </Avatar>
-            <div className="flex flex-row justify-between items-center">
-              <div className="flex  justify-between   pt-2">
-                <span className="font-medium text-foreground">
-                  {course.createdBy?.name || "Unknown creator"}
-                </span>
-                <span className="text-sm text-muted-foreground">
-                  {course.createdBy?.role || "Unknown creator"}
-                </span>
-              </div>
-              <div className="border-t pt-4 text-muted-foreground text-sm space-y-2">
-                <p>
-                  <strong>Duration:</strong> {course.duration || "N/A"}
-                </p>
-                <p>
-                  <strong>Level:</strong> {course.level || "Beginner"}
-                </p>
-              </div>
-            </div>
-          </Link>
-          {user?._id !== course.createdBy?._id && canAccess && (
-            <div className="pt-10 space-y-5 border-t border-border">
-              {userReview && (
-                <div className="text-sm text-muted-foreground">
-                  You reviewed this course on{" "}
-                  {new Date(userReview.createdAt).toLocaleDateString("en-US", {
-                    year: "numeric",
-                    month: "long",
-                    day: "numeric",
-                  })}
-                  .
-                </div>
-              )}
-              {!submitted && !userReview && (
-                <>
-                  <h2 className="text-3xl font-semibold">Leave a Review</h2>
-                  <form onSubmit={handleSubmit} className="space-y-4">
-                    <StarRate
-                      value={rating}
-                      onChange={setRating}
-                      maxStars={5}
-                      editable={!submitting && !submitted}
-                      label={
-                        rating > 0
-                          ? `Your rating: ${rating} star${
-                              rating > 1 ? "s" : ""
-                            }`
-                          : undefined
-                      }
-                    />
-                    <Textarea
-                      placeholder="What did you think about the course?"
-                      className="bg-muted/50 min-h-[120px] border-accent focus:outline-none"
-                      value={review}
-                      onChange={(e) => setReview(e.target.value)}
-                      disabled={submitting || submitted}
-                    />
-                    {error && (
-                      <div className="text-red-500 text-sm">{error}</div>
-                    )}
-                    <Button
-                      wide
-                      round
-                      className="bg-accent hover:bg-highlight font-semibold mt-2 transition"
-                      type="submit"
-                      disabled={
-                        submitting || rating === 0 || review.trim() === ""
-                      }
-                      loading={submitting}
-                    >
-                      Submit Review
-                    </Button>
-                  </form>
-                </>
-              )}
-            </div>
-          )}
-        </div>
-        <aside className="space-y-4">
-          <div className="border rounded-xl p-6 shadow-lg bg-card space-y-6 sticky top-4">
-            <div className="text-center space-y-2">
-              <p className="text-sm text-muted-foreground">Course Price</p>
-              <div className="text-5xl font-bold text-brand-text">
-                {course.price === 0 ? "Free" : `$${course.price}`}
-              </div>
-            </div>
-
-            {!hasCourse && !purchased && user?._id !== course.createdBy?._id ? (
-              <div className="space-y-2">
-                <Button
-                  wide
-                  round
-                  onClick={handlePurchaseCourse}
-                  loading={loading}
-                  className="w-full bg-accent hover:bg-accent/90 text-white font-semibold py-6 text-lg"
-                >
-                  <Wallet className="w-5 h-5 mr-2" />
-                  {course.price === 0
-                    ? "Enroll Now - Free!"
-                    : `Pay $${course.price} with Stellar`}
-                </Button>
-                {!creatorHasWallet && course.price > 0 && (
-                  <p className="text-sm text-orange-500 text-center">
-                    Note: Creator has not connected their Stellar wallet yet
-                  </p>
-                )}
-              </div>
-            ) : canAccess ? (
-              <div className="bg-green-50 dark:bg-green-950 border border-green-200 dark:border-green-900 rounded-lg p-4 text-center">
-                <p className="text-green-800 dark:text-green-200 font-semibold">
-                  ✅ You have access to this course
-                </p>
-              </div>
-            ) : null}
-
-            <div className="space-y-3 pt-4 border-t">
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">
-                  Students Enrolled
-                </span>
-                <span className="font-semibold">
-                  {course.enrolledUsers?.length || 0}
-                </span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">Reviews</span>
-                <span className="font-semibold">
-                  {course.reviews?.length || 0}
-                </span>
-              </div>
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">Category</span>
-                <span className="font-semibold text-brand-text capitalize">
+                  <Tag className="h-3.5 w-3.5" />
                   {course.category}
                 </span>
+              )}
+              <span
+                className={cn(
+                  poppins_500,
+                  "inline-flex items-center gap-1.5 rounded-full border border-accent/10 bg-surface px-3 py-1 text-xs text-ink-muted"
+                )}
+              >
+                <BarChart3 className="h-3.5 w-3.5 text-accent" />
+                {course.level || "Beginner"}
+              </span>
+              {course.duration && (
+                <span
+                  className={cn(
+                    poppins_500,
+                    "inline-flex items-center gap-1.5 rounded-full border border-accent/10 bg-surface px-3 py-1 text-xs text-ink-muted"
+                  )}
+                >
+                  <Clock className="h-3.5 w-3.5 text-accent" />
+                  {course.duration}
+                </span>
+              )}
+            </div>
+
+            <h1 className={cn(poppins_600, "text-2xl leading-tight text-ink sm:text-3xl")}>
+              {course.title}
+            </h1>
+
+            <div className="flex flex-wrap items-center gap-x-5 gap-y-3">
+              <Link
+                href={`/account/profile/${course.createdBy?._id}`}
+                className="group flex items-center gap-2.5"
+              >
+                <Avatar className="h-9 w-9 rounded-lg">
+                  <AvatarImage src={course.createdBy?.avatar || "/images/img1.jpeg"} />
+                  <AvatarFallback>
+                    {course.createdBy?.name?.charAt(0) || "A"}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="leading-tight">
+                  <p className={cn(poppins_500, "text-sm text-ink group-hover:text-secondary")}>
+                    {course.createdBy?.name || "Unknown creator"}
+                  </p>
+                  <p className={cn(poppins_400, "text-xs capitalize text-ink-muted")}>
+                    {course.createdBy?.role || "Educator"}
+                  </p>
+                </div>
+              </Link>
+
+              <div className="flex items-center gap-2">
+                <div className="flex items-center gap-0.5">
+                  {[1, 2, 3, 4, 5].map((s) => (
+                    <Star
+                      key={s}
+                      className={cn(
+                        "h-4 w-4",
+                        s <= Math.round(avgRating)
+                          ? "fill-yellow-400 text-yellow-400"
+                          : "text-ink-muted/30"
+                      )}
+                    />
+                  ))}
+                </div>
+                <span className={cn(poppins_600, "text-sm text-ink")}>
+                  {avgRating > 0 ? avgRating.toFixed(1) : "New"}
+                </span>
+                <span className={cn(poppins_400, "text-xs text-ink-muted")}>
+                  ({reviewCount} {reviewCount === 1 ? "review" : "reviews"})
+                </span>
               </div>
             </div>
           </div>
-        </aside>
-      </div>
+        </Panel>
 
-      <div className="px-2 sm:px-10 mt-12">
-        <h2 className="text-3xl font-semibold mb-6">Reviews</h2>
-        <ReviewsSection
-          reviews={course.reviews || []}
-          currentUserId={user?._id}
-          loading={false}
-          enableEditDelete={false}
-        />
+        {/* ── Main + sidebar ── */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          {/* Main column */}
+          <div className="space-y-6 lg:col-span-2">
+            {/* Player / preview */}
+            {canAccess ? (
+              <div className="space-y-4">
+                <Panel className="overflow-hidden p-2 sm:p-3">
+                  <div className="w-full aspect-video overflow-hidden rounded-xl">
+                    <VidPlayerBox
+                      key={playerKey}
+                      data={course}
+                      startTime={effectiveStartTime}
+                      onTimeUpdate={handleTimeUpdate}
+                      onEnded={handleEnded}
+                    />
+                  </div>
+                </Panel>
+
+                {progress.percent > 0 &&
+                  !progress.completed &&
+                  resumeLabel &&
+                  !useResume && (
+                    <Panel className="flex flex-col items-center justify-between gap-3 border-accent/20 bg-accent/5 p-4 sm:flex-row">
+                      <div className="flex items-center gap-3">
+                        <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+                          <Play className="h-5 w-5 text-accent" />
+                        </div>
+                        <div>
+                          <p className={cn(poppins_500, "text-sm text-ink")}>
+                            {resumeLabel}
+                          </p>
+                          <Progress
+                            value={progress.percent}
+                            className="mt-1.5 h-1.5 w-48"
+                          />
+                        </div>
+                      </div>
+                      <div className="flex gap-2">
+                        <Button
+                          round
+                          className="bg-accent px-4 text-sm font-semibold text-white hover:bg-accent/90"
+                          onClick={handleResume}
+                        >
+                          <Play className="mr-1 h-4 w-4" />
+                          Resume
+                        </Button>
+                        <Button
+                          round
+                          outlined
+                          className="px-4 text-sm"
+                          onClick={handleStartOver}
+                        >
+                          <RotateCcw className="mr-1 h-4 w-4" />
+                          Start Over
+                        </Button>
+                      </div>
+                    </Panel>
+                  )}
+
+                {progress.completed && (
+                  <Panel className="flex items-center gap-2 border-secondary/20 bg-secondary/5 p-4">
+                    <CheckCircle2 className="h-5 w-5 text-secondary" />
+                    <span className={cn(poppins_500, "text-sm text-ink")}>
+                      Course Completed
+                    </span>
+                    <Button
+                      round
+                      outlined
+                      className="ml-auto px-3 py-1 text-xs"
+                      onClick={handleStartOver}
+                    >
+                      <RotateCcw className="mr-1 h-3 w-3" />
+                      Watch Again
+                    </Button>
+                  </Panel>
+                )}
+
+                {progress.percent > 0 && (
+                  <Panel className="p-4">
+                    <div
+                      className={cn(
+                        poppins_500,
+                        "mb-1.5 flex justify-between text-xs text-ink-muted"
+                      )}
+                    >
+                      <span className="text-ink">{progress.percent}% complete</span>
+                      <span>
+                        {formatTime(progress.positionSeconds)} /{" "}
+                        {formatTime(progress.durationSeconds)}
+                      </span>
+                    </div>
+                    <Progress value={progress.percent} className="h-1.5" />
+                  </Panel>
+                )}
+              </div>
+            ) : (
+              <div className="relative aspect-video w-full overflow-hidden rounded-2xl border border-accent/10 shadow-sm">
+                <div className="absolute inset-0 z-10 flex items-center justify-center bg-gradient-to-br from-accent/20 to-highlight/20 backdrop-blur-sm">
+                  <div className="space-y-4 rounded-2xl border border-accent/10 bg-surface-raised/95 p-8 text-center shadow-xl">
+                    <div className="mx-auto flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+                      <Lock className="h-7 w-7 text-accent" />
+                    </div>
+                    <h3 className={cn(poppins_600, "text-xl text-ink")}>
+                      Course Locked
+                    </h3>
+                    <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                      Purchase this course to unlock full access
+                    </p>
+                    <div className={cn(poppins_600, "text-3xl text-accent")}>
+                      {priceLabel}
+                    </div>
+                  </div>
+                </div>
+                <img
+                  src={course.thumbnail || "/images/dnb.png"}
+                  alt={course.title}
+                  className="h-full w-full object-cover blur-sm"
+                />
+              </div>
+            )}
+
+            {/* About this course */}
+            <Panel className="p-5 sm:p-6">
+              <SectionHeading
+                icon={BookOpen}
+                title="About this course"
+                subtitle="What you'll be learning"
+              />
+              <p className={cn(poppins_400, "leading-relaxed text-ink-muted")}>
+                {course.description}
+              </p>
+
+              <div className="mt-5 grid grid-cols-2 gap-3 border-t border-accent/10 pt-5 sm:grid-cols-3">
+                <div>
+                  <p className={cn(poppins_400, "text-xs text-ink-muted")}>Duration</p>
+                  <p className={cn(poppins_500, "text-sm text-ink")}>
+                    {course.duration || "N/A"}
+                  </p>
+                </div>
+                <div>
+                  <p className={cn(poppins_400, "text-xs text-ink-muted")}>Level</p>
+                  <p className={cn(poppins_500, "text-sm capitalize text-ink")}>
+                    {course.level || "Beginner"}
+                  </p>
+                </div>
+                <div>
+                  <p className={cn(poppins_400, "text-xs text-ink-muted")}>Category</p>
+                  <p className={cn(poppins_500, "text-sm capitalize text-ink")}>
+                    {course.category || "General"}
+                  </p>
+                </div>
+              </div>
+            </Panel>
+
+            {/* Reviews */}
+            <Panel className="p-5 sm:p-6">
+              <SectionHeading
+                icon={MessageSquare}
+                title="Reviews"
+                subtitle={`${reviewCount} learner ${
+                  reviewCount === 1 ? "review" : "reviews"
+                }`}
+              />
+
+              {!isCreator && canAccess && (
+                <div className="mb-6 space-y-5">
+                  {userReview && (
+                    <div
+                      className={cn(
+                        poppins_400,
+                        "rounded-xl border border-accent/10 bg-surface p-4 text-sm text-ink-muted"
+                      )}
+                    >
+                      You reviewed this course on{" "}
+                      {new Date(userReview.createdAt).toLocaleDateString("en-US", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                      .
+                    </div>
+                  )}
+                  {!submitted && !userReview && (
+                    <div className="rounded-xl border border-accent/10 bg-surface p-4 sm:p-5">
+                      <h3 className={cn(poppins_600, "text-base text-ink")}>
+                        Leave a Review
+                      </h3>
+                      <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+                        <StarRate
+                          value={rating}
+                          onChange={setRating}
+                          maxStars={5}
+                          editable={!submitting && !submitted}
+                          label={
+                            rating > 0
+                              ? `Your rating: ${rating} star${
+                                  rating > 1 ? "s" : ""
+                                }`
+                              : undefined
+                          }
+                        />
+                        <Textarea
+                          placeholder="What did you think about the course?"
+                          className="min-h-[120px] border-accent/20 bg-surface-raised focus:outline-none"
+                          value={review}
+                          onChange={(e) => setReview(e.target.value)}
+                          disabled={submitting || submitted}
+                        />
+                        {error && (
+                          <div className={cn(poppins_400, "text-sm text-red-600")}>
+                            {error}
+                          </div>
+                        )}
+                        <Button
+                          wide
+                          round
+                          className="mt-1 bg-accent font-semibold text-white transition hover:bg-highlight"
+                          type="submit"
+                          disabled={
+                            submitting || rating === 0 || review.trim() === ""
+                          }
+                          loading={submitting}
+                        >
+                          Submit Review
+                        </Button>
+                      </form>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <ReviewsSection
+                reviews={course.reviews || []}
+                currentUserId={user?._id}
+                loading={false}
+                enableEditDelete={false}
+              />
+            </Panel>
+          </div>
+
+          {/* Right sidebar */}
+          <aside className="lg:col-span-1">
+            <Panel className="sticky top-4 space-y-5 p-6">
+              {canAccess && !isCreator && (
+                <div className="flex items-center gap-2 rounded-xl border border-secondary/20 bg-secondary/5 px-3 py-2">
+                  <GraduationCap className="h-4 w-4 text-secondary" />
+                  <span className={cn(poppins_500, "text-xs text-ink")}>
+                    Enrolled
+                  </span>
+                </div>
+              )}
+
+              <div className="text-center">
+                <p className={cn(poppins_400, "text-xs uppercase tracking-wider text-ink-muted")}>
+                  Course Price
+                </p>
+                <div className={cn(poppins_600, "mt-1 text-4xl text-accent")}>
+                  {priceLabel}
+                </div>
+              </div>
+
+              {!hasCourse && !purchased && !isCreator ? (
+                <div className="space-y-2">
+                  <Button
+                    wide
+                    round
+                    onClick={handlePurchaseCourse}
+                    loading={loading}
+                    className="w-full bg-accent py-6 text-lg font-semibold text-white hover:bg-accent/90"
+                  >
+                    <Wallet className="mr-2 h-5 w-5" />
+                    {course.price === 0
+                      ? "Enroll Now - Free!"
+                      : `Pay $${course.price} with Stellar`}
+                  </Button>
+                  {!creatorHasWallet && course.price > 0 && (
+                    <p className={cn(poppins_400, "text-center text-xs text-ink-muted")}>
+                      Note: Creator has not connected their Stellar wallet yet
+                    </p>
+                  )}
+                </div>
+              ) : canAccess ? (
+                <div className="space-y-3">
+                  <div className="flex items-center justify-center gap-2 rounded-xl border border-secondary/20 bg-secondary/5 p-4 text-center">
+                    <CheckCircle2 className="h-5 w-5 text-secondary" />
+                    <p className={cn(poppins_500, "text-sm text-ink")}>
+                      You own this course
+                    </p>
+                  </div>
+                  {progress.percent > 0 && (
+                    <div className="rounded-xl border border-accent/10 bg-surface p-4">
+                      <div
+                        className={cn(
+                          poppins_500,
+                          "mb-1.5 flex items-center justify-between text-xs"
+                        )}
+                      >
+                        <span className="text-ink-muted">Your progress</span>
+                        <span className="text-accent">{progress.percent}%</span>
+                      </div>
+                      <Progress value={progress.percent} className="h-1.5" />
+                    </div>
+                  )}
+                </div>
+              ) : null}
+
+              <div className="space-y-3 border-t border-accent/10 pt-5">
+                <div className="flex items-center justify-between">
+                  <span className={cn(poppins_400, "flex items-center gap-2 text-sm text-ink-muted")}>
+                    <Users className="h-4 w-4 text-accent" />
+                    Students Enrolled
+                  </span>
+                  <span className={cn(poppins_600, "text-sm text-ink")}>
+                    {course.enrolledUsers?.length || 0}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className={cn(poppins_400, "flex items-center gap-2 text-sm text-ink-muted")}>
+                    <MessageSquare className="h-4 w-4 text-accent" />
+                    Reviews
+                  </span>
+                  <span className={cn(poppins_600, "text-sm text-ink")}>
+                    {reviewCount}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span className={cn(poppins_400, "flex items-center gap-2 text-sm text-ink-muted")}>
+                    <Tag className="h-4 w-4 text-accent" />
+                    Category
+                  </span>
+                  <span className={cn(poppins_600, "text-sm capitalize text-ink")}>
+                    {course.category}
+                  </span>
+                </div>
+              </div>
+            </Panel>
+          </aside>
+        </div>
       </div>
 
       <PaymentModal

--- a/app/dashboard/courses/page.jsx
+++ b/app/dashboard/courses/page.jsx
@@ -4,12 +4,17 @@ import { GraduationCap, Bookmark, Plus } from "lucide-react";
 import CourseCard from "@/components/molecules/dashboard/cards/courseCard";
 import CourseCardSkeleton from "@/components/atoms/skeletons/CourseCardSkeleton";
 import Button from "@/components/atoms/form/Button";
-import { Card, CardContent } from "@/components/ui/card";
 import { fetchCourses } from "@/lib/actions/courses/fetch-courses";
 import { getBookmarkedCourses } from "@/lib/actions/courses/bookmark-course";
 import useAuth from "@/hooks/useAuth";
 import { useAllCourseProgress } from "@/hooks/useCourseProgress";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 export default function CoursesPage() {
   const { user } = useAuth();
@@ -51,24 +56,33 @@ export default function CoursesPage() {
   }
 
   return (
-    <div className="p-4 sm:p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <GraduationCap className="h-6 w-6 text-brand-text" />
-            {showBookmarks ? "My Bookmarked Courses" : "All Courses"}
-          </h1>
-          <p className="text-muted-foreground text-sm mt-1">
-            {showBookmarks
-              ? "Courses you've saved for later"
-              : "Browse and enroll in courses"}
-          </p>
+    <div className="space-y-6 bg-surface p-4 sm:p-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+            <GraduationCap className="h-5 w-5 text-accent" />
+          </div>
+          <div>
+            <h1
+              className={cn(
+                poppins_600,
+                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+              )}
+            >
+              {showBookmarks ? "My Bookmarked Courses" : "All Courses"}
+            </h1>
+            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+              {showBookmarks
+                ? "Courses you've saved for later"
+                : "Browse and enroll in courses"}
+            </p>
+          </div>
         </div>
         <div className="flex gap-2">
           <Button
             round
             outlined
-            onClick={() => window.location.href = "/dashboard/courses/create"}
+            onClick={() => (window.location.href = "/dashboard/courses/create")}
           >
             <Plus className="h-4 w-4 mr-1" />
             Create
@@ -92,14 +106,21 @@ export default function CoursesPage() {
           ))}
         </div>
       ) : courses.length === 0 ? (
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
-            <GraduationCap className="h-12 w-12 text-muted-foreground" />
+        <div className="rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
+          <div className="flex flex-col items-center justify-center space-y-4 py-16 text-center">
+            <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+              <GraduationCap className="h-7 w-7 text-accent" />
+            </div>
             <div>
-              <h3 className="font-semibold text-lg">
+              <h3 className={cn(poppins_600, "text-lg text-ink")}>
                 {showBookmarks ? "No Bookmarked Courses" : "No Courses Yet"}
               </h3>
-              <p className="text-muted-foreground text-sm mt-1 max-w-md">
+              <p
+                className={cn(
+                  poppins_400,
+                  "mt-1 max-w-md text-sm text-ink-muted"
+                )}
+              >
                 {showBookmarks
                   ? "Start bookmarking courses you're interested in!"
                   : "No courses available at the moment."}
@@ -109,13 +130,15 @@ export default function CoursesPage() {
               <Button
                 round
                 outlined
-                onClick={() => window.location.href = "/dashboard/courses/create"}
+                onClick={() =>
+                  (window.location.href = "/dashboard/courses/create")
+                }
               >
                 Create Course
               </Button>
             )}
-          </CardContent>
-        </Card>
+          </div>
+        </div>
       ) : (
         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
           {courses

--- a/app/dashboard/earnings/page.jsx
+++ b/app/dashboard/earnings/page.jsx
@@ -1,8 +1,12 @@
 "use client";
 import { useState } from "react";
-import { DollarSign, ShoppingCart, TrendingUp, TrendingDown, Wallet } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import {
+  DollarSign,
+  ShoppingCart,
+  TrendingUp,
+  TrendingDown,
+  Wallet,
+} from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import Button from "@/components/atoms/form/Button";
 import {
@@ -14,60 +18,134 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts";
 import WalletConnectButton from "@/components/stellar/WalletConnectButton";
 import useEarnings from "@/hooks/useEarnings";
 import Link from "next/link";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
-const statusColors = {
-  confirmed: "bg-success/10 text-success",
-  pending: "bg-warning/10 text-warning",
-  submitted: "bg-info/10 text-info",
-  failed: "bg-error/10 text-error",
-  expired: "bg-muted text-muted-foreground",
+const statusStyles = {
+  confirmed: "bg-secondary/10 text-secondary border-secondary/20",
+  pending: "bg-amber-100 text-amber-700 border-amber-200",
+  submitted: "bg-sky-100 text-sky-700 border-sky-200",
+  failed: "bg-red-100 text-red-600 border-red-200",
+  expired: "bg-ink/5 text-ink-muted border-accent/10",
 };
+
+/* ── building blocks (design-system consistent) ── */
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
+
+const PageHeader = () => (
+  <div className="flex items-center gap-3">
+    <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+      <DollarSign className="h-5 w-5 text-accent" />
+    </div>
+    <div>
+      <h1
+        className={cn(
+          poppins_600,
+          "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+        )}
+      >
+        Earnings Dashboard
+      </h1>
+      <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+        Track your sales, revenue, and payout analytics
+      </p>
+    </div>
+  </div>
+);
+
+const SectionHeading = ({ title, subtitle, right }) => (
+  <div className="mb-5 flex items-start justify-between gap-3">
+    <div>
+      <h2 className={cn(poppins_600, "text-lg text-ink")}>{title}</h2>
+      {subtitle && (
+        <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+          {subtitle}
+        </p>
+      )}
+    </div>
+    {right}
+  </div>
+);
+
+const StatusBadge = ({ status, small }) => (
+  <span
+    className={cn(
+      poppins_500,
+      "inline-flex items-center rounded-full border capitalize",
+      small ? "px-2 py-0.5 text-[11px]" : "px-3 py-1 text-xs",
+      statusStyles[status] || statusStyles.expired
+    )}
+  >
+    {status}
+  </span>
+);
 
 function SummaryTile({ icon: Icon, label, value, subtext, trend, trendLabel }) {
   return (
-    <Card>
-      <CardContent className="pt-6">
-        <div className="flex items-start justify-between">
-          <div className="space-y-1">
-            <p className="text-sm text-muted-foreground">{label}</p>
-            <p className="text-3xl font-bold">{value}</p>
-            {subtext && (
-              <p className="text-xs text-muted-foreground">{subtext}</p>
+    <Panel className="p-5 transition-all duration-300 hover:-translate-y-0.5 hover:border-secondary/30">
+      <div className="flex items-start justify-between">
+        <div className="space-y-1">
+          <p
+            className={cn(
+              poppins_500,
+              "text-xs uppercase tracking-wider text-ink-muted"
             )}
-          </div>
-          <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center">
-            <Icon className="h-5 w-5 text-primary" />
-          </div>
+          >
+            {label}
+          </p>
+          <p className={cn(poppins_600, "text-3xl text-ink")}>{value}</p>
+          {subtext && (
+            <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+              {subtext}
+            </p>
+          )}
         </div>
-        {trend !== undefined && (
-          <div className="mt-4 flex items-center gap-1 text-sm">
-            {trend >= 0 ? (
-              <TrendingUp className="h-4 w-4 text-success" />
-            ) : (
-              <TrendingDown className="h-4 w-4 text-error" />
-            )}
-            <span className={trend >= 0 ? "text-success" : "text-error"}>
-              {Math.abs(trend)}%
-            </span>
-            <span className="text-muted-foreground ml-1">{trendLabel}</span>
-          </div>
-        )}
-      </CardContent>
-    </Card>
+        <div className="flex size-10 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+          <Icon className="h-5 w-5 text-accent" />
+        </div>
+      </div>
+      {trend !== undefined && (
+        <div className={cn(poppins_500, "mt-4 flex items-center gap-1 text-sm")}>
+          {trend >= 0 ? (
+            <TrendingUp className="h-4 w-4 text-secondary" />
+          ) : (
+            <TrendingDown className="h-4 w-4 text-red-600" />
+          )}
+          <span className={trend >= 0 ? "text-secondary" : "text-red-600"}>
+            {Math.abs(trend)}%
+          </span>
+          <span className={cn(poppins_400, "ml-1 text-ink-muted")}>
+            {trendLabel}
+          </span>
+        </div>
+      )}
+    </Panel>
   );
 }
 
 function SummarySkeleton() {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
       {[...Array(4)].map((_, i) => (
-        <Card key={i}>
-          <CardContent className="pt-6 space-y-3">
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-8 w-32" />
-            <Skeleton className="h-3 w-20" />
-          </CardContent>
-        </Card>
+        <Panel key={i} className="space-y-3 p-5">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="h-3 w-20" />
+        </Panel>
       ))}
     </div>
   );
@@ -90,134 +168,103 @@ export default function EarningsPage() {
   } = useEarnings();
 
   const [chartRange, setChartRange] = useState("30d");
-
   const chartData = revenueChartData(chartRange);
 
   if (!hasWallet && !isLoading) {
     return (
-      <div className="p-4 sm:p-6 space-y-6">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <DollarSign className="h-6 w-6 text-brand-text" />
-            Earnings Dashboard
-          </h1>
-          <p className="text-muted-foreground text-sm">
-            Track your sales, revenue, and payout analytics
-          </p>
-        </div>
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
-            <Wallet className="h-12 w-12 text-muted-foreground" />
-            <div>
-              <h3 className="font-semibold text-lg">Connect Your Wallet</h3>
-              <p className="text-muted-foreground text-sm mt-1">
-                Connect your Stellar wallet to view your earnings and sales analytics
-              </p>
-            </div>
-            <WalletConnectButton />
-          </CardContent>
-        </Card>
+      <div className="space-y-6 bg-surface p-4 sm:p-6">
+        <PageHeader />
+        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+          <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+            <Wallet className="h-7 w-7 text-accent" />
+          </div>
+          <div>
+            <h3 className={cn(poppins_600, "text-lg text-ink")}>
+              Connect Your Wallet
+            </h3>
+            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+              Connect your Stellar wallet to view your earnings and sales
+              analytics
+            </p>
+          </div>
+          <WalletConnectButton />
+        </Panel>
       </div>
     );
   }
 
   if (error) {
     return (
-      <div className="p-4 sm:p-6 space-y-6">
-        <h1 className="text-2xl font-bold flex items-center gap-2">
-          <DollarSign className="h-6 w-6 text-brand-text" />
-          Earnings Dashboard
-        </h1>
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
-            <div className="rounded-full bg-error/10 p-3">
-              <TrendingDown className="h-8 w-8 text-error" />
-            </div>
-            <div>
-              <h3 className="font-semibold text-lg">Failed to Load Data</h3>
-              <p className="text-muted-foreground text-sm mt-1">{error}</p>
-            </div>
-            <Button round outlined onClick={() => window.location.reload()}>
-              Try Again
-            </Button>
-          </CardContent>
-        </Card>
+      <div className="space-y-6 bg-surface p-4 sm:p-6">
+        <PageHeader />
+        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+          <div className="flex size-14 items-center justify-center rounded-2xl bg-red-50">
+            <TrendingDown className="h-7 w-7 text-red-600" />
+          </div>
+          <div>
+            <h3 className={cn(poppins_600, "text-lg text-ink")}>
+              Failed to Load Data
+            </h3>
+            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+              {error}
+            </p>
+          </div>
+          <Button round outlined onClick={() => window.location.reload()}>
+            Try Again
+          </Button>
+        </Panel>
       </div>
     );
   }
 
   const chartConfig = {
-    revenue: {
-      label: "Revenue",
-      color: "hsl(var(--primary))",
-    },
+    revenue: { label: "Revenue", color: "#009900" },
   };
 
   return (
-    <div className="p-4 sm:p-6 space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold flex items-center gap-2">
-          <DollarSign className="h-6 w-6 text-brand-text" />
-          Earnings Dashboard
-        </h1>
-        <p className="text-muted-foreground text-sm">
-          Track your sales, revenue, and payout analytics
-        </p>
-      </div>
+    <div className="space-y-6 bg-surface p-4 sm:p-6">
+      <PageHeader />
 
       {isLoading ? (
         <>
           <SummarySkeleton />
-          <Card>
-            <CardHeader>
-              <Skeleton className="h-6 w-48" />
-            </CardHeader>
-            <CardContent>
-              <Skeleton className="h-64 w-full" />
-            </CardContent>
-          </Card>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            <Card>
-              <CardHeader>
+          <Panel className="p-6">
+            <Skeleton className="mb-4 h-6 w-48" />
+            <Skeleton className="h-64 w-full rounded-xl" />
+          </Panel>
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            {[...Array(2)].map((_, i) => (
+              <Panel key={i} className="space-y-4 p-6">
                 <Skeleton className="h-6 w-32" />
-              </CardHeader>
-              <CardContent className="space-y-4">
-                {[...Array(3)].map((_, i) => (
-                  <Skeleton key={i} className="h-12 w-full" />
+                {[...Array(4)].map((_, j) => (
+                  <Skeleton key={j} className="h-10 w-full rounded-lg" />
                 ))}
-              </CardContent>
-            </Card>
-            <Card>
-              <CardHeader>
-                <Skeleton className="h-6 w-36" />
-              </CardHeader>
-              <CardContent className="space-y-3">
-                {[...Array(4)].map((_, i) => (
-                  <Skeleton key={i} className="h-8 w-full" />
-                ))}
-              </CardContent>
-            </Card>
+              </Panel>
+            ))}
           </div>
         </>
       ) : totalEarned === 0 && salesCount === 0 ? (
         <>
           <SummarySkeleton />
-          <Card>
-            <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
-              <DollarSign className="h-12 w-12 text-muted-foreground" />
-              <div>
-                <h3 className="font-semibold text-lg">No Sales Yet</h3>
-                <p className="text-muted-foreground text-sm mt-1">
-                  Your earnings will appear here once students purchase your courses or books
-                </p>
-              </div>
-            </CardContent>
-          </Card>
+          <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+            <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+              <DollarSign className="h-7 w-7 text-accent" />
+            </div>
+            <div>
+              <h3 className={cn(poppins_600, "text-lg text-ink")}>
+                No Sales Yet
+              </h3>
+              <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+                Your earnings will appear here once students purchase your
+                courses or books
+              </p>
+            </div>
+          </Panel>
         </>
       ) : (
         <>
-          {/* Summary Tiles */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {/* Summary tiles */}
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
             <SummaryTile
               icon={DollarSign}
               label="Total Earned (USDC)"
@@ -245,196 +292,222 @@ export default function EarningsPage() {
             />
           </div>
 
-          {/* Revenue Chart */}
-          <Card>
-            <CardHeader>
-              <div className="flex items-center justify-between">
-                <div>
-                  <CardTitle>Revenue Over Time</CardTitle>
-                  <CardDescription>
-                    Confirmed sales revenue aggregated over time
-                  </CardDescription>
-                </div>
-                <div className="flex gap-1">
+          {/* Revenue chart */}
+          <Panel className="p-6">
+            <SectionHeading
+              title="Revenue Over Time"
+              subtitle="Confirmed sales revenue aggregated over time"
+              right={
+                <div className="flex gap-1.5">
                   {["7d", "30d", "all"].map((range) => (
-                    <Button
+                    <button
                       key={range}
-                      round
-                      outlined={chartRange !== range}
-                      className={chartRange === range ? "bg-accent text-white" : ""}
                       onClick={() => setChartRange(range)}
+                      className={cn(
+                        poppins_500,
+                        "rounded-lg px-3 py-1.5 text-sm transition-all",
+                        chartRange === range
+                          ? "bg-accent text-white shadow-sm"
+                          : "border border-accent/15 bg-surface text-ink-muted hover:border-secondary/40 hover:text-ink"
+                      )}
                     >
                       {range === "all" ? "All" : range}
-                    </Button>
+                    </button>
                   ))}
                 </div>
-              </div>
-            </CardHeader>
-            <CardContent>
-              {chartData.length === 0 ? (
-                <div className="flex items-center justify-center h-64 text-muted-foreground">
-                  No revenue data for this period
-                </div>
-              ) : (
-                <ChartContainer config={chartConfig} className="h-72">
-                  <BarChart data={chartData}>
-                    <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                    <XAxis
-                      dataKey="date"
-                      tickLine={false}
-                      axisLine={false}
-                      tickMargin={8}
-                      tickFormatter={(val) => {
-                        const d = new Date(val + "T00:00:00");
-                        return d.toLocaleDateString("en-US", {
-                          month: "short",
-                          day: "numeric",
-                        });
-                      }}
-                    />
-                    <YAxis
-                      tickLine={false}
-                      axisLine={false}
-                      tickMargin={8}
-                      tickFormatter={(val) => `$${val}`}
-                    />
-                    <ChartTooltip
-                      cursor={{ fill: "hsl(var(--muted))" }}
-                      content={
-                        <ChartTooltipContent
-                          formatter={(value) => `$${value.toFixed(2)}`}
-                        />
-                      }
-                    />
-                    <Bar
-                      dataKey="revenue"
-                      fill="var(--color-revenue)"
-                      radius={[4, 4, 0, 0]}
-                    />
-                  </BarChart>
-                </ChartContainer>
-              )}
-            </CardContent>
-          </Card>
-
-          {/* Bottom Grid */}
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {/* Top Items */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Top Items</CardTitle>
-                <CardDescription>
-                  Revenue and units sold per course or book
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                {topItems.length === 0 ? (
-                  <p className="text-muted-foreground text-sm py-8 text-center">
-                    No items sold yet
-                  </p>
-                ) : (
-                  <div className="space-y-4">
-                    {topItems.slice(0, 10).map((item, index) => {
-                      const link = findItemLink(item.itemTitle, item.itemType);
-                      const maxRevenue = topItems[0]?.revenue || 1;
-                      const barWidth = (item.revenue / maxRevenue) * 100;
-                      return (
-                        <div key={`${item.itemType}:${item.itemTitle}`}>
-                          <div className="flex items-center justify-between mb-1">
-                            <div className="flex items-center gap-2 min-w-0 flex-1">
-                              <span className="text-sm text-muted-foreground font-medium">
-                                #{index + 1}
-                              </span>
-                              <div className="min-w-0 flex-1">
-                                {link ? (
-                                  <Link
-                                    href={link}
-                                    className="text-sm font-medium truncate block hover:underline"
-                                  >
-                                    {item.itemTitle}
-                                  </Link>
-                                ) : (
-                                  <p className="text-sm font-medium truncate">
-                                    {item.itemTitle}
-                                  </p>
-                                )}
-                                <span className="text-xs text-muted-foreground capitalize">
-                                  {item.itemType}
-                                </span>
-                              </div>
-                            </div>
-                            <div className="text-right flex-shrink-0 ml-4">
-                              <p className="text-sm font-semibold">
-                                ${item.revenue.toFixed(2)}
-                              </p>
-                              <p className="text-xs text-muted-foreground">
-                                {item.units} sold
-                              </p>
-                            </div>
-                          </div>
-                          <div className="w-full h-2 bg-muted rounded-full overflow-hidden">
-                            <div
-                              className="h-full bg-primary rounded-full transition-all"
-                              style={{ width: `${barWidth}%` }}
-                            />
-                          </div>
-                        </div>
-                      );
-                    })}
-                  </div>
+              }
+            />
+            {chartData.length === 0 ? (
+              <div
+                className={cn(
+                  poppins_400,
+                  "flex h-64 items-center justify-center text-ink-muted"
                 )}
-              </CardContent>
-            </Card>
+              >
+                No revenue data for this period
+              </div>
+            ) : (
+              <ChartContainer config={chartConfig} className="h-72 w-full">
+                <BarChart data={chartData}>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    vertical={false}
+                    stroke="#265902"
+                    strokeOpacity={0.12}
+                  />
+                  <XAxis
+                    dataKey="date"
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={8}
+                    tickFormatter={(val) => {
+                      const d = new Date(val + "T00:00:00");
+                      return d.toLocaleDateString("en-US", {
+                        month: "short",
+                        day: "numeric",
+                      });
+                    }}
+                  />
+                  <YAxis
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={8}
+                    tickFormatter={(val) => `$${val}`}
+                  />
+                  <ChartTooltip
+                    cursor={{ fill: "rgba(0,153,0,0.06)" }}
+                    content={
+                      <ChartTooltipContent
+                        formatter={(value) => `$${value.toFixed(2)}`}
+                      />
+                    }
+                  />
+                  <Bar
+                    dataKey="revenue"
+                    fill="var(--color-revenue)"
+                    radius={[6, 6, 0, 0]}
+                  />
+                </BarChart>
+              </ChartContainer>
+            )}
+          </Panel>
 
-            {/* Status Breakdown */}
-            <Card>
-              <CardHeader>
-                <CardTitle>Transaction Status</CardTitle>
-                <CardDescription>
-                  Overview of all your creator transactions by status
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-3">
-                  {Object.entries(statusBreakdown)
-                    .filter(([_, count]) => count > 0)
-                    .sort(([, a], [, b]) => b - a)
-                    .map(([status, count]) => (
-                      <div
-                        key={status}
-                        className="flex items-center justify-between p-3 rounded-lg border"
-                      >
-                        <div className="flex items-center gap-3">
-                          <Badge
-                            variant="secondary"
-                            className={statusColors[status]}
-                          >
-                            {status}
-                          </Badge>
-                        </div>
-                        <span className="font-semibold">{count}</span>
-                      </div>
-                    ))}
-                  {Object.values(statusBreakdown).every((c) => c === 0) && (
-                    <p className="text-muted-foreground text-sm py-8 text-center">
-                      No transactions yet
-                    </p>
+          {/* Bottom grid */}
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            {/* Top items */}
+            <Panel className="p-6">
+              <SectionHeading
+                title="Top Items"
+                subtitle="Revenue and units sold per course or book"
+              />
+              {topItems.length === 0 ? (
+                <p
+                  className={cn(
+                    poppins_400,
+                    "py-8 text-center text-sm text-ink-muted"
                   )}
+                >
+                  No items sold yet
+                </p>
+              ) : (
+                <div className="space-y-4">
+                  {topItems.slice(0, 10).map((item, index) => {
+                    const link = findItemLink(item.itemTitle, item.itemType);
+                    const maxRevenue = topItems[0]?.revenue || 1;
+                    const barWidth = (item.revenue / maxRevenue) * 100;
+                    return (
+                      <div key={`${item.itemType}:${item.itemTitle}`}>
+                        <div className="mb-1.5 flex items-center justify-between">
+                          <div className="flex min-w-0 flex-1 items-center gap-2">
+                            <span
+                              className={cn(
+                                poppins_600,
+                                "text-sm text-ink-muted"
+                              )}
+                            >
+                              #{index + 1}
+                            </span>
+                            <div className="min-w-0 flex-1">
+                              {link ? (
+                                <Link
+                                  href={link}
+                                  className={cn(
+                                    poppins_500,
+                                    "block truncate text-sm text-ink hover:text-secondary hover:underline"
+                                  )}
+                                >
+                                  {item.itemTitle}
+                                </Link>
+                              ) : (
+                                <p
+                                  className={cn(
+                                    poppins_500,
+                                    "truncate text-sm text-ink"
+                                  )}
+                                >
+                                  {item.itemTitle}
+                                </p>
+                              )}
+                              <span
+                                className={cn(
+                                  poppins_400,
+                                  "text-xs capitalize text-ink-muted"
+                                )}
+                              >
+                                {item.itemType}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="ml-4 flex-shrink-0 text-right">
+                            <p className={cn(poppins_600, "text-sm text-ink")}>
+                              ${item.revenue.toFixed(2)}
+                            </p>
+                            <p
+                              className={cn(
+                                poppins_400,
+                                "text-xs text-ink-muted"
+                              )}
+                            >
+                              {item.units} sold
+                            </p>
+                          </div>
+                        </div>
+                        <div className="h-2 w-full overflow-hidden rounded-full bg-accent/10">
+                          <div
+                            className="h-full rounded-full bg-gradient-to-r from-secondary to-highlight transition-all"
+                            style={{ width: `${barWidth}%` }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
                 </div>
-                <div className="mt-4 p-3 bg-muted rounded-lg">
-                  <p className="text-xs text-muted-foreground">
-                    <strong>Note:</strong> Only{" "}
-                    <Badge
-                      variant="secondary"
-                      className={`${statusColors.confirmed} text-xs`}
+              )}
+            </Panel>
+
+            {/* Status breakdown */}
+            <Panel className="p-6">
+              <SectionHeading
+                title="Transaction Status"
+                subtitle="Overview of all your creator transactions by status"
+              />
+              <div className="space-y-2.5">
+                {Object.entries(statusBreakdown)
+                  .filter(([, count]) => count > 0)
+                  .sort(([, a], [, b]) => b - a)
+                  .map(([status, count]) => (
+                    <div
+                      key={status}
+                      className="flex items-center justify-between rounded-xl border border-accent/10 bg-surface p-3"
                     >
-                      confirmed
-                    </Badge>{" "}
-                    transactions count toward your earnings totals.
+                      <StatusBadge status={status} />
+                      <span className={cn(poppins_600, "text-ink")}>{count}</span>
+                    </div>
+                  ))}
+                {Object.values(statusBreakdown).every((c) => c === 0) && (
+                  <p
+                    className={cn(
+                      poppins_400,
+                      "py-8 text-center text-sm text-ink-muted"
+                    )}
+                  >
+                    No transactions yet
                   </p>
-                </div>
-              </CardContent>
-            </Card>
+                )}
+              </div>
+              <div className="mt-4 rounded-xl border border-accent/10 bg-surface p-3">
+                <p
+                  className={cn(
+                    poppins_400,
+                    "flex flex-wrap items-center gap-1 text-xs text-ink-muted"
+                  )}
+                >
+                  <strong className={cn(poppins_500, "text-ink")}>Note:</strong>{" "}
+                  Only <StatusBadge status="confirmed" small /> transactions
+                  count toward your earnings totals.
+                </p>
+              </div>
+            </Panel>
           </div>
         </>
       )}

--- a/app/dashboard/library/[bookid]/BookDetailPageClient.jsx
+++ b/app/dashboard/library/[bookid]/BookDetailPageClient.jsx
@@ -1,20 +1,84 @@
 "use client";
 import React, { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
-import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
 import Button from "@/components/atoms/form/Button";
 import { Textarea } from "@/components/ui/textarea";
-import { DownloadCloud, Wallet } from "lucide-react";
+import {
+  DownloadCloud,
+  Wallet,
+  Star,
+  Tag,
+  FileText,
+  BookOpen,
+  User,
+  MessageSquare,
+} from "lucide-react";
 import StarRate from "@/components/atoms/form/StarRate";
 import ReviewsSection from "@/components/organisms/dashboard/ReviewsSection";
 import { addBookReview } from "@/lib/actions/library/addReview";
+import { getAverageRating } from "@/hooks/getAverageRating";
 import { toast } from "sonner";
 import useAuth from "@/hooks/useAuth";
-import { CustomSidebar } from "@/components/organisms/dashboard/CustomSidebar";
-import BookStatsInfo from "@/components/molecules/dashboard/BookStats&Info";
 import { useHasBook, usePurchaseBook } from "@/hooks/usePurchase";
 import PaymentModal from "@/components/stellar/PaymentModal";
 import { useStellar } from "@/components/stellar/StellarProvider";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+
+/* ── building blocks (design-system consistent) ── */
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
+
+const SectionHeading = ({ icon: Icon, title, subtitle }) => (
+  <div className="mb-5 flex items-start gap-3">
+    {Icon && (
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+        <Icon className="h-5 w-5 text-accent" />
+      </div>
+    )}
+    <div>
+      <h2 className={cn(poppins_600, "text-lg text-ink")}>{title}</h2>
+      {subtitle && (
+        <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+          {subtitle}
+        </p>
+      )}
+    </div>
+  </div>
+);
+
+const MetaChip = ({ icon: Icon, label, value }) => (
+  <div className="flex items-center gap-3 rounded-xl border border-accent/10 bg-surface px-4 py-3">
+    <div className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-gradient-to-br from-secondary/15 to-highlight/10">
+      <Icon className="h-4 w-4 text-accent" />
+    </div>
+    <div className="min-w-0">
+      <p
+        className={cn(
+          poppins_400,
+          "text-[11px] uppercase tracking-wider text-ink-muted"
+        )}
+      >
+        {label}
+      </p>
+      <p className={cn(poppins_600, "truncate text-sm text-ink")}>{value}</p>
+    </div>
+  </div>
+);
 
 export default function BookDetailPage({ book }) {
   const { user, refreshUser } = useAuth();
@@ -98,76 +162,204 @@ export default function BookDetailPage({ book }) {
     }
   };
 
+  const averageRating = getAverageRating(book?.reviews);
+  const reviewCount = book?.reviews?.length || 0;
+  const priceLabel = book?.price ? `$${book.price}` : "Free";
+
   return (
-    <div className="min-h-screen py-12 px-4 md:px-12">
-      <div className="max-w-7xl mx-auto grid md:grid-cols-12 gap-10">
-        {/* Book Showcase and Main Content */}
-        <div className="md:col-span-8 space-y-12">
-          <div className="relative h-[500px] rounded-3xl overflow-hidden shadow-2xl border border-border backdrop-blur-md bg-muted/50">
-            <Image
-              src={book.image || "/images/placeholder.jpg"}
-              alt={book.title}
-              fill
-              className="object-cover"
-            />
-          </div>
-          {/* Title & Category */}
-          <div className="space-y-4">
-            <h1 className="text-5xl font-black tracking-tight">{book.title}</h1>
-            <div className="flex flex-wrap items-center gap-3">
-              <Badge className="bg-accent text-white">{book.category}</Badge>
-              <Badge variant="accent" className="bg-muted/50 text-brand-text">
-                {book.price ? `$${book.price}` : "Free"}
-              </Badge>
+    <div className="min-h-screen space-y-6 bg-surface p-4 sm:p-6 lg:p-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        {/* ── Hero: cover (left) · details + CTA (right) ── */}
+        <Panel className="overflow-hidden">
+          <div className="grid grid-cols-1 gap-8 p-6 sm:p-8 md:grid-cols-[minmax(0,340px)_1fr] lg:gap-10">
+            {/* Cover */}
+            <div className="mx-auto w-full max-w-[320px] md:mx-0">
+              <div className="relative aspect-[3/4] overflow-hidden rounded-2xl border border-accent/10 bg-gradient-to-br from-secondary/10 to-highlight/10 shadow-lg">
+                <Image
+                  src={book.image || "/images/placeholder.jpg"}
+                  alt={book.title}
+                  fill
+                  className="object-cover"
+                />
+              </div>
             </div>
-            <p className="text-md /80 leading-relaxed">{book.description}</p>
-          </div>
-          {/* Action Buttons */}
-          <div className="flex flex-wrap gap-4">
-            {canAccessBook ? (
-              <>
-                <Button
-                  wide
-                  className="bg-accent hover:highlight text-white font-bold shadow-lg transition"
-                  round
-                  to={`/dashboard/library/read/${book._id ?? book.id}`}
-                >
-                  Start Reading
-                </Button>
-                <Button
-                  outlined
-                  round
-                  to={book.fileUrl}
-                  download
-                  target="_blank"
-                >
-                  <DownloadCloud className="w-4 h-4 mr-2" /> Download
-                </Button>
-              </>
-            ) : (
-              <div className="flex flex-col gap-2">
-                <Button
-                  wide
-                  className="bg-accent hover:bg-highlight text-white font-bold shadow-lg transition"
-                  round
-                  onClick={handlePurchaseBook}
-                  loading={loading}
-                >
-                  <Wallet className="w-4 h-4 mr-2" /> Pay with Stellar
-                </Button>
-                {!creatorHasWallet && (
-                  <p className="text-sm text-orange-500">
-                    Note: Creator has not connected their Stellar wallet yet
-                  </p>
+
+            {/* Details */}
+            <div className="flex flex-col">
+              <span
+                className={cn(
+                  poppins_500,
+                  "inline-flex w-fit items-center gap-1.5 rounded-full border border-secondary/20 bg-secondary/10 px-3 py-1 text-xs text-accent"
+                )}
+              >
+                <Tag className="h-3.5 w-3.5" />
+                {book.category}
+              </span>
+
+              <h1
+                className={cn(
+                  poppins_600,
+                  "mt-4 text-3xl leading-tight text-ink sm:text-4xl"
+                )}
+              >
+                {book.title}
+              </h1>
+
+              {book.author?.name && (
+                <div className="mt-3 flex items-center gap-2">
+                  <User className="h-4 w-4 text-ink-muted" />
+                  {book.author?._id ? (
+                    <Link
+                      href={`/account/profile/${book.author._id}`}
+                      className={cn(
+                        poppins_500,
+                        "text-sm text-accent hover:text-highlight hover:underline"
+                      )}
+                    >
+                      {book.author.name}
+                    </Link>
+                  ) : (
+                    <span className={cn(poppins_500, "text-sm text-ink")}>
+                      {book.author.name}
+                    </span>
+                  )}
+                </div>
+              )}
+
+              {/* Rating */}
+              <div className="mt-4 flex flex-wrap items-center gap-2">
+                <div className="flex items-center gap-1">
+                  {[1, 2, 3, 4, 5].map((i) => (
+                    <Star
+                      key={i}
+                      className={cn(
+                        "h-4 w-4",
+                        i <= Math.round(averageRating)
+                          ? "fill-yellow-400 text-yellow-400"
+                          : "text-accent/20"
+                      )}
+                    />
+                  ))}
+                </div>
+                <span className={cn(poppins_600, "text-sm text-ink")}>
+                  {averageRating > 0 ? averageRating.toFixed(1) : "New"}
+                </span>
+                <span className={cn(poppins_400, "text-sm text-ink-muted")}>
+                  ({reviewCount} {reviewCount === 1 ? "review" : "reviews"})
+                </span>
+              </div>
+
+              {/* Price */}
+              <div className="mt-5 flex items-baseline gap-2">
+                <span className={cn(poppins_600, "text-3xl text-ink")}>
+                  {priceLabel}
+                </span>
+                {book?.price ? (
+                  <span className={cn(poppins_400, "text-sm text-ink-muted")}>
+                    USDC
+                  </span>
+                ) : null}
+              </div>
+
+              {/* CTA */}
+              <div className="mt-auto pt-6">
+                {canAccessBook ? (
+                  <div className="flex flex-wrap gap-3">
+                    <Button
+                      wide
+                      round
+                      className="bg-accent text-white shadow-sm transition hover:bg-highlight"
+                      to={`/dashboard/library/read/${book._id ?? book.id}`}
+                    >
+                      <BookOpen className="mr-2 h-4 w-4" /> Read now
+                    </Button>
+                    <Button
+                      outlined
+                      round
+                      to={book.fileUrl}
+                      download
+                      target="_blank"
+                    >
+                      <DownloadCloud className="mr-2 h-4 w-4" /> Download
+                    </Button>
+                  </div>
+                ) : (
+                  <div className="flex flex-col gap-2">
+                    <Button
+                      wide
+                      round
+                      className="bg-accent text-white shadow-sm transition hover:bg-highlight"
+                      onClick={handlePurchaseBook}
+                      loading={loading}
+                    >
+                      <Wallet className="mr-2 h-4 w-4" /> Buy to read
+                    </Button>
+                    {!creatorHasWallet && (
+                      <p className={cn(poppins_400, "text-sm text-red-600")}>
+                        Note: Creator has not connected their Stellar wallet yet
+                      </p>
+                    )}
+                  </div>
                 )}
               </div>
-            )}
+            </div>
           </div>
-          {/* Review Section */}
-          {user?._id !== book.author._id && (
-            <div className="pt-10 space-y-5 border-t border-border">
+        </Panel>
+
+        {/* ── About + meta ── */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <Panel className="p-6 lg:col-span-2">
+            <SectionHeading
+              icon={BookOpen}
+              title="About this book"
+              subtitle="What you'll find inside"
+            />
+            <p
+              className={cn(
+                poppins_400,
+                "leading-relaxed text-ink-muted"
+              )}
+            >
+              {book.description || "No description available for this book yet."}
+            </p>
+          </Panel>
+
+          <Panel className="p-6">
+            <SectionHeading title="Details" />
+            <div className="space-y-3">
+              <MetaChip icon={Tag} label="Category" value={book.category || "—"} />
+              {book?.pages ? (
+                <MetaChip
+                  icon={FileText}
+                  label="Pages"
+                  value={`${book.pages} pages`}
+                />
+              ) : null}
+              <MetaChip icon={Wallet} label="Price" value={priceLabel} />
+            </div>
+          </Panel>
+        </div>
+
+        {/* ── Reviews ── */}
+        <Panel className="p-6">
+          <SectionHeading
+            icon={MessageSquare}
+            title="Reviews"
+            subtitle={`${reviewCount} ${
+              reviewCount === 1 ? "reader has" : "readers have"
+            } shared their thoughts`}
+          />
+
+          {/* Write a review */}
+          {user?._id !== book?.author?._id && (
+            <>
               {userReview && (
-                <div className="text-sm text-muted-foreground">
+                <div
+                  className={cn(
+                    poppins_400,
+                    "mb-6 rounded-xl border border-accent/10 bg-surface px-4 py-3 text-sm text-ink-muted"
+                  )}
+                >
                   You reviewed this book on{" "}
                   {new Date(userReview.createdAt).toLocaleDateString("en-US", {
                     year: "numeric",
@@ -178,9 +370,11 @@ export default function BookDetailPage({ book }) {
                 </div>
               )}
               {!submitted && !userReview && (
-                <>
-                  <h2 className="text-3xl font-semibold">Leave a Review</h2>
-                  <form onSubmit={handleSubmit} className="space-y-4">
+                <div className="mb-8 rounded-xl border border-accent/10 bg-surface p-5">
+                  <h3 className={cn(poppins_600, "text-base text-ink")}>
+                    Leave a Review
+                  </h3>
+                  <form onSubmit={handleSubmit} className="mt-4 space-y-4">
                     <StarRate
                       value={rating}
                       onChange={setRating}
@@ -196,18 +390,19 @@ export default function BookDetailPage({ book }) {
                     />
                     <Textarea
                       placeholder="What did you think about the book?"
-                      className="bg-muted/50 min-h-[120px] border-accent focus:outline-none"
+                      className="min-h-[120px] border-accent/15 bg-surface-raised focus:outline-none"
                       value={review}
                       onChange={(e) => setReview(e.target.value)}
                       disabled={submitting || submitted}
                     />
                     {error && (
-                      <div className="text-red-500 text-sm">{error}</div>
+                      <div className={cn(poppins_400, "text-sm text-red-600")}>
+                        {error}
+                      </div>
                     )}
                     <Button
-                      wide
                       round
-                      className="bg-accent hover:bg-highlight font-semibold mt-2 transition"
+                      className="bg-accent text-white transition hover:bg-highlight"
                       type="submit"
                       disabled={
                         submitting || rating === 0 || review.trim() === ""
@@ -217,29 +412,19 @@ export default function BookDetailPage({ book }) {
                       Submit Review
                     </Button>
                   </form>
-                </>
+                </div>
               )}
-            </div>
+            </>
           )}
-          {/* Reviews List */}
-          <div className="pt-8">
-            <h2 className="text-3xl font-semibold mb-6">Reviews</h2>
-            <ReviewsSection
-              reviews={book.reviews || []}
-              currentUserId={user?._id}
-              loading={false}
-              enableEditDelete={false}
-            />
-          </div>
-        </div>
-        {/* Sidebar for desktop/tablet */}
-        <div className="md:col-span-4 hidden md:block space-y-8 sticky top-20 self-start">
-          <CustomSidebar book={book} side="right" collapsible="none" />
-        </div>
-        {/* BookStatsInfo for mobile only */}
-        <div className="block md:hidden mt-8">
-          <BookStatsInfo book={book} />
-        </div>
+
+          {/* Reviews list */}
+          <ReviewsSection
+            reviews={book.reviews || []}
+            currentUserId={user?._id}
+            loading={false}
+            enableEditDelete={false}
+          />
+        </Panel>
       </div>
 
       {/* Stellar Payment Modal */}

--- a/app/dashboard/library/page.jsx
+++ b/app/dashboard/library/page.jsx
@@ -10,7 +10,6 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { BookOpen, Bookmark, Plus } from "lucide-react";
 import LibraryBookCard from "@/components/molecules/dashboard/cards/libraryCard";
 import Button from "@/components/atoms/form/Button";
-import { Card, CardContent } from "@/components/ui/card";
 import Modal from "@/components/molecules/Modal";
 import BookCreateForm from "@/components/organisms/create/book-create-form";
 import { fetchBooks } from "@/lib/actions/library/fetch-books";
@@ -29,6 +28,12 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const PAGE_SIZE = 9;
 
@@ -48,6 +53,19 @@ const createdAtOf = (book) => {
 };
 
 const priceOf = (book) => Number(book?.price) || 0;
+
+/* ── building blocks (design-system consistent) ── */
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
 
 const BookGridSkeleton = () => (
   <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
@@ -239,18 +257,27 @@ const LibraryPageContent = () => {
   }
 
   return (
-    <div className="p-4 sm:p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <BookOpen className="h-6 w-6 text-brand-text" />
-            {showBookmarks ? "My Bookmarked Books" : "All Books"}
-          </h1>
-          <p className="text-muted-foreground text-sm mt-1">
-            {showBookmarks
-              ? "Books you've saved for later"
-              : "Browse and read Islamic books"}
-          </p>
+    <div className="space-y-6 bg-surface p-4 sm:p-6">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+            <BookOpen className="h-5 w-5 text-accent" />
+          </div>
+          <div>
+            <h1
+              className={cn(
+                poppins_600,
+                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+              )}
+            >
+              {showBookmarks ? "My Bookmarked Books" : "All Books"}
+            </h1>
+            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+              {showBookmarks
+                ? "Books you've saved for later"
+                : "Browse and read Islamic books"}
+            </p>
+          </div>
         </div>
         <div className="flex gap-2">
           <Button round outlined onClick={() => setModalOpen(true)}>
@@ -289,38 +316,43 @@ const LibraryPageContent = () => {
       {loading ? (
         <BookGridSkeleton />
       ) : filteredBooks.length === 0 ? (
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
-            <BookOpen className="h-12 w-12 text-muted-foreground" />
-            <div>
-              <h3 className="font-semibold text-lg">
-                {isFiltered
-                  ? "No Matching Books"
-                  : showBookmarks
-                  ? "No Bookmarked Books"
-                  : "No Books Yet"}
-              </h3>
-              <p className="text-muted-foreground text-sm mt-1 max-w-md">
-                {isFiltered
-                  ? "No books match the current filters. Try widening your search."
-                  : showBookmarks
-                  ? "Save titles you want to revisit!"
-                  : "No books available at the moment."}
-              </p>
-            </div>
-            {isFiltered ? (
-              <Button round outlined onClick={handleClearFilters}>
-                Clear filters
+        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+          <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+            <BookOpen className="h-7 w-7 text-accent" />
+          </div>
+          <div>
+            <h3 className={cn(poppins_600, "text-lg text-ink")}>
+              {isFiltered
+                ? "No Matching Books"
+                : showBookmarks
+                ? "No Bookmarked Books"
+                : "No Books Yet"}
+            </h3>
+            <p
+              className={cn(
+                poppins_400,
+                "mt-1 max-w-md text-sm text-ink-muted"
+              )}
+            >
+              {isFiltered
+                ? "No books match the current filters. Try widening your search."
+                : showBookmarks
+                ? "Save titles you want to revisit!"
+                : "No books available at the moment."}
+            </p>
+          </div>
+          {isFiltered ? (
+            <Button round outlined onClick={handleClearFilters}>
+              Clear filters
+            </Button>
+          ) : (
+            !showBookmarks && (
+              <Button round outlined onClick={() => setModalOpen(true)}>
+                Create Book
               </Button>
-            ) : (
-              !showBookmarks && (
-                <Button round outlined onClick={() => setModalOpen(true)}>
-                  Create Book
-                </Button>
-              )
-            )}
-          </CardContent>
-        </Card>
+            )
+          )}
+        </Panel>
       ) : (
         <>
           <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
@@ -394,7 +426,7 @@ const LibraryPageContent = () => {
 const LibraryPage = () => (
   <Suspense
     fallback={
-      <div className="p-4 sm:p-6">
+      <div className="bg-surface p-4 sm:p-6">
         <BookGridSkeleton />
       </div>
     }

--- a/app/dashboard/library/read/[bookid]/BookReaderClient.jsx
+++ b/app/dashboard/library/read/[bookid]/BookReaderClient.jsx
@@ -13,8 +13,17 @@ import {
   ZoomIn,
   ZoomOut,
   Loader2,
-  Sparkles,
+  Lock,
+  BookOpen,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 import { GlobalWorkerOptions, getDocument } from "pdfjs-dist";
 import workerSrc from "pdfjs-dist/build/pdf.worker.min.js?url";
 
@@ -24,6 +33,21 @@ const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 const MIN_SCALE = 0.5;
 const MAX_SCALE = 3;
 const INITIAL_SCALE = 1.2;
+
+/* ── chrome building blocks (design-system consistent) ── */
+
+const IconButton = ({ className, children, ...props }) => (
+  <button
+    type="button"
+    className={cn(
+      "inline-flex size-9 items-center justify-center rounded-xl border border-accent/10 bg-surface-raised text-ink-muted transition-colors hover:border-secondary/40 hover:text-accent disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:border-accent/10 disabled:hover:text-ink-muted",
+      className
+    )}
+    {...props}
+  >
+    {children}
+  </button>
+);
 
 const BookReaderClient = ({ book }) => {
   const { user } = useAuth();
@@ -213,89 +237,165 @@ const BookReaderClient = ({ book }) => {
 
   if (!book) {
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-muted px-4 text-center">
-        <p className="text-lg font-semibold text-muted-foreground">
-          Book not found.
-        </p>
-        <Button
-          to="/dashboard/library"
-          round
-          className="mt-6 bg-accent text-white"
-        >
-          Back to Library
-        </Button>
-      </div>
-    );
-  }
-
-  if (!canAccess) {
-    return (
-      <div className="flex min-h-screen flex-col items-center justify-center bg-muted px-4 text-center">
-        <h1 className="text-2xl font-semibold text-foreground">
-          You don&apos;t have access to this book yet.
-        </h1>
-        <p className="mt-3 max-w-xl text-sm text-muted-foreground">
-          Please purchase this title first or return to the book page to learn
-          more.
-        </p>
-        <div className="mt-6 flex gap-3">
+      <div className="flex min-h-screen flex-col items-center justify-center bg-surface px-4 text-center">
+        <div className="w-full max-w-md rounded-2xl border border-accent/10 bg-surface-raised p-8 shadow-sm">
+          <div className="mx-auto flex size-12 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+            <BookOpen className="h-6 w-6 text-accent" />
+          </div>
+          <p className={cn(poppins_600, "mt-4 text-lg text-ink")}>
+            Book not found.
+          </p>
           <Button
-            round
-            outlined
             to="/dashboard/library"
-            className="text-normal"
+            round
+            className="mt-6 bg-accent text-white"
           >
             Back to Library
-          </Button>
-          <Button
-            round
-            className="bg-accent text-white"
-            to={`/dashboard/library/${book._id}`}
-          >
-            View Book Details
           </Button>
         </div>
       </div>
     );
   }
 
+  if (!canAccess) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-surface px-4 py-10 text-center">
+        <div className="w-full max-w-lg overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
+          <div className="relative bg-gradient-to-br from-secondary/10 via-surface-raised to-highlight/10 px-6 py-10 sm:px-10">
+            <div className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full bg-secondary/10 blur-3xl" />
+            <div className="relative">
+              <div className="mx-auto flex size-14 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+                <Lock className="h-7 w-7 text-accent" />
+              </div>
+              <h1 className={cn(poppins_600, "mt-5 text-2xl text-ink")}>
+                Unlock the full book
+              </h1>
+              <p
+                className={cn(
+                  poppins_400,
+                  "mx-auto mt-3 max-w-md text-sm leading-relaxed text-ink-muted"
+                )}
+              >
+                {book.title
+                  ? `Purchase “${book.title}” to read the full book, or head back to the book page to learn more.`
+                  : "Purchase this title to read the full book, or head back to the book page to learn more."}
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col justify-center gap-3 px-6 py-6 sm:flex-row sm:px-10">
+            <Button
+              round
+              outlined
+              to="/dashboard/library"
+              className="text-normal"
+            >
+              Back to Library
+            </Button>
+            <Button
+              round
+              className="bg-accent text-white"
+              to={`/dashboard/library/${book._id}`}
+            >
+              Buy to read the full book
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex min-h-screen flex-col bg-gradient-to-br from-muted via-white to-muted">
-      <header className="sticky top-0 z-10 border-b border-border/80 bg-white/80 px-4 py-3 backdrop-blur md:px-8">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
+    <div className="flex min-h-screen flex-col bg-surface">
+      {/* ── Slim sticky reader toolbar ── */}
+      <header className="sticky top-0 z-20 border-b border-accent/10 bg-surface-raised/85 px-4 py-2.5 backdrop-blur md:px-6">
+        <div className="flex items-center justify-between gap-3">
+          {/* left: back + title */}
+          <div className="flex min-w-0 items-center gap-3">
             <Link
               href={`/dashboard/library/${book._id}`}
-              className="inline-flex items-center gap-2 text-sm font-medium text-brand-text transition hover:text-highlight"
+              aria-label="Back to book details"
+              className="inline-flex size-9 shrink-0 items-center justify-center rounded-xl border border-accent/10 bg-surface-raised text-ink-muted transition-colors hover:border-secondary/40 hover:text-accent"
             >
               <ArrowLeft className="h-4 w-4" />
-              Back to details
             </Link>
-            <div>
-              <h1 className="text-lg font-semibold text-foreground">
+            <div className="min-w-0">
+              <h1
+                className={cn(
+                  poppins_600,
+                  "truncate text-sm text-ink sm:text-base"
+                )}
+              >
                 {book.title}
               </h1>
               {book.author?.name && (
-                <p className="text-xs text-muted-foreground">
+                <p
+                  className={cn(
+                    poppins_400,
+                    "truncate text-xs text-ink-muted"
+                  )}
+                >
                   by {book.author.name}
                 </p>
               )}
             </div>
           </div>
-          <div className="flex items-center gap-2">
-            <Button
-              round
-              outlined
-              className="text-normal"
-              to={`/dashboard/library/${book._id}`}
+
+          {/* right: page indicator + zoom + fit-width */}
+          <div className="flex shrink-0 items-center gap-1.5 sm:gap-2">
+            <span
+              className={cn(
+                poppins_500,
+                "hidden rounded-lg border border-accent/10 bg-surface px-3 py-1.5 text-xs text-ink-muted sm:inline-flex"
+              )}
             >
-              Book Details
-            </Button>
+              Page {pageNumber}
+              {pageCount ? ` / ${pageCount}` : ""}
+            </span>
+
+            <div className="hidden items-center gap-1.5 sm:flex">
+              <IconButton
+                onClick={() => handleZoom(-1)}
+                disabled={fitWidth || baseScale <= MIN_SCALE}
+                aria-label="Zoom out"
+              >
+                <ZoomOut className="h-4 w-4" />
+              </IconButton>
+              <span
+                className={cn(
+                  poppins_600,
+                  "w-12 text-center text-xs text-ink-muted"
+                )}
+              >
+                {(effectiveScale * 100).toFixed(0)}%
+              </span>
+              <IconButton
+                onClick={() => handleZoom(1)}
+                disabled={fitWidth || baseScale >= MAX_SCALE}
+                aria-label="Zoom in"
+              >
+                <ZoomIn className="h-4 w-4" />
+              </IconButton>
+            </div>
+
+            <IconButton
+              onClick={() => setFitWidth((prev) => !prev)}
+              aria-label={fitWidth ? "Switch to free zoom" : "Fit width"}
+              className={cn(
+                fitWidth && "border-secondary/40 text-accent"
+              )}
+            >
+              {fitWidth ? (
+                <Minimize2 className="h-4 w-4" />
+              ) : (
+                <Maximize2 className="h-4 w-4" />
+              )}
+            </IconButton>
+
             {book.fileUrl && (
               <Button
                 round
                 outlined
-                className="flex items-center gap-2 text-normal"
+                className="hidden items-center gap-2 text-normal sm:inline-flex"
                 to={book.fileUrl}
                 download
                 target="_blank"
@@ -308,56 +408,133 @@ const BookReaderClient = ({ book }) => {
         </div>
       </header>
 
-      <main className="flex flex-1 flex-col gap-4 px-4 py-4 md:px-8">
+      {/* ── Reading stage ── */}
+      <main className="relative flex flex-1 flex-col">
         {!book.fileUrl ? (
-          <div className="flex flex-1 items-center justify-center rounded-2xl border border-dashed border-muted-foreground/30 bg-white text-center shadow-sm">
-            <div>
-              <p className="text-lg font-semibold text-muted-foreground">
+          <div className="flex flex-1 items-center justify-center px-4 py-16">
+            <div className="w-full max-w-md rounded-2xl border border-dashed border-accent/20 bg-surface-raised p-10 text-center shadow-sm">
+              <div className="mx-auto flex size-12 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+                <BookOpen className="h-6 w-6 text-accent" />
+              </div>
+              <p className={cn(poppins_600, "mt-4 text-lg text-ink")}>
                 This book file is not available yet.
               </p>
-              <p className="mt-2 text-sm text-muted-foreground/80">
+              <p
+                className={cn(poppins_400, "mt-2 text-sm text-ink-muted")}
+              >
                 Please contact support if you believe this is a mistake.
               </p>
             </div>
           </div>
         ) : loadingDocument && !docRef.current ? (
-          <div className="flex flex-1 flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-muted-foreground/30 bg-white text-center shadow-sm">
-            <Loader2 className="h-10 w-10 animate-spin text-brand-text" />
-            <p className="text-sm text-muted-foreground">
+          <div className="flex flex-1 flex-col items-center justify-center gap-4 px-4 py-16 text-center">
+            <div className="flex size-14 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+              <Loader2 className="h-7 w-7 animate-spin text-accent" />
+            </div>
+            <p className={cn(poppins_500, "text-sm text-ink-muted")}>
               Preparing your reading experience...
             </p>
           </div>
         ) : pdfError ? (
-          <div className="flex flex-1 items-center justify-center rounded-2xl border border-rose-300/60 bg-rose-50 text-center shadow-sm">
-            <div>
-              <p className="text-lg font-semibold text-rose-700">{pdfError}</p>
-              <p className="mt-2 text-sm text-rose-600">
-                Try reloading the page or download the book to continue reading.
+          <div className="flex flex-1 items-center justify-center px-4 py-16">
+            <div className="w-full max-w-md rounded-2xl border border-accent/10 bg-surface-raised p-10 text-center shadow-sm">
+              <div className="mx-auto flex size-12 items-center justify-center rounded-xl bg-red-50">
+                <Lock className="h-6 w-6 text-red-600" />
+              </div>
+              <p className={cn(poppins_600, "mt-4 text-lg text-red-600")}>
+                {pdfError}
               </p>
+              <p className={cn(poppins_400, "mt-2 text-sm text-ink-muted")}>
+                Try reloading the page or download the book to continue
+                reading.
+              </p>
+              {book.fileUrl && (
+                <Button
+                  round
+                  outlined
+                  className="mt-5 inline-flex items-center gap-2 text-normal"
+                  to={book.fileUrl}
+                  download
+                  target="_blank"
+                >
+                  <DownloadCloud className="h-4 w-4" />
+                  Download book
+                </Button>
+              )}
             </div>
           </div>
         ) : (
           <>
-            <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-border/40 bg-white/90 px-4 py-3 shadow-sm backdrop-blur">
-              <div className="flex items-center gap-3 text-sm">
-                <span className="inline-flex items-center gap-2 font-medium text-muted-foreground">
-                  <Sparkles className="h-4 w-4 text-brand-text" />
-                  Page {pageNumber}
-                  {pageCount ? ` / ${pageCount}` : ""}
-                </span>
-                <div className="flex items-center gap-1">
-                  <button
-                    type="button"
-                    className="rounded-full border border-border/70 p-2 text-muted-foreground transition hover:border-accent hover:text-brand-text disabled:cursor-not-allowed disabled:opacity-40"
+            {/* Scrollable stage with centered PDF sheet */}
+            <div
+              ref={containerRef}
+              className="relative flex-1 overflow-auto bg-surface"
+            >
+              <div className="flex min-h-full w-full items-start justify-center px-4 py-8 md:px-10">
+                <canvas
+                  ref={canvasRef}
+                  className="transition-transform duration-300"
+                  style={{
+                    backgroundColor: "#fafafa",
+                    borderRadius: "0.75rem",
+                    boxShadow:
+                      "0 10px 40px -12px rgba(0,0,0,0.28), 0 2px 8px -2px rgba(0,0,0,0.12)",
+                  }}
+                />
+                {(renderingPage || isTransitioning) && (
+                  <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-surface/40 backdrop-blur-sm">
+                    <div className="flex size-12 items-center justify-center rounded-2xl border border-accent/5 bg-surface-raised/90 shadow-sm">
+                      <Loader2 className="h-6 w-6 animate-spin text-accent" />
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              {/* Floating prev / next controls */}
+              <button
+                type="button"
+                onClick={() => goToPage(-1)}
+                disabled={pageNumber <= 1 || isTransitioning}
+                aria-label="Previous page"
+                className="fixed left-3 top-1/2 z-10 flex size-11 -translate-y-1/2 items-center justify-center rounded-full border border-accent/10 bg-surface-raised/90 text-ink-muted shadow-md backdrop-blur transition-colors hover:border-secondary/40 hover:text-accent disabled:cursor-not-allowed disabled:opacity-0 md:left-6"
+              >
+                <ChevronLeft className="h-5 w-5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => goToPage(1)}
+                disabled={
+                  isTransitioning ||
+                  (pageCount ? pageNumber >= pageCount : true)
+                }
+                aria-label="Next page"
+                className="fixed right-3 top-1/2 z-10 flex size-11 -translate-y-1/2 items-center justify-center rounded-full border border-accent/10 bg-surface-raised/90 text-ink-muted shadow-md backdrop-blur transition-colors hover:border-secondary/40 hover:text-accent disabled:cursor-not-allowed disabled:opacity-0 md:right-6"
+              >
+                <ChevronRight className="h-5 w-5" />
+              </button>
+            </div>
+
+            {/* Bottom bar: page nav + thumbnails */}
+            <div className="sticky bottom-0 z-20 border-t border-accent/10 bg-surface-raised/85 px-4 py-2.5 backdrop-blur md:px-6">
+              <div className="flex items-center gap-3">
+                <div className="flex shrink-0 items-center gap-1.5">
+                  <IconButton
                     onClick={() => goToPage(-1)}
                     disabled={pageNumber <= 1 || isTransitioning}
                     aria-label="Previous page"
                   >
-                    <ArrowLeft className="h-4 w-4" />
-                  </button>
-                  <button
-                    type="button"
-                    className="rounded-full border border-border/70 p-2 text-muted-foreground transition hover:border-accent hover:text-brand-text disabled:cursor-not-allowed disabled:opacity-40"
+                    <ChevronLeft className="h-4 w-4" />
+                  </IconButton>
+                  <span
+                    className={cn(
+                      poppins_500,
+                      "min-w-[4.5rem] text-center text-xs text-ink-muted"
+                    )}
+                  >
+                    {pageNumber}
+                    {pageCount ? ` / ${pageCount}` : ""}
+                  </span>
+                  <IconButton
                     onClick={() => goToPage(1)}
                     disabled={
                       isTransitioning ||
@@ -365,94 +542,35 @@ const BookReaderClient = ({ book }) => {
                     }
                     aria-label="Next page"
                   >
-                    <ArrowLeft className="h-4 w-4 rotate-180" />
-                  </button>
+                    <ChevronRight className="h-4 w-4" />
+                  </IconButton>
                 </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <button
-                  type="button"
-                  className="rounded-full border border-border/70 p-2 text-muted-foreground transition hover:border-accent hover:text-brand-text disabled:cursor-not-allowed disabled:opacity-40"
-                  onClick={() => handleZoom(-1)}
-                  disabled={fitWidth || baseScale <= MIN_SCALE}
-                  aria-label="Zoom out"
-                >
-                  <ZoomOut className="h-4 w-4" />
-                </button>
-                <span className="w-16 text-center text-sm font-semibold text-muted-foreground">
-                  {(effectiveScale * 100).toFixed(0)}%
-                </span>
-                <button
-                  type="button"
-                  className="rounded-full border border-border/70 p-2 text-muted-foreground transition hover:border-accent hover:text-brand-text disabled:cursor-not-allowed disabled:opacity-40"
-                  onClick={() => handleZoom(1)}
-                  disabled={fitWidth || baseScale >= MAX_SCALE}
-                  aria-label="Zoom in"
-                >
-                  <ZoomIn className="h-4 w-4" />
-                </button>
-                <button
-                  type="button"
-                  className="ml-2 inline-flex items-center gap-1 rounded-full border border-border/70 px-3 py-2 text-xs font-medium text-muted-foreground transition hover:border-accent hover:text-brand-text"
-                  onClick={() => setFitWidth((prev) => !prev)}
-                >
-                  {fitWidth ? (
-                    <>
-                      <Minimize2 className="h-3.5 w-3.5" />
-                      Fit Width
-                    </>
-                  ) : (
-                    <>
-                      <Maximize2 className="h-3.5 w-3.5" />
-                      Free Zoom
-                    </>
-                  )}
-                </button>
-              </div>
-            </div>
 
-            <div
-              ref={containerRef}
-              className="relative flex-1 overflow-auto rounded-3xl border border-border/40 bg-white shadow-lg"
-            >
-              <div className="relative flex h-full w-full items-start justify-center px-6 py-8">
-                <canvas
-                  ref={canvasRef}
-                  className="shadow-2xl transition-transform duration-300"
-                  style={{
-                    backgroundColor: "#fafafa",
-                    borderRadius: "1.25rem",
-                  }}
-                />
-                {(renderingPage || isTransitioning) && (
-                  <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-3xl bg-white/40 backdrop-blur-sm">
-                    <Loader2 className="h-8 w-8 animate-spin text-brand-text" />
+                {pageCount > 1 && (
+                  <div className="flex flex-1 items-center gap-1.5 overflow-x-auto">
+                    {Array.from({ length: pageCount }).map((_, index) => {
+                      const page = index + 1;
+                      return (
+                        <button
+                          key={`page-thumb-${page}`}
+                          type="button"
+                          onClick={() => setPageNumber(page)}
+                          className={cn(
+                            poppins_500,
+                            "shrink-0 rounded-lg border px-3 py-1 text-xs transition-colors",
+                            pageNumber === page
+                              ? "border-accent bg-accent text-white shadow-sm"
+                              : "border-accent/10 bg-surface text-ink-muted hover:border-secondary/40 hover:text-accent"
+                          )}
+                        >
+                          {page}
+                        </button>
+                      );
+                    })}
                   </div>
                 )}
               </div>
             </div>
-
-            {pageCount > 1 && (
-              <div className="flex items-center gap-2 overflow-x-auto rounded-2xl border border-border/40 bg-white px-4 py-3 shadow-sm">
-                {Array.from({ length: pageCount }).map((_, index) => {
-                  const page = index + 1;
-                  return (
-                    <button
-                      key={`page-thumb-${page}`}
-                      type="button"
-                      onClick={() => setPageNumber(page)}
-                      className={`rounded-xl border px-3 py-1 text-xs font-semibold transition ${
-                        pageNumber === page
-                          ? "border-accent bg-accent text-white shadow"
-                          : "border-transparent bg-muted/70 text-muted-foreground hover:border-accent/30 hover:text-brand-text"
-                      }`}
-                    >
-                      Page {page}
-                    </button>
-                  );
-                })}
-              </div>
-            )}
           </>
         )}
       </main>

--- a/app/dashboard/messages/[room]/page.jsx
+++ b/app/dashboard/messages/[room]/page.jsx
@@ -19,6 +19,12 @@ import { toast } from "sonner";
 import Link from "next/link";
 import Loader from "@/components/molecules/loaders/rootLoader";
 import { markMessagesAsRead } from "@/hooks/markMessageAsRead";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 export default function Page({ params }) {
   const router = useRouter();
@@ -143,8 +149,8 @@ export default function Page({ params }) {
   };
 
   return (
-    <div className="flex h-full w-full flex-col overflow-hidden overscroll-none">
-      <div className="flex items-center gap-2 p-2 sm:p-4 border-t border-b bg-accent/10 border-b-accent/20 rounded-t-2xl">
+    <div className="flex h-full w-full flex-col overflow-hidden overscroll-none bg-surface">
+      <div className="flex items-center gap-2 rounded-t-2xl border-b border-accent/20 bg-surface-raised p-2 shadow-sm sm:p-4">
         <Button
           variant="ghost"
           size="icon"
@@ -152,7 +158,7 @@ export default function Page({ params }) {
           onClick={() => router.push("/dashboard/messages")}
           aria-label="Back to messages list"
         >
-          <ArrowLeft className="h-5 w-5" />
+          <ArrowLeft className="h-5 w-5 text-accent" />
         </Button>
         <Link href={`/account/profile/${otherParticipantInfo?._id}`}>
           <Avatar className="h-10 w-10 sm:h-13 sm:w-13">
@@ -164,20 +170,40 @@ export default function Page({ params }) {
         </Link>
         <Link href={`/account/profile/${otherParticipantInfo?._id}`}>
           <div className="flex-1 min-w-0">
-            <h2 className="font-semibold font-stretch-125% text-sm sm:text-base truncate">
+            <h2
+              className={cn(
+                poppins_600,
+                "truncate text-sm text-ink sm:text-base"
+              )}
+            >
               {otherParticipantInfo?.name}
             </h2>
             {otherOnline ? (
-              <p className="text-xs sm:text-sm text-green-500">Active now</p>
+              <p
+                className={cn(
+                  poppins_500,
+                  "text-xs text-secondary sm:text-sm"
+                )}
+              >
+                Active now
+              </p>
             ) : otherLastSeen ? (
-              <p className="text-xs sm:text-sm text-muted-foreground">
+              <p
+                className={cn(
+                  poppins_400,
+                  "text-xs text-ink-muted sm:text-sm"
+                )}
+              >
                 Last seen {formatDistanceToNow(otherLastSeen.toDate?.() || otherLastSeen, { addSuffix: true })}
               </p>
             ) : null}
             {/* Show typing indicator */}
             {Object.entries(typingUsers).map(([uid, isTyping]) =>
               uid !== user._id && isTyping ? (
-                <p key={uid} className="text-xs text-muted-foreground">
+                <p
+                  key={uid}
+                  className={cn(poppins_400, "text-xs text-ink-muted")}
+                >
                   typing...
                 </p>
               ) : null
@@ -185,12 +211,17 @@ export default function Page({ params }) {
           </div>
         </Link>
         {otherOnline && (
-          <div className="h-2 w-2 rounded-full bg-green-500" />
+          <div className="h-2 w-2 rounded-full bg-secondary" />
         )}
       </div>
 
       {error && (
-        <div className="bg-destructive/15 text-destructive px-3 py-1.5 sm:px-4 sm:py-2 text-xs sm:text-sm">
+        <div
+          className={cn(
+            poppins_400,
+            "bg-red-50 px-3 py-1.5 text-xs text-red-600 sm:px-4 sm:py-2 sm:text-sm"
+          )}
+        >
           {error}
         </div>
       )}
@@ -199,7 +230,12 @@ export default function Page({ params }) {
         {isLoading ? (
           <Loader />
         ) : messages.length === 0 ? (
-          <div className="flex justify-center items-center h-full text-muted-foreground text-sm sm:text-base">
+          <div
+            className={cn(
+              poppins_400,
+              "flex h-full items-center justify-center text-sm text-ink-muted sm:text-base"
+            )}
+          >
             No messages yet. Start the conversation!
           </div>
         ) : (
@@ -256,15 +292,17 @@ export default function Page({ params }) {
                   } max-w-[85%] sm:max-w-[70%]`}
                 >
                   <div
-                    className={`rounded-2xl px-3 py-2 sm:px-4 sm:py-2.5 text-sm ${
+                    className={cn(
+                      poppins_400,
+                      "rounded-2xl px-3 py-2 text-sm shadow-sm sm:px-4 sm:py-2.5",
                       isOwnMessage
-                        ? "bg-accent text-white rounded-tr-none"
-                        : "bg-muted rounded-tl-none"
-                    } shadow-sm`}
+                        ? "rounded-tr-none bg-accent text-white"
+                        : "rounded-tl-none border border-accent/10 bg-surface-raised text-ink"
+                    )}
                   >
                     {msg.text || msg.content}
                   </div>
-                  <span className="text-xs text-muted-foreground">
+                  <span className={cn(poppins_400, "text-xs text-ink-muted")}>
                     {showTime &&
                       (() => {
                         try {
@@ -287,7 +325,7 @@ export default function Page({ params }) {
       </div>
 
       <form
-        className="border-b-4 rounded-b-2xl p-2 sm:p-4 bg-accent/10 "
+        className="rounded-b-2xl border-t border-accent/20 bg-surface-raised p-2 sm:p-4"
         onSubmit={handleSendMessage}
       >
         <div className="flex relative max-w-4xl mx-auto gap-4">
@@ -300,7 +338,10 @@ export default function Page({ params }) {
               // Optionally, debounce and set to false after user stops typing
             }}
             onBlur={() => setTyping(room, user._id, false)}
-            className="min-h-[40px] sm:min-h-[44px] resize-none pr-10 sm:pr-12 rounded-full border-none shadow-none focus:outline-none bg-muted/50 text-sm sm:text-base"
+            className={cn(
+              poppins_400,
+              "min-h-[40px] resize-none rounded-full border border-accent/15 bg-surface pr-10 text-sm shadow-none focus:outline-none sm:min-h-[44px] sm:pr-12 sm:text-base"
+            )}
             onKeyDown={(e) => {
               if (e.key === "Enter" && !e.shiftKey) {
                 e.preventDefault();

--- a/app/dashboard/purchases/page.jsx
+++ b/app/dashboard/purchases/page.jsx
@@ -10,8 +10,6 @@ import {
   Library,
   CircleAlert,
 } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import Button from "@/components/atoms/form/Button";
 import {
@@ -23,14 +21,33 @@ import {
 } from "@/components/ui/dialog";
 import usePurchases from "@/hooks/usePurchases";
 import dayjs from "dayjs";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const statusColors = {
-  confirmed: "bg-success/10 text-success",
-  pending: "bg-warning/10 text-warning",
-  submitted: "bg-info/10 text-info",
-  failed: "bg-error/10 text-error",
-  expired: "bg-muted text-muted-foreground",
+  confirmed: "bg-secondary/10 text-secondary",
+  pending: "bg-amber-100 text-amber-600",
+  submitted: "bg-sky-100 text-accent",
+  failed: "bg-red-100 text-red-600",
+  expired: "bg-accent/10 text-ink-muted",
 };
+
+/* ── building blocks (design-system consistent) ── */
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
 
 function truncateAddress(addr) {
   if (!addr) return "";
@@ -42,72 +59,100 @@ function ReceiptModal({ open, onClose, item, receipt, itemType }) {
 
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="sm:max-w-md">
+      <DialogContent className="border border-accent/10 bg-surface-raised sm:max-w-md">
         <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Receipt className="h-5 w-5" />
+          <DialogTitle
+            className={cn(poppins_600, "flex items-center gap-2 text-ink")}
+          >
+            <Receipt className="h-5 w-5 text-accent" />
             Payment Receipt
           </DialogTitle>
-          <DialogDescription>
+          <DialogDescription className={cn(poppins_400, "text-ink-muted")}>
             Transaction details for your purchase
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="p-4 bg-muted rounded-lg space-y-2">
+          <div className="space-y-2 rounded-xl border border-accent/10 bg-surface p-4">
             <div className="flex items-center gap-2">
               {itemType === "book" ? (
-                <BookOpen className="h-4 w-4 text-muted-foreground" />
+                <BookOpen className="h-4 w-4 text-ink-muted" />
               ) : (
-                <GraduationCap className="h-4 w-4 text-muted-foreground" />
+                <GraduationCap className="h-4 w-4 text-ink-muted" />
               )}
-              <h4 className="font-semibold">{item?.title}</h4>
+              <h4 className={cn(poppins_600, "text-ink")}>{item?.title}</h4>
             </div>
-            <Badge variant="outline" className="capitalize">
+            <span
+              className={cn(
+                poppins_500,
+                "inline-flex items-center rounded-full border border-accent/15 bg-surface-raised px-3 py-0.5 text-xs capitalize text-accent"
+              )}
+            >
               {itemType}
-            </Badge>
+            </span>
           </div>
 
           {receipt ? (
             <div className="space-y-3">
-              <div className="flex justify-between items-center p-3 bg-success/5 border border-success/20 rounded-lg">
-                <span className="text-sm text-success font-medium">Amount Paid</span>
-                <span className="text-xl font-bold text-success">
+              <div className="flex items-center justify-between rounded-xl border border-secondary/20 bg-secondary/5 p-3">
+                <span className={cn(poppins_500, "text-sm text-secondary")}>
+                  Amount Paid
+                </span>
+                <span className={cn(poppins_600, "text-xl text-secondary")}>
                   ${receipt.amount?.toFixed(2)} USDC
                 </span>
               </div>
 
               <div className="grid grid-cols-2 gap-3">
-                <div className="p-3 border rounded-lg">
-                  <p className="text-xs text-muted-foreground">Status</p>
-                  <Badge variant="secondary" className={`mt-1 ${statusColors[receipt.status]}`}>
+                <div className="rounded-xl border border-accent/10 p-3">
+                  <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                    Status
+                  </p>
+                  <span
+                    className={cn(
+                      poppins_500,
+                      "mt-1 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs capitalize",
+                      statusColors[receipt.status] || statusColors.expired
+                    )}
+                  >
                     {receipt.status}
-                  </Badge>
+                  </span>
                 </div>
-                <div className="p-3 border rounded-lg">
-                  <p className="text-xs text-muted-foreground">Date</p>
-                  <p className="text-sm font-medium mt-1">
+                <div className="rounded-xl border border-accent/10 p-3">
+                  <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                    Date
+                  </p>
+                  <p className={cn(poppins_500, "mt-1 text-sm text-ink")}>
                     {dayjs(receipt.createdAt).format("MMM D, YYYY")}
                   </p>
                 </div>
               </div>
 
-              <div className="p-3 border rounded-lg">
-                <p className="text-xs text-muted-foreground">Paid To (Creator)</p>
-                <p className="text-sm font-medium mt-1">
+              <div className="rounded-xl border border-accent/10 p-3">
+                <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                  Paid To (Creator)
+                </p>
+                <p className={cn(poppins_500, "mt-1 text-sm text-ink")}>
                   {receipt.creatorName || "Creator"}
                 </p>
                 {receipt.creatorWallet && (
-                  <p className="text-xs font-mono text-muted-foreground mt-0.5">
+                  <p
+                    className={cn(
+                      poppins_400,
+                      "mt-0.5 font-mono text-xs text-ink-muted"
+                    )}
+                  >
                     {truncateAddress(receipt.creatorWallet)}
                   </p>
                 )}
               </div>
 
-              <div className="p-3 border rounded-lg">
-                <p className="text-xs text-muted-foreground">Your Wallet</p>
+              <div className="rounded-xl border border-accent/10 p-3">
+                <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                  Your Wallet
+                </p>
                 {receipt.buyerWallet && (
-                  <p className="text-sm font-mono mt-1">
+                  <p className={cn(poppins_500, "mt-1 font-mono text-sm text-ink")}>
                     {truncateAddress(receipt.buyerWallet)}
                   </p>
                 )}
@@ -118,7 +163,10 @@ function ReceiptModal({ open, onClose, item, receipt, itemType }) {
                   href={receipt.explorerUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1 text-sm text-primary hover:underline"
+                  className={cn(
+                    poppins_500,
+                    "inline-flex items-center gap-1 text-sm text-secondary hover:text-highlight"
+                  )}
                 >
                   <ExternalLink className="h-4 w-4" />
                   View on Stellar Explorer
@@ -126,13 +174,13 @@ function ReceiptModal({ open, onClose, item, receipt, itemType }) {
               )}
             </div>
           ) : (
-            <div className="p-4 border border-info/20 bg-info/5 rounded-lg text-center">
-              <p className="text-sm text-info font-medium">
+            <div className="rounded-xl border border-accent/15 bg-secondary/5 p-4 text-center">
+              <p className={cn(poppins_500, "text-sm text-accent")}>
                 Free Enrollment
               </p>
-              <p className="text-xs text-info/70 mt-1">
-                This item was free or enrolled without a Stellar payment. No on-chain
-                transaction receipt is available.
+              <p className={cn(poppins_400, "mt-1 text-xs text-ink-muted")}>
+                This item was free or enrolled without a Stellar payment. No
+                on-chain transaction receipt is available.
               </p>
             </div>
           )}
@@ -157,7 +205,7 @@ function PurchaseCard({ item, itemType, getReceipt }) {
 
   return (
     <>
-      <Card className="relative flex flex-col overflow-hidden rounded-2xl bg-muted/30 backdrop-blur-xl shadow-lg hover:shadow-2xl hover:scale-[1.015] transition-all group">
+      <Panel className="group relative flex flex-col overflow-hidden transition-all hover:-translate-y-0.5 hover:border-secondary/30 hover:shadow-md">
         <div className="relative h-48 w-full">
           <Image
             src={thumbnail}
@@ -166,37 +214,59 @@ function PurchaseCard({ item, itemType, getReceipt }) {
             className="object-cover transition-transform duration-500 group-hover:scale-105"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent" />
-          <div className="absolute top-3 left-3">
-            <Badge className="bg-white/80 text-brand-text font-bold px-3 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider">
+          <div className="absolute left-3 top-3">
+            <span
+              className={cn(
+                poppins_600,
+                "inline-flex items-center rounded-full bg-white/80 px-3 py-1 text-xs uppercase tracking-wider text-ink shadow"
+              )}
+            >
               {item.category || itemType}
-            </Badge>
+            </span>
           </div>
           <div className="absolute bottom-3 left-3 right-3 flex items-center justify-between">
-            <Badge variant="secondary" className="bg-black/60 text-white border-0">
+            <span
+              className={cn(
+                poppins_500,
+                "inline-flex items-center rounded-full bg-black/60 px-3 py-1 text-xs text-white"
+              )}
+            >
               {item.price > 0 ? `$${item.price} USDC` : "Free"}
-            </Badge>
+            </span>
             {receipt ? (
-              <Badge variant="secondary" className="bg-success/80 text-white border-0">
+              <span
+                className={cn(
+                  poppins_500,
+                  "inline-flex items-center rounded-full bg-secondary/80 px-3 py-1 text-xs text-white"
+                )}
+              >
                 Paid
-              </Badge>
+              </span>
             ) : (
-              <Badge variant="secondary" className="bg-info/80 text-white border-0">
+              <span
+                className={cn(
+                  poppins_500,
+                  "inline-flex items-center rounded-full bg-accent/80 px-3 py-1 text-xs text-white"
+                )}
+              >
                 Enrolled
-              </Badge>
+              </span>
             )}
           </div>
         </div>
 
-        <CardHeader className="pb-2">
-          <CardTitle className="text-base font-bold line-clamp-1">{title}</CardTitle>
-          <p className="text-xs text-muted-foreground line-clamp-2">
+        <div className="px-6 pb-2 pt-4">
+          <h3 className={cn(poppins_600, "line-clamp-1 text-base text-ink")}>
+            {title}
+          </h3>
+          <p className={cn(poppins_400, "line-clamp-2 text-xs text-ink-muted")}>
             {item.description || item.author?.name || ""}
           </p>
-        </CardHeader>
+        </div>
 
-        <CardContent className="pt-0 space-y-3">
+        <div className="space-y-3 px-6 pb-6 pt-0">
           <div className="flex items-center gap-2">
-            <div className="h-8 w-8 rounded-full bg-muted overflow-hidden relative">
+            <div className="relative h-8 w-8 overflow-hidden rounded-full bg-surface">
               <Image
                 src={authorAvatar}
                 alt={authorName}
@@ -205,36 +275,30 @@ function PurchaseCard({ item, itemType, getReceipt }) {
               />
             </div>
             <div className="text-xs">
-              <p className="font-medium">{authorName}</p>
-              <p className="text-muted-foreground">{itemType === "course" ? "Instructor" : "Author"}</p>
+              <p className={cn(poppins_500, "text-ink")}>{authorName}</p>
+              <p className={cn(poppins_400, "text-ink-muted")}>
+                {itemType === "course" ? "Instructor" : "Author"}
+              </p>
             </div>
           </div>
 
           <div className="flex gap-2">
-            <Button
-              round
-              to={actionHref}
-              className="flex-1"
-            >
+            <Button round to={actionHref} className="flex-1">
               {itemType === "course" ? (
-                <GraduationCap className="h-4 w-4 mr-1" />
+                <GraduationCap className="mr-1 h-4 w-4" />
               ) : (
-                <BookOpen className="h-4 w-4 mr-1" />
+                <BookOpen className="mr-1 h-4 w-4" />
               )}
               {actionLabel}
             </Button>
             {receipt && (
-              <Button
-                round
-                outlined
-                onClick={() => setReceiptOpen(true)}
-              >
+              <Button round outlined onClick={() => setReceiptOpen(true)}>
                 <Receipt className="h-4 w-4" />
               </Button>
             )}
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </Panel>
 
       <ReceiptModal
         open={receiptOpen}
@@ -249,15 +313,15 @@ function PurchaseCard({ item, itemType, getReceipt }) {
 
 function LoadingGrid() {
   return (
-    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {[...Array(6)].map((_, i) => (
-        <Card key={i} className="overflow-hidden">
+        <Panel key={i} className="overflow-hidden">
           <Skeleton className="h-48 w-full rounded-none" />
-          <CardHeader className="pb-2">
+          <div className="px-6 pb-2 pt-4">
             <Skeleton className="h-5 w-3/4" />
-            <Skeleton className="h-3 w-full mt-2" />
-          </CardHeader>
-          <CardContent className="space-y-3">
+            <Skeleton className="mt-2 h-3 w-full" />
+          </div>
+          <div className="space-y-3 px-6 pb-6 pt-0">
             <div className="flex items-center gap-2">
               <Skeleton className="h-8 w-8 rounded-full" />
               <div className="space-y-1">
@@ -266,12 +330,31 @@ function LoadingGrid() {
               </div>
             </div>
             <Skeleton className="h-9 w-full" />
-          </CardContent>
-        </Card>
+          </div>
+        </Panel>
       ))}
     </div>
   );
 }
+
+const PageHeader = ({ subtitle }) => (
+  <div className="flex items-center gap-3">
+    <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+      <Library className="h-5 w-5 text-accent" />
+    </div>
+    <div>
+      <h1
+        className={cn(
+          poppins_600,
+          "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+        )}
+      >
+        My Purchases
+      </h1>
+      <p className={cn(poppins_400, "text-sm text-ink-muted")}>{subtitle}</p>
+    </div>
+  </div>
+);
 
 export default function PurchasesPage() {
   const { courses, books, isLoading, error, getReceipt, isEmpty } = usePurchases();
@@ -279,67 +362,62 @@ export default function PurchasesPage() {
 
   if (error) {
     return (
-      <div className="p-4 sm:p-6 space-y-6">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <Library className="h-6 w-6 text-brand-text" />
-            My Purchases
-          </h1>
-          <p className="text-muted-foreground text-sm">Your owned courses and books</p>
-        </div>
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
-            <CircleAlert className="h-12 w-12 text-error" />
-            <div>
-              <h3 className="font-semibold text-lg">Failed to Load</h3>
-              <p className="text-muted-foreground text-sm mt-1">{error}</p>
-            </div>
-            <Button round outlined onClick={() => window.location.reload()}>
-              Try Again
-            </Button>
-          </CardContent>
-        </Card>
+      <div className="space-y-6 bg-surface p-4 sm:p-6">
+        <PageHeader subtitle="Your owned courses and books" />
+        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+          <div className="flex size-14 items-center justify-center rounded-2xl bg-red-50">
+            <CircleAlert className="h-7 w-7 text-red-600" />
+          </div>
+          <div>
+            <h3 className={cn(poppins_600, "text-lg text-ink")}>
+              Failed to Load
+            </h3>
+            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+              {error}
+            </p>
+          </div>
+          <Button round outlined onClick={() => window.location.reload()}>
+            Try Again
+          </Button>
+        </Panel>
       </div>
     );
   }
 
   return (
-    <div className="p-4 sm:p-6 space-y-6">
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <Library className="h-6 w-6 text-brand-text" />
-            My Purchases
-          </h1>
-          <p className="text-muted-foreground text-sm">
-            All your courses and books in one place
-          </p>
-        </div>
-      </div>
+    <div className="space-y-6 bg-surface p-4 sm:p-6">
+      <PageHeader subtitle="All your courses and books in one place" />
 
       {isLoading ? (
         <LoadingGrid />
       ) : isEmpty ? (
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
-            <Wallet className="h-12 w-12 text-muted-foreground" />
-            <div>
-              <h3 className="font-semibold text-lg">No Purchases Yet</h3>
-              <p className="text-muted-foreground text-sm mt-1 max-w-md">
-                You haven&apos;t purchased any courses or books yet. Browse our
-                library and enroll to get started.
-              </p>
-            </div>
-            <div className="flex gap-3">
-              <Button round to="/dashboard/courses">
-                Browse Courses
-              </Button>
-              <Button round outlined to="/dashboard/library">
-                Browse Books
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+          <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+            <Wallet className="h-7 w-7 text-accent" />
+          </div>
+          <div>
+            <h3 className={cn(poppins_600, "text-lg text-ink")}>
+              No Purchases Yet
+            </h3>
+            <p
+              className={cn(
+                poppins_400,
+                "mx-auto mt-1 max-w-md text-sm text-ink-muted"
+              )}
+            >
+              You haven&apos;t purchased any courses or books yet. Browse our
+              library and enroll to get started.
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <Button round to="/dashboard/courses">
+              Browse Courses
+            </Button>
+            <Button round outlined to="/dashboard/library">
+              Browse Books
+            </Button>
+          </div>
+        </Panel>
       ) : (
         <>
           {/* Tab Toggle */}
@@ -364,17 +442,17 @@ export default function PurchasesPage() {
 
           {tab === "courses" ? (
             courses.length === 0 ? (
-              <Card>
-                <CardContent className="flex flex-col items-center justify-center py-12 text-center space-y-3">
-                  <GraduationCap className="h-10 w-10 text-muted-foreground" />
-                  <p className="text-muted-foreground">No courses purchased yet</p>
-                  <Button round outlined to="/dashboard/courses">
-                    Browse Courses
-                  </Button>
-                </CardContent>
-              </Card>
+              <Panel className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+                <GraduationCap className="h-10 w-10 text-ink-muted" />
+                <p className={cn(poppins_400, "text-ink-muted")}>
+                  No courses purchased yet
+                </p>
+                <Button round outlined to="/dashboard/courses">
+                  Browse Courses
+                </Button>
+              </Panel>
             ) : (
-              <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
                 {courses.map((course) => (
                   <PurchaseCard
                     key={course._id}
@@ -386,17 +464,17 @@ export default function PurchasesPage() {
               </div>
             )
           ) : books.length === 0 ? (
-            <Card>
-              <CardContent className="flex flex-col items-center justify-center py-12 text-center space-y-3">
-                <BookOpen className="h-10 w-10 text-muted-foreground" />
-                <p className="text-muted-foreground">No books purchased yet</p>
-                <Button round outlined to="/dashboard/library">
-                  Browse Books
-                </Button>
-              </CardContent>
-            </Card>
+            <Panel className="flex flex-col items-center justify-center gap-3 py-12 text-center">
+              <BookOpen className="h-10 w-10 text-ink-muted" />
+              <p className={cn(poppins_400, "text-ink-muted")}>
+                No books purchased yet
+              </p>
+              <Button round outlined to="/dashboard/library">
+                Browse Books
+              </Button>
+            </Panel>
           ) : (
-            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
               {books.map((book) => (
                 <PurchaseCard
                   key={book._id}

--- a/app/dashboard/reels/page.jsx
+++ b/app/dashboard/reels/page.jsx
@@ -1,15 +1,17 @@
 "use client";
 
 import dynamic from "next/dynamic";
+import { cn } from "@/lib/utils";
+import { poppins_500 } from "@/lib/config/font.config";
 
 const ReelFeed = dynamic(
   () => import("@/components/organisms/reels/ReelFeed"),
   {
     ssr: false,
     loading: () => (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-muted-foreground">
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface text-ink-muted">
         <div className="h-16 w-16 animate-spin rounded-full border-b-2 border-accent" />
-        <p className="text-sm">Loading reels feed…</p>
+        <p className={cn(poppins_500, "text-sm")}>Loading reels feed…</p>
       </div>
     ),
   }

--- a/app/dashboard/sadaqah/page.jsx
+++ b/app/dashboard/sadaqah/page.jsx
@@ -1,15 +1,6 @@
 "use client";
 import { useState, useEffect, useCallback } from "react";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import Button from "@/components/atoms/form/Button";
-import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   HeartHandshake,
@@ -23,8 +14,19 @@ import {
   Sparkles,
   ShieldCheck,
   Coins,
+  TrendingUp,
+  Users,
+  MousePointerClick,
+  PenLine,
+  Landmark,
 } from "lucide-react";
 import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 import { useStellar } from "@/components/stellar/StellarProvider";
 import useStellarDonation from "@/hooks/useStellarDonation";
 import Sep7QrCode from "@/components/stellar/Sep7QrCode";
@@ -39,15 +41,56 @@ const formatAmount = (value) => {
   });
 };
 
-const formatDate = (dateString) => {
-  return new Date(dateString).toLocaleDateString("en-US", {
+const formatDate = (dateString) =>
+  new Date(dateString).toLocaleDateString("en-US", {
     year: "numeric",
     month: "short",
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
   });
-};
+
+/* ── building blocks ── */
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
+
+const Chip = ({ icon: Icon, children }) => (
+  <span
+    className={cn(
+      poppins_500,
+      "inline-flex items-center gap-1.5 rounded-full border border-secondary/20 bg-secondary/10 px-3 py-1 text-xs text-accent"
+    )}
+  >
+    <Icon className="h-3.5 w-3.5 text-accent" />
+    {children}
+  </span>
+);
+
+const SectionHeading = ({ title, subtitle }) => (
+  <div className="mb-5">
+    <h2 className={cn(poppins_600, "text-lg text-ink")}>{title}</h2>
+    {subtitle && (
+      <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+        {subtitle}
+      </p>
+    )}
+  </div>
+);
+
+const HOW_IT_WORKS = [
+  { icon: MousePointerClick, text: "Choose an amount to give" },
+  { icon: PenLine, text: "Sign the payment in your Stellar wallet" },
+  { icon: Landmark, text: "It funds the on-chain scholarship pool" },
+];
 
 export default function SadaqahPage() {
   const { connectedWallet, walletInfo, connectWallet, network, isConnecting } =
@@ -60,13 +103,11 @@ export default function SadaqahPage() {
     isProcessing,
   } = useStellarDonation();
 
-  // Fund stats state
   const [stats, setStats] = useState(null);
   const [statsLoading, setStatsLoading] = useState(true);
   const [statsError, setStatsError] = useState(null);
   const [statsUnconfigured, setStatsUnconfigured] = useState(false);
 
-  // Donation flow state
   const [step, setStep] = useState("amount"); // amount | confirm | processing | success | error
   const [selectedAmount, setSelectedAmount] = useState(10);
   const [customAmount, setCustomAmount] = useState("");
@@ -120,10 +161,8 @@ export default function SadaqahPage() {
       toast.error("Please enter a valid donation amount");
       return;
     }
-
     setStep("processing");
     const data = await initializeDonation({ amount });
-
     if (data) {
       setDonationData(data);
       setStep("confirm");
@@ -135,7 +174,6 @@ export default function SadaqahPage() {
   const handleConfirm = async () => {
     setStep("processing");
     const success = await executeDonation(donationData);
-
     if (success) {
       setResult(success);
       setStep("success");
@@ -161,151 +199,215 @@ export default function SadaqahPage() {
     setStep("amount");
   };
 
-  return (
-    <div className="p-4 sm:p-6 space-y-6">
-      {/* Hero Header */}
-      <div className="rounded-xl p-6 sm:p-8 shadow-sm bg-gradient-to-br from-green-50 via-white to-green-100/80 backdrop-blur-xl">
-        <div className="flex items-center gap-3">
-          <HeartHandshake className="h-8 w-8 text-brand-text" />
-          <h1 className="text-2xl sm:text-3xl font-bold bg-gradient-to-r from-accent via-green-500 to-highlight text-transparent bg-clip-text">
-            Sadaqah Jariyah
-          </h1>
-        </div>
-        <p className="mt-3 text-muted-foreground max-w-3xl">
-          Give a charity that keeps on giving. Your donation funds scholarships
-          for students of knowledge, held in a transparent on-chain USDC fund
-          on the Stellar network. Every contribution is publicly verifiable,
-          from your wallet to the scholarship pool.
-        </p>
-        <div className="flex flex-wrap gap-2 mt-4">
-          <Badge variant="secondary" className="gap-1">
-            <ShieldCheck className="h-3 w-3" />
-            On-chain transparency
-          </Badge>
-          <Badge variant="secondary" className="gap-1">
-            <Coins className="h-3 w-3" />
-            USDC on Stellar
-          </Badge>
-          <Badge variant="secondary" className="gap-1">
-            <Sparkles className="h-3 w-3" />
-            Funds scholarships
-          </Badge>
-        </div>
-      </div>
+  const presetActive = (preset) =>
+    customAmount === "" && selectedAmount === preset;
 
-      {/* Fund Stats */}
+  /* ── Featured pool panel (right of hero) ── */
+  const PoolPanel = () => (
+    <Panel className="flex h-full flex-col justify-center bg-gradient-to-br from-basic to-accent p-6 text-ink-inverse">
       {statsLoading ? (
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          {[...Array(3)].map((_, i) => (
-            <Skeleton key={i} className="h-24 w-full rounded-xl" />
-          ))}
+        <div className="space-y-3">
+          <Skeleton className="h-3 w-28 bg-white/20" />
+          <Skeleton className="h-9 w-40 bg-white/20" />
+          <Skeleton className="h-10 w-full bg-white/10" />
         </div>
       ) : statsUnconfigured ? (
-        <div className="p-4 border border-warning/20 bg-warning/5 rounded-lg flex items-center gap-3">
-          <AlertCircle className="h-5 w-5 text-warning shrink-0" />
-          <p className="text-sm text-warning">
-            The donation fund is not configured yet. Please check back soon,
-            insha&apos;Allah.
+        <div className="flex items-center gap-2 text-ink-inverse-muted">
+          <AlertCircle className="h-4 w-4 shrink-0" />
+          <p className={cn(poppins_400, "text-sm")}>
+            Fund not configured yet — check back soon, insha&apos;Allah.
           </p>
         </div>
       ) : statsError ? (
-        <div className="p-4 border border-error/20 bg-error/5 rounded-lg flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <AlertCircle className="h-5 w-5 text-error shrink-0" />
-            <p className="text-sm text-error">{statsError}</p>
-          </div>
-          <Button round outlined onClick={fetchStats}>
-            <RefreshCw className="h-4 w-4 mr-2" />
-            Retry
-          </Button>
+        <div className="space-y-3">
+          <p className={cn(poppins_400, "text-sm text-ink-inverse-muted")}>
+            {statsError}
+          </p>
+          <button
+            onClick={fetchStats}
+            className={cn(
+              poppins_500,
+              "inline-flex items-center gap-2 text-sm text-ink-inverse hover:opacity-80"
+            )}
+          >
+            <RefreshCw className="h-4 w-4" /> Retry
+          </button>
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <div className="rounded-xl p-4 space-y-2 shadow-sm bg-gradient-to-br from-green-50 via-white to-green-100/80 backdrop-blur-xl">
-            <p className="text-sm bg-gradient-to-r from-accent via-green-500 to-highlight text-transparent bg-clip-text">
-              Scholarship Pool Balance
-            </p>
-            <h3 className="text-2xl font-bold text-brand-text">
-              ${formatAmount(stats?.poolBalance)}{" "}
-              <span className="text-base font-medium">USDC</span>
-            </h3>
+        <>
+          <p
+            className={cn(
+              poppins_500,
+              "text-xs uppercase tracking-wider text-ink-inverse-muted"
+            )}
+          >
+            Scholarship Pool Balance
+          </p>
+          <p className={cn(poppins_600, "mt-1 text-4xl leading-none")}>
+            ${formatAmount(stats?.poolBalance)}
+            <span
+              className={cn(poppins_500, "ml-1 text-lg text-ink-inverse-muted")}
+            >
+              USDC
+            </span>
+          </p>
+          <div className="mt-5 grid grid-cols-2 gap-3">
+            <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">
+              <p className={cn(poppins_400, "text-[11px] text-ink-inverse-muted")}>
+                Total donated
+              </p>
+              <p className={cn(poppins_600, "text-base text-ink-inverse")}>
+                ${formatAmount(stats?.totalDonated)}
+              </p>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">
+              <p className={cn(poppins_400, "text-[11px] text-ink-inverse-muted")}>
+                Donations
+              </p>
+              <p className={cn(poppins_600, "text-base text-ink-inverse")}>
+                {stats?.donationCount ?? 0}
+              </p>
+            </div>
           </div>
-          <div className="rounded-xl p-4 space-y-2 shadow-sm bg-gradient-to-br from-green-50 via-white to-green-100/80 backdrop-blur-xl">
-            <p className="text-sm bg-gradient-to-r from-accent via-green-500 to-highlight text-transparent bg-clip-text">
-              Total Donated
-            </p>
-            <h3 className="text-2xl font-bold text-brand-text">
-              ${formatAmount(stats?.totalDonated)}{" "}
-              <span className="text-base font-medium">USDC</span>
-            </h3>
-          </div>
-          <div className="rounded-xl p-4 space-y-2 shadow-sm bg-gradient-to-br from-green-50 via-white to-green-100/80 backdrop-blur-xl">
-            <p className="text-sm bg-gradient-to-r from-accent via-green-500 to-highlight text-transparent bg-clip-text">
-              Donations
-            </p>
-            <h3 className="text-2xl font-bold text-brand-text">
-              {stats?.donationCount ?? 0}
-            </h3>
-          </div>
-        </div>
+        </>
       )}
+    </Panel>
+  );
 
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Donate Card */}
-        <Card className="lg:col-span-2">
-          <CardHeader>
-            <CardTitle>
-              {step === "success" ? "Donation Complete!" : "Make a Donation"}
-            </CardTitle>
-            <CardDescription>
-              {step === "amount" &&
-                "Choose an amount to donate to the scholarship fund"}
-              {step === "confirm" &&
-                "Sign with your wallet, or scan the QR with a mobile wallet"}
-              {step === "processing" && "Processing your donation..."}
-              {step === "success" && "May Allah accept it from you"}
-              {step === "error" && "Something went wrong"}
-            </CardDescription>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            {/* Amount Selection */}
+  return (
+    <div className="space-y-6 bg-surface p-4 sm:p-6">
+      {/* ── Hero + featured pool (2/3 · 1/3) ── */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <Panel className="relative overflow-hidden bg-gradient-to-br from-secondary/10 via-surface-raised to-highlight/10 p-6 sm:p-8 lg:col-span-2">
+          <div className="pointer-events-none absolute -right-10 -top-10 h-40 w-40 rounded-full bg-secondary/10 blur-3xl" />
+          <div className="relative">
+            <div className="flex items-center gap-3">
+              <div className="flex size-12 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+                <HeartHandshake className="h-6 w-6 text-accent" />
+              </div>
+              <h1
+                className={cn(
+                  poppins_600,
+                  "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent sm:text-3xl"
+                )}
+              >
+                Sadaqah Jariyah
+              </h1>
+            </div>
+            <p
+              className={cn(
+                poppins_400,
+                "mt-3 max-w-xl leading-relaxed text-ink-muted"
+              )}
+            >
+              Give a charity that keeps on giving. Your donation funds
+              scholarships for students of knowledge, held in a transparent
+              on-chain USDC fund on Stellar — publicly verifiable, from your
+              wallet to the pool.
+            </p>
+            <div className="mt-5 flex flex-wrap gap-2">
+              <Chip icon={ShieldCheck}>On-chain transparency</Chip>
+              <Chip icon={Coins}>USDC on Stellar</Chip>
+              <Chip icon={Sparkles}>Funds scholarships</Chip>
+            </div>
+          </div>
+        </Panel>
+
+        <PoolPanel />
+      </div>
+
+      {/* ── Give (2/3) · sidebar (1/3) ── */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Give */}
+        <Panel className="p-6 lg:col-span-2">
+          <SectionHeading
+            title={step === "success" ? "Donation Complete!" : "Make a Donation"}
+            subtitle={
+              {
+                amount: "Choose an amount to donate to the scholarship fund",
+                confirm: "Sign with your wallet, or scan the QR with a mobile wallet",
+                processing: "Processing your donation…",
+                success: "May Allah accept it from you",
+                error: "Something went wrong",
+              }[step]
+            }
+          />
+
+          <div className="space-y-5">
             {step === "amount" && (
               <>
-                <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
                   {PRESET_AMOUNTS.map((preset) => (
-                    <Button
+                    <button
                       key={preset}
                       type="button"
-                      round
-                      outlined={!(customAmount === "" && selectedAmount === preset)}
-                      className={customAmount === "" && selectedAmount === preset ? "bg-accent text-white h-12 text-base" : "h-12 text-base"}
                       onClick={() => handlePresetSelect(preset)}
+                      className={cn(
+                        poppins_600,
+                        "flex h-16 flex-col items-center justify-center rounded-xl border text-lg transition-all",
+                        presetActive(preset)
+                          ? "border-accent bg-accent text-white shadow-md"
+                          : "border-accent/15 bg-surface text-ink hover:border-secondary/50 hover:bg-secondary/5"
+                      )}
                     >
                       ${preset}
-                    </Button>
+                      <span
+                        className={cn(
+                          poppins_400,
+                          "text-[10px] uppercase tracking-wider",
+                          presetActive(preset)
+                            ? "text-white/70"
+                            : "text-ink-muted"
+                        )}
+                      >
+                        USDC
+                      </span>
+                    </button>
                   ))}
                 </div>
-                <div className="space-y-1">
+
+                <div className="space-y-1.5">
                   <label
                     htmlFor="custom-amount"
-                    className="text-sm text-muted-foreground"
+                    className={cn(poppins_500, "text-sm text-ink-muted")}
                   >
-                    Or enter a custom amount (USDC)
+                    Or enter a custom amount
                   </label>
-                  <Input
-                    id="custom-amount"
-                    type="text"
-                    inputMode="decimal"
-                    placeholder="e.g. 50"
-                    value={customAmount}
-                    onChange={handleCustomChange}
-                  />
+                  <div className="relative">
+                    <span
+                      className={cn(
+                        poppins_600,
+                        "pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-ink-muted"
+                      )}
+                    >
+                      $
+                    </span>
+                    <input
+                      id="custom-amount"
+                      type="text"
+                      inputMode="decimal"
+                      placeholder="e.g. 50"
+                      value={customAmount}
+                      onChange={handleCustomChange}
+                      className={cn(
+                        poppins_500,
+                        "w-full rounded-xl border border-accent/15 bg-surface py-3 pl-8 pr-16 text-ink outline-none transition-colors placeholder:text-ink-muted/60 focus:border-secondary focus:ring-2 focus:ring-secondary/20"
+                      )}
+                    />
+                    <span
+                      className={cn(
+                        poppins_500,
+                        "pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs uppercase tracking-wider text-ink-muted"
+                      )}
+                    >
+                      USDC
+                    </span>
+                  </div>
                 </div>
 
-                {/* Wallet Not Connected */}
                 {!connectedWallet ? (
-                  <div className="p-4 border border-warning/20 bg-warning/5 rounded-lg">
-                    <p className="text-sm text-warning mb-3">
+                  <div className="rounded-xl border border-secondary/20 bg-secondary/5 p-4">
+                    <p className={cn(poppins_500, "mb-3 text-sm text-accent")}>
                       Connect your Stellar wallet to donate
                     </p>
                     <Button
@@ -317,7 +419,7 @@ export default function SadaqahPage() {
                       {isConnecting ? (
                         <>
                           <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                          Connecting...
+                          Connecting…
                         </>
                       ) : (
                         <>
@@ -328,33 +430,37 @@ export default function SadaqahPage() {
                     </Button>
                   </div>
                 ) : (
-                  <div className="p-4 border rounded-lg space-y-3">
-                    <div className="flex justify-between items-center">
-                      <span className="text-sm text-muted-foreground">
-                        USDC Balance
+                  <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-accent/10 bg-surface px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <Wallet className="h-4 w-4 text-accent" />
+                      <span className={cn(poppins_400, "text-sm text-ink-muted")}>
+                        Balance
                       </span>
                       <span
-                        className={`font-semibold ${
-                          hasInsufficientBalance
-                            ? "text-error"
-                            : "text-success"
-                        }`}
+                        className={cn(
+                          poppins_600,
+                          "text-sm",
+                          hasInsufficientBalance ? "text-red-600" : "text-ink"
+                        )}
                       >
                         {formatAmount(walletInfo?.usdcBalance)} USDC
                       </span>
                     </div>
-                    <div className="flex justify-between items-center">
-                      <span className="text-sm text-muted-foreground">
-                        Network
-                      </span>
-                      <Badge variant="secondary">{network}</Badge>
-                    </div>
-                    {hasInsufficientBalance && (
-                      <p className="text-sm text-error">
-                        Insufficient USDC balance for this amount.
-                      </p>
-                    )}
+                    <span
+                      className={cn(
+                        poppins_500,
+                        "rounded-full border border-accent/15 bg-surface-raised px-3 py-0.5 text-xs capitalize text-accent"
+                      )}
+                    >
+                      {network}
+                    </span>
                   </div>
+                )}
+
+                {connectedWallet && hasInsufficientBalance && (
+                  <p className={cn(poppins_400, "text-sm text-red-600")}>
+                    Insufficient USDC balance for this amount.
+                  </p>
                 )}
 
                 {connectedWallet && (
@@ -380,24 +486,30 @@ export default function SadaqahPage() {
               </>
             )}
 
-            {/* Confirm Step */}
             {step === "confirm" && donationData && (
               <>
-                <div className="p-4 border border-info/20 bg-info/5 rounded-lg space-y-1">
-                  <p className="text-sm text-info font-medium">
+                <div className="space-y-1 rounded-xl border border-secondary/20 bg-secondary/5 p-4">
+                  <p className={cn(poppins_500, "text-sm text-accent")}>
                     Please confirm the transaction in your wallet extension.
                   </p>
-                  <div className="flex items-center gap-2 text-sm text-info/80">
-                    <span className="text-muted-foreground">Donating:</span>
-                    <span className="font-semibold">
+                  <div className="flex items-center gap-2 text-sm">
+                    <span className={cn(poppins_400, "text-ink-muted")}>
+                      Donating:
+                    </span>
+                    <span className={cn(poppins_600, "text-ink")}>
                       ${formatAmount(donationData.amount)} USDC
                     </span>
                   </div>
                 </div>
 
                 {donationData.sep7Uri && (
-                  <div className="p-4 border rounded-lg">
-                    <p className="text-sm font-medium text-center mb-3">
+                  <div className="rounded-xl border border-accent/10 bg-surface p-4">
+                    <p
+                      className={cn(
+                        poppins_500,
+                        "mb-3 text-center text-sm text-ink"
+                      )}
+                    >
                       Prefer mobile? Pay by QR instead
                     </p>
                     <Sep7QrCode uri={donationData.sep7Uri} />
@@ -405,45 +517,40 @@ export default function SadaqahPage() {
                 )}
 
                 <div className="flex gap-3">
-                  <Button
-                    round
-                    outlined
-                    onClick={handleBack}
-                    className="flex-1"
-                  >
+                  <Button round outlined onClick={handleBack} className="flex-1">
                     Back
                   </Button>
                   <Button round onClick={handleConfirm} className="flex-1">
                     <Wallet className="mr-2 h-4 w-4" />
-                    Sign & Donate
+                    Sign &amp; Donate
                   </Button>
                 </div>
               </>
             )}
 
-            {/* Processing Step */}
             {step === "processing" && (
-              <div className="flex flex-col items-center py-8">
-                <Loader2 className="h-12 w-12 animate-spin text-primary" />
-                <p className="mt-4 text-muted-foreground">
+              <div className="flex flex-col items-center py-10">
+                <Loader2 className="h-12 w-12 animate-spin text-secondary" />
+                <p className={cn(poppins_500, "mt-4 text-ink")}>
                   {isProcessing
-                    ? "Processing donation..."
-                    : "Preparing transaction..."}
+                    ? "Processing donation…"
+                    : "Preparing transaction…"}
                 </p>
-                <p className="text-xs text-muted-foreground mt-2">
+                <p className={cn(poppins_400, "mt-2 text-xs text-ink-muted")}>
                   Please check your wallet for the signing request
                 </p>
               </div>
             )}
 
-            {/* Success Step */}
             {step === "success" && (
-              <div className="text-center py-4">
-                <CheckCircle className="h-16 w-16 text-success mx-auto" />
-                <h3 className="text-xl font-semibold mt-4">
+              <div className="py-6 text-center">
+                <div className="mx-auto flex size-16 items-center justify-center rounded-full bg-secondary/10">
+                  <CheckCircle className="h-9 w-9 text-secondary" />
+                </div>
+                <h3 className={cn(poppins_600, "mt-4 text-xl text-ink")}>
                   JazakAllahu Khairan!
                 </h3>
-                <p className="text-muted-foreground mt-2">
+                <p className={cn(poppins_400, "mt-2 text-ink-muted")}>
                   Your donation was recorded on the Stellar network.
                 </p>
                 {result?.explorerUrl && (
@@ -451,10 +558,12 @@ export default function SadaqahPage() {
                     href={result.explorerUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-sm text-primary mt-4 hover:underline"
+                    className={cn(
+                      poppins_500,
+                      "mt-4 inline-flex items-center gap-1 text-sm text-secondary hover:text-highlight"
+                    )}
                   >
-                    View on Stellar Explorer{" "}
-                    <ExternalLink className="h-3 w-3" />
+                    View on Stellar Explorer <ExternalLink className="h-3 w-3" />
                   </a>
                 )}
                 <Button round wide onClick={handleReset} className="mt-6">
@@ -463,45 +572,49 @@ export default function SadaqahPage() {
               </div>
             )}
 
-            {/* Error Step */}
             {step === "error" && (
-              <div className="text-center py-4">
-                <AlertCircle className="h-16 w-16 text-error mx-auto" />
-                <h3 className="text-xl font-semibold mt-4">Donation Failed</h3>
-                <p className="text-muted-foreground mt-2">{error}</p>
+              <div className="py-6 text-center">
+                <div className="mx-auto flex size-16 items-center justify-center rounded-full bg-red-50">
+                  <AlertCircle className="h-9 w-9 text-red-600" />
+                </div>
+                <h3 className={cn(poppins_600, "mt-4 text-xl text-ink")}>
+                  Donation Failed
+                </h3>
+                <p className={cn(poppins_400, "mt-2 text-ink-muted")}>{error}</p>
                 <Button round wide onClick={handleReset} className="mt-6">
                   Try Again
                 </Button>
               </div>
             )}
-          </CardContent>
-        </Card>
+          </div>
+        </Panel>
 
-        {/* Recent Donations */}
-        <Card>
-          <CardHeader>
-            <CardTitle>Recent Donations</CardTitle>
-            <CardDescription>
-              Latest contributions to the fund, verifiable on-chain
-            </CardDescription>
-          </CardHeader>
-          <CardContent>
+        {/* Sidebar: recent + how it works */}
+        <div className="space-y-6">
+          <Panel className="p-6">
+            <SectionHeading
+              title="Recent Donations"
+              subtitle="Latest contributions, verifiable on-chain"
+            />
             {statsLoading ? (
               <div className="space-y-2">
-                {[...Array(5)].map((_, i) => (
-                  <Skeleton key={i} className="h-14 w-full" />
+                {[...Array(4)].map((_, i) => (
+                  <Skeleton key={i} className="h-14 w-full rounded-xl" />
                 ))}
               </div>
             ) : statsUnconfigured || statsError ? (
-              <div className="text-center py-8 border rounded-lg">
-                <p className="text-sm text-muted-foreground">
+              <div className="rounded-xl border border-dashed border-accent/15 py-8 text-center">
+                <p className={cn(poppins_400, "text-sm text-ink-muted")}>
                   Donation activity is unavailable right now
                 </p>
               </div>
             ) : !stats?.recent?.length ? (
-              <div className="text-center py-8 border rounded-lg">
-                <p className="text-muted-foreground">No donations yet</p>
-                <p className="text-sm text-muted-foreground mt-1">
+              <div className="rounded-xl border border-dashed border-accent/15 py-10 text-center">
+                <div className="mx-auto mb-3 flex size-11 items-center justify-center rounded-xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+                  <HeartHandshake className="h-5 w-5 text-accent" />
+                </div>
+                <p className={cn(poppins_500, "text-ink")}>No donations yet</p>
+                <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
                   Be the first to give Sadaqah Jariyah
                 </p>
               </div>
@@ -510,25 +623,32 @@ export default function SadaqahPage() {
                 {stats.recent.map((donation, i) => (
                   <div
                     key={donation.txHash || i}
-                    className="flex items-center justify-between p-3 border rounded-lg"
+                    className="flex items-center justify-between rounded-xl border border-accent/10 bg-surface p-3 transition-colors hover:border-secondary/30"
                   >
-                    <div>
-                      <p className="font-semibold text-brand-text">
-                        ${formatAmount(donation.amount)}{" "}
-                        <span className="text-muted-foreground text-sm font-normal">
-                          USDC
-                        </span>
-                      </p>
-                      <p className="text-xs text-muted-foreground">
-                        {formatDate(donation.createdAt)}
-                      </p>
+                    <div className="flex items-center gap-3">
+                      <div className="flex size-9 items-center justify-center rounded-lg bg-gradient-to-br from-secondary/15 to-highlight/10">
+                        <HeartHandshake className="h-4 w-4 text-accent" />
+                      </div>
+                      <div>
+                        <p className={cn(poppins_600, "text-ink")}>
+                          ${formatAmount(donation.amount)}{" "}
+                          <span
+                            className={cn(poppins_400, "text-xs text-ink-muted")}
+                          >
+                            USDC
+                          </span>
+                        </p>
+                        <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                          {formatDate(donation.createdAt)}
+                        </p>
+                      </div>
                     </div>
                     {donation.explorerUrl && (
                       <a
                         href={donation.explorerUrl}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="text-primary hover:text-primary/80"
+                        className="text-secondary transition-colors hover:text-highlight"
                         title="View on Stellar Explorer"
                       >
                         <ExternalLink className="h-4 w-4" />
@@ -538,8 +658,35 @@ export default function SadaqahPage() {
                 ))}
               </div>
             )}
-          </CardContent>
-        </Card>
+          </Panel>
+
+          <Panel className="p-6">
+            <SectionHeading title="How it works" />
+            <ol className="space-y-4">
+              {HOW_IT_WORKS.map((s, i) => (
+                <li key={i} className="flex items-start gap-3">
+                  <div className="flex size-9 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+                    <s.icon className="h-4 w-4 text-accent" />
+                  </div>
+                  <div className="pt-1">
+                    <p className={cn(poppins_500, "text-sm text-ink")}>
+                      <span className="text-ink-muted">{i + 1}.</span> {s.text}
+                    </p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+            <p
+              className={cn(
+                poppins_400,
+                "mt-5 border-t border-accent/10 pt-4 text-xs leading-relaxed text-ink-muted"
+              )}
+            >
+              Non-custodial: you sign every payment yourself. DeenBridge never
+              holds your funds — they go straight to the on-chain pool.
+            </p>
+          </Panel>
+        </div>
       </div>
     </div>
   );

--- a/app/dashboard/saved/page.jsx
+++ b/app/dashboard/saved/page.jsx
@@ -7,10 +7,26 @@ import LibraryBookCard from "@/components/molecules/dashboard/cards/libraryCard"
 import CourseCardSkeleton from "@/components/atoms/skeletons/CourseCardSkeleton";
 import LibraryBookSkeleton from "@/components/atoms/skeletons/LibraryBookSkeleton";
 import Button from "@/components/atoms/form/Button";
-import { Card, CardContent } from "@/components/ui/card";
 import { getBookmarkedCourses } from "@/lib/actions/courses/bookmark-course";
 import { getBookmarkedBooks } from "@/lib/actions/library/bookmark-book";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
 
 export default function SavedPage() {
   const [activeTab, setActiveTab] = useState("courses");
@@ -91,15 +107,24 @@ export default function SavedPage() {
   }
 
   return (
-    <div className="p-4 sm:p-6 space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold flex items-center gap-2">
-          <Bookmark className="h-6 w-6 text-brand-text fill-accent" />
-          My Saved Hub
-        </h1>
-        <p className="text-muted-foreground text-sm mt-1">
-          Access all your bookmarked courses and books in one place
-        </p>
+    <div className="space-y-6 bg-surface p-4 sm:p-6">
+      <div className="flex items-center gap-3">
+        <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+          <Bookmark className="h-5 w-5 fill-accent text-accent" />
+        </div>
+        <div>
+          <h1
+            className={cn(
+              poppins_600,
+              "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+            )}
+          >
+            My Saved Hub
+          </h1>
+          <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+            Access all your bookmarked courses and books in one place
+          </p>
+        </div>
       </div>
 
       {/* Tab Toggle */}
@@ -137,20 +162,22 @@ export default function SavedPage() {
         </div>
       ) : activeTab === "courses" ? (
         courses.length === 0 ? (
-          <Card>
-            <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
-              <LaptopMinimal className="h-12 w-12 text-muted-foreground" />
-              <div>
-                <h3 className="font-semibold text-lg">No Saved Courses</h3>
-                <p className="text-muted-foreground text-sm mt-1 max-w-md">
-                  Explore our catalog and bookmark courses you are interested in.
-                </p>
-              </div>
-              <Button round outlined onClick={() => window.location.href = "/dashboard/courses"}>
-                Browse Courses
-              </Button>
-            </CardContent>
-          </Card>
+          <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+            <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+              <LaptopMinimal className="h-7 w-7 text-accent" />
+            </div>
+            <div>
+              <h3 className={cn(poppins_600, "text-lg text-ink")}>
+                No Saved Courses
+              </h3>
+              <p className={cn(poppins_400, "mt-1 max-w-md text-sm text-ink-muted")}>
+                Explore our catalog and bookmark courses you are interested in.
+              </p>
+            </div>
+            <Button round outlined onClick={() => window.location.href = "/dashboard/courses"}>
+              Browse Courses
+            </Button>
+          </Panel>
         ) : (
           <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
             {courses.map((course) => (
@@ -166,20 +193,22 @@ export default function SavedPage() {
           </div>
         )
       ) : books.length === 0 ? (
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
-            <Book className="h-12 w-12 text-muted-foreground" />
-            <div>
-              <h3 className="font-semibold text-lg">No Saved Books</h3>
-              <p className="text-muted-foreground text-sm mt-1 max-w-md">
-                Browse our Islamic library and save books to build your personal reading list.
-              </p>
-            </div>
-            <Button round outlined onClick={() => window.location.href = "/dashboard/library"}>
-              Browse Library
-            </Button>
-          </CardContent>
-        </Card>
+        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+          <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+            <Book className="h-7 w-7 text-accent" />
+          </div>
+          <div>
+            <h3 className={cn(poppins_600, "text-lg text-ink")}>
+              No Saved Books
+            </h3>
+            <p className={cn(poppins_400, "mt-1 max-w-md text-sm text-ink-muted")}>
+              Browse our Islamic library and save books to build your personal reading list.
+            </p>
+          </div>
+          <Button round outlined onClick={() => window.location.href = "/dashboard/library"}>
+            Browse Library
+          </Button>
+        </Panel>
       ) : (
         <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
           {books.map((book) => (

--- a/app/dashboard/search/[searchparam]/page.jsx
+++ b/app/dashboard/search/[searchparam]/page.jsx
@@ -2,9 +2,13 @@
 import React, { useEffect, useState } from "react";
 import Link from "next/link";
 import { searchQuery } from "@/hooks/useSearch";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import Image from "next/image";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const typeLabels = {
   course: "Course",
@@ -38,16 +42,26 @@ const typeDescription = (item) => {
 const typeBadge = (item) => {
   if (item.type === "course" || item.type === "book" || item.type === "space") {
     return (
-      <Badge className="bg-card/80 text-brand-text font-bold px-3 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider">
+      <span
+        className={cn(
+          poppins_600,
+          "rounded-full border border-accent/15 bg-surface-raised/90 px-3 py-1 text-xs uppercase tracking-wider text-ink shadow-sm"
+        )}
+      >
         {item.category || typeLabels[item.type]}
-      </Badge>
+      </span>
     );
   }
   if (item.type === "user") {
     return (
-      <Badge className="bg-accent text-white font-bold px-3 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider">
+      <span
+        className={cn(
+          poppins_600,
+          "rounded-full bg-accent px-3 py-1 text-xs uppercase tracking-wider text-white shadow-sm"
+        )}
+      >
         User
-      </Badge>
+      </span>
     );
   }
   return null;
@@ -74,14 +88,19 @@ const Page = ({ params }) => {
   };
 
   return (
-    <div className="min-h-screen bg-background py-8 px-2 sm:px-6">
-      <h1 className="text-3xl md:text-4xl font-bold mb-8 text-left bg-gradient-to-r from-accent via-green-500 to-highlight text-transparent bg-clip-text">
+    <div className="min-h-screen bg-surface px-2 py-8 sm:px-6">
+      <h1
+        className={cn(
+          poppins_600,
+          "mb-8 bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-left text-3xl text-transparent md:text-4xl"
+        )}
+      >
         Search Results for "{searchparam}"
       </h1>
       {loading ? (
         <div className="flex flex-col items-center justify-center py-20">
           <svg
-            className="animate-spin h-10 w-10 text-brand-text mb-4"
+            className="mb-4 h-10 w-10 animate-spin text-secondary"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -100,38 +119,32 @@ const Page = ({ params }) => {
               d="M4 12a8 8 0 018-8v8z"
             ></path>
           </svg>
-          <span className="text-brand-text text-lg font-semibold">
+          <span className={cn(poppins_500, "text-lg text-ink")}>
             Searching...
           </span>
         </div>
       ) : results.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-20">
-          <svg width="80" height="80" fill="none" className="mb-4">
-            <circle
-              cx="40"
-              cy="40"
-              r="38"
-              stroke="#22c55e"
-              strokeWidth="4"
-              fill="#F7F7F7"
-            />
-            <path
-              d="M28 40h24M40 28v24"
-              stroke="#22c55e"
-              strokeWidth="4"
-              strokeLinecap="round"
-            />
-          </svg>
-          <span className="text-muted-foreground text-lg font-semibold">
+          <div className="mb-4 flex size-20 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+            <svg width="40" height="40" fill="none" className="text-accent">
+              <path
+                d="M8 20h24M20 8v24"
+                stroke="currentColor"
+                strokeWidth="4"
+                strokeLinecap="round"
+              />
+            </svg>
+          </div>
+          <span className={cn(poppins_500, "text-lg text-ink-muted")}>
             No results found.
           </span>
         </div>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {results.map((item) => (
-            <Card
+            <div
               key={item.id}
-              className="flex flex-col overflow-hidden rounded-2xl bg-card shadow-lg border-0 hover:shadow-2xl transition-all group"
+              className="group flex flex-col overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-sm transition-all hover:-translate-y-0.5 hover:border-secondary/30 hover:shadow-md"
             >
               {/* Image */}
               <div className="relative h-44 w-full">
@@ -142,27 +155,42 @@ const Page = ({ params }) => {
                   className="object-cover transition-transform duration-500 group-hover:scale-105"
                   priority
                 />
-                <div className="absolute top-3 left-3 right-3 z-20 flex justify-between">
+                <div className="absolute left-3 right-3 top-3 z-20 flex justify-between">
                   {typeBadge(item)}
                 </div>
               </div>
-              <CardHeader className="pb-2">
-                <CardTitle className="text-lg font-bold line-clamp-1 text-brand-text drop-shadow-sm mb-1">
+              <div className="px-6 pb-2 pt-4">
+                <h3
+                  className={cn(
+                    poppins_600,
+                    "mb-1 line-clamp-1 text-lg text-ink"
+                  )}
+                >
                   {item.title ||
                     item.name ||
                     item.description?.slice(0, 30) + "..."}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
+                </h3>
+              </div>
+              <div className="px-6 pb-6">
                 {/* Detailed rendering by type */}
                 {item.type === "course" && (
                   <>
-                    <p className="text-sm text-muted-foreground line-clamp-2 mb-2">
+                    <p
+                      className={cn(
+                        poppins_400,
+                        "mb-2 line-clamp-2 text-sm text-ink-muted"
+                      )}
+                    >
                       {item.description}
                     </p>
-                    <div className="flex justify-between items-center mb-2">
+                    <div className="mb-2 flex items-center justify-between">
                       {item.price !== undefined && (
-                        <span className="bg-gradient-to-r from-highlight to-accent text-white text-xs font-bold px-3 py-1 rounded-full shadow">
+                        <span
+                          className={cn(
+                            poppins_600,
+                            "rounded-full bg-gradient-to-r from-highlight to-accent px-3 py-1 text-xs text-white shadow-sm"
+                          )}
+                        >
                           {item.price ? `$${item.price}` : "Free"}
                         </span>
                       )}
@@ -171,22 +199,39 @@ const Page = ({ params }) => {
                 )}
                 {item.type === "book" && (
                   <>
-                    <p className="text-sm text-muted-foreground line-clamp-2 mb-2">
+                    <p
+                      className={cn(
+                        poppins_400,
+                        "mb-2 line-clamp-2 text-sm text-ink-muted"
+                      )}
+                    >
                       {item.description}
                     </p>
-                    <div className="flex flex-wrap gap-2 items-center mb-2">
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
                       {item.category && (
-                        <span className="bg-card/80 text-brand-text font-bold px-2 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider">
+                        <span
+                          className={cn(
+                            poppins_600,
+                            "rounded-full border border-accent/15 bg-surface px-2 py-1 text-xs uppercase tracking-wider text-ink"
+                          )}
+                        >
                           {item.category}
                         </span>
                       )}
                       {item.price !== undefined && (
-                        <span className="bg-gradient-to-r from-highlight to-accent text-white text-xs font-bold px-3 py-1 rounded-full shadow">
+                        <span
+                          className={cn(
+                            poppins_600,
+                            "rounded-full bg-gradient-to-r from-highlight to-accent px-3 py-1 text-xs text-white shadow-sm"
+                          )}
+                        >
                           {item.price ? `$${item.price}` : "Free"}
                         </span>
                       )}
                       {item.author && (
-                        <span className="text-xs text-muted-foreground">
+                        <span
+                          className={cn(poppins_400, "text-xs text-ink-muted")}
+                        >
                           By{" "}
                           {typeof item.author === "object"
                             ? item.author.name
@@ -198,7 +243,7 @@ const Page = ({ params }) => {
                 )}
                 {item.type === "user" && (
                   <>
-                    <div className="flex items-center gap-2 mb-2">
+                    <div className="mb-2 flex items-center gap-2">
                       {item.avatar && (
                         <Image
                           src={item.avatar}
@@ -208,12 +253,14 @@ const Page = ({ params }) => {
                           className="rounded-full object-cover"
                         />
                       )}
-                      <span className="font-semibold text-brand-text">
+                      <span className={cn(poppins_600, "text-ink")}>
                         {item.name}
                       </span>
                     </div>
                     {item.role && (
-                      <span className="text-xs text-muted-foreground">
+                      <span
+                        className={cn(poppins_400, "text-xs text-ink-muted")}
+                      >
                         Role: {item.role}
                       </span>
                     )}
@@ -221,32 +268,53 @@ const Page = ({ params }) => {
                 )}
                 {item.type === "space" && (
                   <>
-                    <p className="text-sm text-muted-foreground line-clamp-2 mb-2">
+                    <p
+                      className={cn(
+                        poppins_400,
+                        "mb-2 line-clamp-2 text-sm text-ink-muted"
+                      )}
+                    >
                       {item.description}
                     </p>
-                    <div className="flex flex-wrap gap-2 items-center mb-2">
+                    <div className="mb-2 flex flex-wrap items-center gap-2">
                       {item.status && (
-                        <span className="bg-gradient-to-r from-green-500 to-accent text-white text-xs rounded-full font-semibold shadow-md border-0 px-2 py-1">
+                        <span
+                          className={cn(
+                            poppins_600,
+                            "rounded-full bg-gradient-to-r from-secondary to-accent px-2 py-1 text-xs text-white shadow-sm"
+                          )}
+                        >
                           {item.status.toUpperCase()}
                         </span>
                       )}
                       {item.price !== undefined && (
-                        <span className="bg-gradient-to-r from-highlight to-accent text-white text-xs font-bold px-3 py-1 rounded-full shadow">
+                        <span
+                          className={cn(
+                            poppins_600,
+                            "rounded-full bg-gradient-to-r from-highlight to-accent px-3 py-1 text-xs text-white shadow-sm"
+                          )}
+                        >
                           {item.price ? `$${item.price}` : "Free"}
                         </span>
                       )}
                       {item.eventDate && (
-                        <span className="text-xs text-muted-foreground">
+                        <span
+                          className={cn(poppins_400, "text-xs text-ink-muted")}
+                        >
                           Event: {formatDate(item.eventDate)}
                         </span>
                       )}
                       {item.duration && (
-                        <span className="text-xs text-muted-foreground">
+                        <span
+                          className={cn(poppins_400, "text-xs text-ink-muted")}
+                        >
                           Duration: {item.duration} min
                         </span>
                       )}
                       {item.host && (
-                        <span className="text-xs text-muted-foreground">
+                        <span
+                          className={cn(poppins_400, "text-xs text-ink-muted")}
+                        >
                           Host:{" "}
                           {typeof item.host === "object"
                             ? item.host.name
@@ -258,19 +326,27 @@ const Page = ({ params }) => {
                 )}
                 {item.type === "reel" && (
                   <>
-                    <p className="text-sm text-muted-foreground line-clamp-2 mb-2">
+                    <p
+                      className={cn(
+                        poppins_400,
+                        "mb-2 line-clamp-2 text-sm text-ink-muted"
+                      )}
+                    >
                       {item.description}
                     </p>
                   </>
                 )}
                 <Link
                   href={typeLinks[item.type](item.id)}
-                  className="block w-full text-center px-4 py-2 rounded-full bg-accent text-white text-sm font-semibold shadow hover:bg-highlight transition-colors mt-2"
+                  className={cn(
+                    poppins_500,
+                    "mt-2 block w-full rounded-full bg-accent px-4 py-2 text-center text-sm text-white shadow-sm transition-colors hover:bg-highlight"
+                  )}
                 >
                   View {typeLabels[item.type]}
                 </Link>
-              </CardContent>
-            </Card>
+              </div>
+            </div>
           ))}
         </div>
       )}

--- a/app/dashboard/spaces/[spacesid]/page.jsx
+++ b/app/dashboard/spaces/[spacesid]/page.jsx
@@ -1,11 +1,16 @@
 import Image from "next/image";
 import { notFound } from "next/navigation";
-import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { DownloadCloud, Eye, Star, UserRound, BarChart3 } from "lucide-react";
+import { DownloadCloud, Eye, Star, BarChart3 } from "lucide-react";
 import { getSpaceById } from "@/lib/actions/spaces/doGetSpacesById";
 import JaasMeetingClientButtons from "@/components/organisms/dashboard/JaasMeetingClientSection";
 import { joinSpaceWaitlist } from "@/lib/actions/spaces/joinSpaceWaitlist";
+import { cn } from "@/lib/utils";
+import {
+    poppins_400,
+    poppins_500,
+    poppins_600,
+} from "@/lib/config/font.config";
 
 export default async function Page({ params }) {
     const { spacesid } = await params;
@@ -19,11 +24,11 @@ export default async function Page({ params }) {
     if (!space) return notFound();
 
     return (
-        <div className="min-h-screen py-12 px-4 md:px-12">
+        <div className="min-h-screen bg-surface py-12 px-4 md:px-12">
             <div className="max-w-7xl mx-auto grid md:grid-cols-12 gap-10">
                 {/* space Showcase */}
                 <div className="md:col-span-8 space-y-12">
-                    <div className="relative h-[500px] rounded-3xl overflow-hidden shadow-2xl border border-white/10 backdrop-blur-md bg-white/5">
+                    <div className="relative h-[500px] rounded-2xl overflow-hidden border border-accent/10 bg-surface-raised shadow-sm">
                         <Image
                             src={space.thumbnail || "/images/placeholder.jpg"}
                             alt={space.title}
@@ -34,17 +39,48 @@ export default async function Page({ params }) {
 
                     {/* Title & Category */}
                     <div className="space-y-4">
-                        <h1 className="text-5xl font-black tracking-tight">{space.title}</h1>
+                        <h1
+                            className={cn(
+                                poppins_600,
+                                "text-4xl sm:text-5xl tracking-tight text-ink"
+                            )}
+                        >
+                            {space.title}
+                        </h1>
                         <div className="flex flex-wrap items-center gap-3">
-                            <Badge className="bg-accent ">{space.category}</Badge>
-                            <Badge variant="accent" className="bg-white/10 text-highlight">
+                            <span
+                                className={cn(
+                                    poppins_500,
+                                    "inline-flex items-center rounded-full bg-accent px-3 py-1 text-xs capitalize text-white"
+                                )}
+                            >
+                                {space.category}
+                            </span>
+                            <span
+                                className={cn(
+                                    poppins_500,
+                                    "inline-flex items-center rounded-full border border-secondary/20 bg-secondary/10 px-3 py-1 text-xs text-secondary"
+                                )}
+                            >
                                 {space.price ? `$${space.price}` : "Free"}
-                            </Badge>
-                            <Badge variant="accent" className="bg-white/10 text-highlight">
+                            </span>
+                            <span
+                                className={cn(
+                                    poppins_500,
+                                    "inline-flex items-center rounded-full border border-accent/15 bg-surface-raised px-3 py-1 text-xs text-accent"
+                                )}
+                            >
                                 {space.status.toUpperCase()}
-                            </Badge>
+                            </span>
                         </div>
-                        <p className="text-md /80 leading-relaxed">{space.description}</p>
+                        <p
+                            className={cn(
+                                poppins_400,
+                                "text-base leading-relaxed text-ink-muted"
+                            )}
+                        >
+                            {space.description}
+                        </p>
                     </div>
 
                     {/* Action Buttons */}
@@ -57,32 +93,43 @@ export default async function Page({ params }) {
                 <aside className="md:col-span-4 space-y-8 sticky top-20 self-start">
 
                     {/* Host Card */}
-                    <div className="flex items-center gap-4 mt-10 bg-accent/10 p-4 rounded-2xl shadow">
-                        <Avatar className="h-14 w-14 border border-white/10 shadow-lg">
+                    <div className="flex items-center gap-4 mt-10 rounded-2xl border border-accent/10 bg-surface-raised p-4 shadow-sm">
+                        <Avatar className="h-14 w-14 border border-accent/10 shadow-sm">
                             <AvatarImage src={space.host?.avatar || "/images/avatar-placeholder.png"} />
                             <AvatarFallback>{space.host?.name?.slice(0, 2).toUpperCase() || "HN"}</AvatarFallback>
                         </Avatar>
-                        <div className="text-brand-text ">
-                            <p className="font-bold ">{space.host?.name || "Host"}</p>
-                            <p className="text-sm ">Host & Facilitator</p>
+                        <div>
+                            <p className={cn(poppins_600, "text-ink")}>
+                                {space.host?.name || "Host"}
+                            </p>
+                            <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                                Host & Facilitator
+                            </p>
                         </div>
                     </div>
 
                     {/* space Stats */}
-                    <div className="bg-accent/10 p-6 rounded-3xl  border border-white/10 shadow  space-y-4">
-                        <h3 className="text-xl font-semibold flex items-center gap-2 ">
-                            <BarChart3 className="w-5 h-5" />
+                    <div className="rounded-2xl border border-accent/10 bg-surface-raised p-6 shadow-sm space-y-4">
+                        <h3
+                            className={cn(
+                                poppins_600,
+                                "flex items-center gap-2 text-lg text-ink"
+                            )}
+                        >
+                            <div className="flex size-10 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+                                <BarChart3 className="h-5 w-5 text-accent" />
+                            </div>
                             Space Stats
                         </h3>
 
-                        <StatRow icon={<Eye className="w-4 h-4" />} label="Monthly Reads" value={space.monthlyReads} />
+                        <StatRow icon={<Eye className="w-4 h-4 text-accent" />} label="Monthly Reads" value={space.monthlyReads} />
                         <StatRow
-                            icon={<DownloadCloud className="w-4 h-4 " />}
+                            icon={<DownloadCloud className="w-4 h-4 text-accent" />}
                             label="Downloads"
                             value={space.downloads}
                         />
                         <StatRow
-                            icon={<Star className="w-4 h-4 text-yellow-400" />}
+                            icon={<Star className="w-4 h-4 text-amber-600" />}
                             label="Rating"
                             value={`${space.rating || 0} / 5`}
                         />
@@ -95,9 +142,14 @@ export default async function Page({ params }) {
 
 function StatRow({ icon, label, value }) {
     return (
-        <div className="flex justify-between items-center text-sm font-medium text-brand-text">
+        <div
+            className={cn(
+                poppins_500,
+                "flex justify-between items-center rounded-xl border border-accent/10 bg-surface px-3 py-2.5 text-sm text-ink-muted"
+            )}
+        >
             <div className="flex items-center gap-2">{icon} {label}</div>
-            <span className="font-bold">{value}</span>
+            <span className={cn(poppins_600, "text-ink")}>{value}</span>
         </div>
     );
 }

--- a/app/dashboard/spaces/page.jsx
+++ b/app/dashboard/spaces/page.jsx
@@ -4,12 +4,17 @@ import { Globe, Plus } from "lucide-react";
 import SpaceCard from "@/components/molecules/dashboard/cards/spaceCard";
 import CourseCardSkeleton from "@/components/atoms/skeletons/CourseCardSkeleton";
 import Button from "@/components/atoms/form/Button";
-import { Card, CardContent } from "@/components/ui/card";
 import SpaceCreateForm from "@/components/organisms/create/space-create-form";
 import Modal from "@/components/molecules/Modal";
 import { getSpaces } from "@/lib/actions/spaces/get-spaces";
 import useAuth from "@/hooks/useAuth";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const tabnames = [
   { value: "all", label: "All" },
@@ -63,19 +68,28 @@ const Page = () => {
   );
 
   return (
-    <div className="p-4 sm:p-6 space-y-6">
+    <div className="space-y-6 bg-surface p-4 sm:p-6">
       <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-bold flex items-center gap-2">
-            <Globe className="h-6 w-6 text-brand-text" />
-            Islamic Spaces
-          </h1>
-          <p className="text-muted-foreground text-sm mt-1">
-            Join live sessions, discussions, and community events
-          </p>
+        <div className="flex items-center gap-3">
+          <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+            <Globe className="h-5 w-5 text-accent" />
+          </div>
+          <div>
+            <h1
+              className={cn(
+                poppins_600,
+                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+              )}
+            >
+              Islamic Spaces
+            </h1>
+            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+              Join live sessions, discussions, and community events
+            </p>
+          </div>
         </div>
         <Button round outlined onClick={() => setmodalOpen(true)}>
-          <Plus className="h-4 w-4 mr-1" />
+          <Plus className="mr-1 h-4 w-4" />
           Create
         </Button>
       </div>
@@ -96,18 +110,22 @@ const Page = () => {
       </div>
 
       {loading ? (
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {[...Array(6)].map((_, idx) => (
             <CourseCardSkeleton key={idx} />
           ))}
         </div>
       ) : filteredSpaces.length === 0 ? (
-        <Card>
-          <CardContent className="flex flex-col items-center justify-center py-16 text-center space-y-4">
-            <Globe className="h-12 w-12 text-muted-foreground" />
+        <div className="rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
+          <div className="flex flex-col items-center justify-center space-y-4 py-16 text-center">
+            <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
+              <Globe className="h-7 w-7 text-accent" />
+            </div>
             <div>
-              <h3 className="font-semibold text-lg">No Spaces Found</h3>
-              <p className="text-muted-foreground text-sm mt-1 max-w-md">
+              <h3 className={cn(poppins_600, "text-lg text-ink")}>
+                No Spaces Found
+              </h3>
+              <p className={cn(poppins_400, "mt-1 max-w-md text-sm text-ink-muted")}>
                 {selectedTab === "all"
                   ? "No spaces available at the moment."
                   : `No ${selectedTab} spaces at the moment.`}
@@ -116,10 +134,10 @@ const Page = () => {
             <Button round outlined onClick={() => setmodalOpen(true)}>
               Create Space
             </Button>
-          </CardContent>
-        </Card>
+          </div>
+        </div>
       ) : (
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filteredSpaces.map((space, index) => (
             <SpaceCard key={space._id || index} space={space} />
           ))}

--- a/components/molecules/account/account-routes.jsx
+++ b/components/molecules/account/account-routes.jsx
@@ -1,7 +1,9 @@
 "use client";
 
 import React from 'react';
-import Button from '@/components/atoms/form/Button';
+import Link from 'next/link';
+import { cn } from '@/lib/utils';
+import { poppins_500 } from '@/lib/config/font.config';
 import {
     LayoutDashboard,
     Settings2Icon,
@@ -77,17 +79,20 @@ const AccountRouter = () => {
 
                         return (
                             <SidebarMenuItem key={item.name}>
-                                <Button
-                                    wide
-                                    outlined
-                                    round
-                                    to={item.link}
+                                <Link
+                                    href={item.link}
                                     onClick={handleNavClick}
-                                    className={`flex justify-start items-center pl-16 ${isActive ? "bg-accent text-white" : ""}`}
+                                    className={cn(
+                                        poppins_500,
+                                        "flex w-full items-center gap-3 rounded-xl px-4 py-2.5 text-sm transition-colors",
+                                        isActive
+                                            ? "bg-accent text-white shadow-sm"
+                                            : "text-ink hover:bg-secondary/10 hover:text-accent"
+                                    )}
                                 >
-                                    <item.icon size={15} className="mr-4" />
+                                    <item.icon size={18} className="shrink-0" />
                                     <span>{item.name}</span>
-                                </Button>
+                                </Link>
                             </SidebarMenuItem>
                         );
                     })}

--- a/components/molecules/dashboard/Notybell.jsx
+++ b/components/molecules/dashboard/Notybell.jsx
@@ -28,6 +28,11 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const NotificationBell = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -105,13 +110,13 @@ const NotificationBell = () => {
       case "urgent":
         return "text-red-600 bg-red-50 border-red-200";
       case "high":
-        return "text-orange-600 bg-orange-50 border-orange-200";
+        return "text-amber-600 bg-amber-50 border-amber-200";
       case "medium":
-        return "text-yellow-600 bg-yellow-50 border-yellow-200";
+        return "text-amber-600 bg-amber-50 border-amber-200";
       case "low":
-        return "text-blue-600 bg-blue-50 border-blue-200";
+        return "text-accent bg-secondary/10 border-secondary/20";
       default:
-        return "text-gray-600 bg-gray-50 border-gray-200";
+        return "text-ink-muted bg-surface border-accent/15";
     }
   };
 
@@ -130,7 +135,7 @@ const NotificationBell = () => {
     <>
       <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
         <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon" className="relative">
+          <Button variant="ghost" size="icon" className="relative text-accent">
             <Bell className="h-5 w-5" />
             {unreadCount > 0 && (
               <Badge
@@ -148,9 +153,14 @@ const NotificationBell = () => {
 
         <DropdownMenuContent
           align="end"
-          className="w-80 max-h-96 overflow-y-auto"
+          className="w-80 max-h-96 overflow-y-auto rounded-2xl border border-accent/10 bg-surface-raised shadow-sm"
         >
-          <DropdownMenuLabel className="flex items-center justify-between">
+          <DropdownMenuLabel
+            className={cn(
+              poppins_600,
+              "flex items-center justify-between text-ink"
+            )}
+          >
             <span>Notifications</span>
             <div className="flex items-center gap-2">
               {!isConnected && (
@@ -161,7 +171,7 @@ const NotificationBell = () => {
                     e.stopPropagation();
                     reconnect();
                   }}
-                  className="h-6 w-6 p-0"
+                  className="h-6 w-6 p-0 text-accent"
                 >
                   <RefreshCw className="h-3 w-3" />
                 </Button>
@@ -174,7 +184,10 @@ const NotificationBell = () => {
                     e.stopPropagation();
                     markAllAsRead();
                   }}
-                  className="h-6 text-xs"
+                  className={cn(
+                    poppins_500,
+                    "h-6 text-xs text-secondary hover:text-highlight"
+                  )}
                 >
                   Mark all read
                 </Button>
@@ -182,15 +195,20 @@ const NotificationBell = () => {
             </div>
           </DropdownMenuLabel>
 
-          <DropdownMenuSeparator />
+          <DropdownMenuSeparator className="bg-accent/10" />
 
           {isLoading ? (
-            <div className="p-4 text-center text-muted-foreground">
+            <div
+              className={cn(
+                poppins_400,
+                "p-4 text-center text-ink-muted"
+              )}
+            >
               Loading notifications...
             </div>
           ) : error ? (
             <div className="p-4 text-center text-red-600">
-              <p className="text-sm">{error}</p>
+              <p className={cn(poppins_400, "text-sm")}>{error}</p>
               <Button
                 variant="outline"
                 size="sm"
@@ -198,15 +216,20 @@ const NotificationBell = () => {
                   e.stopPropagation();
                   reconnect();
                 }}
-                className="mt-2"
+                className="mt-2 border-accent/15"
               >
                 Retry
               </Button>
             </div>
           ) : notifications.length === 0 ? (
-            <div className="p-4 text-center text-muted-foreground">
+            <div
+              className={cn(
+                poppins_400,
+                "p-4 text-center text-ink-muted"
+              )}
+            >
               {" "}
-              <Bell className="h-8 w-8 mx-auto mb-2" />
+              <Bell className="h-8 w-8 mx-auto mb-2 text-accent" />
               <p className="text-sm">No notifications yet</p>
             </div>
           ) : (
@@ -215,8 +238,8 @@ const NotificationBell = () => {
                 <DropdownMenuItem
                   key={notification._id}
                   className={cn(
-                    "flex items-start gap-3 p-3 cursor-pointer",
-                    !notification.isRead && "bg-muted/50"
+                    "flex items-start gap-3 p-3 cursor-pointer rounded-xl focus:bg-secondary/5",
+                    !notification.isRead && "bg-secondary/5"
                   )}
                   onClick={() => handleNotificationClick(notification)}
                 >
@@ -224,12 +247,14 @@ const NotificationBell = () => {
                     {notification.sender?.avatar ? (
                       <Avatar className="h-8 w-8">
                         <AvatarImage src={notification.sender.avatar} />
-                        <AvatarFallback>
+                        <AvatarFallback
+                          className={cn(poppins_500, "bg-surface text-ink")}
+                        >
                           {notification.sender.name?.charAt(0) || "U"}
                         </AvatarFallback>
                       </Avatar>
                     ) : (
-                      <div className="h-8 w-8 rounded-full bg-muted flex items-center justify-center text-sm">
+                      <div className="h-8 w-8 rounded-full border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10 flex items-center justify-center text-sm">
                         {getNotificationIcon(notification.type)}
                       </div>
                     )}
@@ -239,8 +264,9 @@ const NotificationBell = () => {
                     <div className="flex items-start justify-between gap-2">
                       <p
                         className={cn(
-                          "text-sm font-medium line-clamp-1",
-                          !notification.isRead && "font-semibold"
+                          poppins_500,
+                          "text-sm text-ink line-clamp-1",
+                          !notification.isRead && poppins_600
                         )}
                       >
                         {notification.title}
@@ -248,6 +274,7 @@ const NotificationBell = () => {
                       <Badge
                         variant="outline"
                         className={cn(
+                          poppins_500,
                           "text-xs px-1 py-0 h-4",
                           getPriorityColor(notification.priority)
                         )}
@@ -256,12 +283,19 @@ const NotificationBell = () => {
                       </Badge>
                     </div>
 
-                    <p className="text-xs text-muted-foreground line-clamp-2 mt-1">
+                    <p
+                      className={cn(
+                        poppins_400,
+                        "text-xs text-ink-muted line-clamp-2 mt-1"
+                      )}
+                    >
                       {notification.message}
                     </p>
 
                     <div className="flex items-center justify-between mt-2">
-                      <span className="text-xs text-muted-foreground">
+                      <span
+                        className={cn(poppins_400, "text-xs text-ink-muted")}
+                      >
                         {formatTime(notification.createdAt)}
                       </span>
 
@@ -274,7 +308,7 @@ const NotificationBell = () => {
                               e.stopPropagation();
                               markAsRead(notification._id);
                             }}
-                            className="h-6 w-6 p-0"
+                            className="h-6 w-6 p-0 text-secondary hover:text-highlight"
                           >
                             <Check className="h-3 w-3" />
                           </Button>
@@ -289,7 +323,7 @@ const NotificationBell = () => {
                               notificationId: notification._id,
                             });
                           }}
-                          className="h-6 text-red-50 hover:text-red-700"
+                          className="h-6 text-red-600 hover:text-red-700"
                         >
                           <Trash2 className="h-3 w-3" />
                         </Button>
@@ -301,9 +335,12 @@ const NotificationBell = () => {
 
               {notifications.length > 10 && (
                 <>
-                  <DropdownMenuSeparator />
+                  <DropdownMenuSeparator className="bg-accent/10" />
                   <DropdownMenuItem
-                    className="text-center text-sm text-muted-foreground cursor-pointer"
+                    className={cn(
+                      poppins_500,
+                      "text-center text-sm text-secondary hover:text-highlight cursor-pointer"
+                    )}
                     onClick={() => {
                       setIsOpen(false);
                       window.location.href = "/account/notifications";
@@ -325,17 +362,26 @@ const NotificationBell = () => {
           setDeleteDialog({ show: open, notificationId: null })
         }
       >
-        <AlertDialogContent>
+        <AlertDialogContent className="rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete Notification</AlertDialogTitle>
-            <AlertDialogDescription>
+            <AlertDialogTitle className={cn(poppins_600, "text-ink")}>
+              Delete Notification
+            </AlertDialogTitle>
+            <AlertDialogDescription
+              className={cn(poppins_400, "text-ink-muted")}
+            >
               Are you sure you want to delete this notification? This action
               cannot be undone.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleDeleteNotification}>
+            <AlertDialogCancel className={cn(poppins_500, "border-accent/15")}>
+              Cancel
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteNotification}
+              className={cn(poppins_500, "bg-red-600 text-white hover:bg-red-700")}
+            >
               Delete
             </AlertDialogAction>
           </AlertDialogFooter>

--- a/components/molecules/dashboard/cards/courseCard.jsx
+++ b/components/molecules/dashboard/cards/courseCard.jsx
@@ -1,5 +1,3 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Progress } from "@/components/ui/progress";
 import Button from "@/components/atoms/form/Button";
 import Link from "next/link";
@@ -9,6 +7,12 @@ import Image from "next/image";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { useBookmark } from "@/hooks/useBookmark";
 import BookmarkButton from "@/components/atoms/BookmarkButton";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked, progress }) => {
   const { user } = useAuth();
@@ -35,7 +39,7 @@ const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked, progress })
     await toggle();
   };
   return (
-    <Card className="relative flex flex-col overflow-hidden rounded-2xl  bg-muted/30 backdrop-blur-xl shadow-lg hover:shadow-2xl hover:scale-[1.015] transition-all group">
+    <div className="group relative flex flex-col overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-sm transition-all hover:-translate-y-0.5 hover:border-secondary/30 hover:shadow-md">
       {/* Image */}
       <div className="relative h-60 w-full">
         <Image
@@ -45,17 +49,27 @@ const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked, progress })
           className="object-cover transition-transform duration-500 group-hover:scale-105"
           priority
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent z-10" />
+        <div className="absolute inset-0 z-10 bg-gradient-to-t from-black/70 to-transparent" />
 
         {/* Category  */}
-        <div className="absolute top-3 left-3 right-3 z-20 flex justify-between">
-          <Badge className="bg-card/80 text-brand-text font-bold px-3 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider">
+        <div className="absolute left-3 right-3 top-3 z-20 flex justify-between">
+          <span
+            className={cn(
+              poppins_600,
+              "rounded-full border border-accent/15 bg-surface-raised/90 px-3 py-1 text-xs uppercase tracking-wider text-ink shadow"
+            )}
+          >
             {course.category || "General"}
-          </Badge>
+          </span>
           {user?._id === course?.createdBy?._id ? (
-            <Badge className="bg-card/80 text-brand-text font-bold px-2 py-1 rounded-full shadow border-0  uppercase tracking-wider">
+            <span
+              className={cn(
+                poppins_600,
+                "flex items-center rounded-full border border-accent/15 bg-surface-raised/90 px-2 py-1 uppercase tracking-wider text-ink shadow"
+              )}
+            >
               <Ellipsis className="size-6" />
-            </Badge>
+            </span>
           ) : null}
         </div>
 
@@ -63,12 +77,22 @@ const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked, progress })
         {showProgress && (
           <div className="absolute bottom-3 left-3 right-3 z-20">
             {isCompleted ? (
-              <div className="flex items-center gap-1 bg-green-500/90 text-white text-xs font-bold px-3 py-1 rounded-full shadow w-fit">
+              <div
+                className={cn(
+                  poppins_600,
+                  "flex w-fit items-center gap-1 rounded-full bg-secondary/90 px-3 py-1 text-xs text-white shadow"
+                )}
+              >
                 <CheckCircle className="h-3 w-3" />
                 Completed
               </div>
             ) : (
-              <div className="bg-black/60 backdrop-blur-sm text-white text-xs font-semibold px-3 py-1 rounded-full shadow w-fit">
+              <div
+                className={cn(
+                  poppins_500,
+                  "w-fit rounded-full bg-black/60 px-3 py-1 text-xs text-white shadow backdrop-blur-sm"
+                )}
+              >
                 {progress.percent}% watched
               </div>
             )}
@@ -77,23 +101,23 @@ const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked, progress })
       </div>
 
       {/* Header */}
-      <CardHeader>
-        <CardTitle className="text-lg font-bold  line-clamp-1">
+      <div className="space-y-1.5 p-6 pb-3">
+        <h3 className={cn(poppins_600, "line-clamp-1 text-lg text-ink")}>
           {course.title}
-        </CardTitle>
-        <p className="text-sm text-muted-foreground line-clamp-2">
+        </h3>
+        <p className={cn(poppins_400, "line-clamp-2 text-sm text-ink-muted")}>
           {course.description}
         </p>
-      </CardHeader>
+      </div>
 
       {/* Instructor */}
-      <CardContent>
+      <div className="px-6 pb-4">
         {showProgress && (
           <div className="mb-3">
             <Progress value={progress.percent} className="h-1.5" />
           </div>
         )}
-        <div className="flex justify-between items-center gap-3">
+        <div className="flex items-center justify-between gap-3">
           <Link
             href={`/educators/${course.createdBy?._id}`}
             className="flex items-center gap-2"
@@ -106,15 +130,22 @@ const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked, progress })
               <AvatarFallback className="rounded-lg">CN</AvatarFallback>
             </Avatar>
             <div className="text-sm">
-              <p className="font-medium">
+              <p className={cn(poppins_500, "text-ink")}>
                 {course.createdBy?.name || "Ali Jamal"}
               </p>
-              <p className="text-muted-foreground text-xs">Instructor</p>
+              <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                Instructor
+              </p>
             </div>
           </Link>
-          <div className="flex gap-4 justify-between items-center">
+          <div className="flex items-center justify-between gap-4">
             {!hasPurchased && (
-              <div className="bg-gradient-to-r from-highlight to-accent text-white text-xs font-bold px-3 py-1 rounded-full shadow">
+              <div
+                className={cn(
+                  poppins_600,
+                  "rounded-full bg-gradient-to-r from-highlight to-accent px-3 py-1 text-xs text-white shadow"
+                )}
+              >
                 {course.price ? `$${course.price}` : "Free"}
               </div>
             )}
@@ -126,20 +157,23 @@ const CourseCard = ({ course, onBookmarkChange, initialIsBookmarked, progress })
             />
           </div>
         </div>
-      </CardContent>
+      </div>
 
       {/* Full-width Button */}
-      <div className="px-5">
+      <div className="px-5 pb-5">
         <Button
           wide
           round
-          className="w-full bg-accent text-white hover:bg-accent/90 text-sm font-semibold"
+          className={cn(
+            poppins_600,
+            "w-full bg-accent text-sm text-white hover:bg-accent/90"
+          )}
           to={`/dashboard/courses/${course._id}`}
         >
           {isCompleted ? "Review Course" : showProgress ? "Continue Learning" : "View Course"}
         </Button>
       </div>
-    </Card>
+    </div>
   );
 };
 

--- a/components/molecules/dashboard/cards/educators/PublicBookCard.jsx
+++ b/components/molecules/dashboard/cards/educators/PublicBookCard.jsx
@@ -2,56 +2,74 @@ import Image from "next/image";
 import Button from "@/components/atoms/form/Button";
 import { Star } from "lucide-react";
 import { getAverageRating } from "@/hooks/getAverageRating";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const PublicBookCard = ({ book }) => {
   const avgRating = getAverageRating(book?.reviews);
 
   return (
-    <div className="bg-card text-card-foreground rounded-2xl overflow-hidden shadow-md w-full max-w-md mx-auto">
-      <div className="relative w-full h-64">
+    <div className="group flex flex-col overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl">
+      <div className="relative h-64 w-full overflow-hidden">
         <Image
           src={book.image || "/images/placeholder.jpg"}
           alt={book.title}
           fill
-          className="object-cover"
+          className="object-cover transition-transform duration-500 group-hover:scale-105"
         />
-        <div className="absolute bottom-0 left-0 w-full bg-gradient-to-t from-black/80 to-transparent text-white px-4 py-3 space-y-1">
-          <h4 className="text-sm font-semibold truncate">{book.title}</h4>
-          <div className="flex justify-between items-center text-xs">
-            <span className="bg-white/20 px-2 py-0.5 rounded">
+        <div className="absolute inset-0 bg-gradient-to-t from-black/75 to-transparent" />
+        <div className="absolute inset-x-0 bottom-0 space-y-1.5 p-4 text-white">
+          <h4 className={cn(poppins_600, "truncate text-sm")}>{book.title}</h4>
+          <div className="flex items-center justify-between text-xs">
+            <span
+              className={cn(
+                poppins_500,
+                "rounded-full bg-white/20 px-2 py-0.5 backdrop-blur"
+              )}
+            >
               {book.category || "General"}
             </span>
-            <span className="font-medium">
+            <span className={poppins_600}>
               {book.price > 0 ? `$${book.price}` : "Free"}
             </span>
           </div>
         </div>
       </div>
 
-      <div className="px-4 py-4 flex flex-col gap-3 text-sm text-muted-foreground">
-        <div className="flex items-center justify-between text-xs">
-          <span>{book.readCount || 0} readers</span>
-          {avgRating > 0 && (
-            <div className="flex items-center gap-0.5 text-yellow-500">
-              {[...Array(5)].map((_, i) => (
-                <Star
-                  key={`${book._id}-star-${i}`}
-                  size={14}
-                  fill={i < Math.round(avgRating) ? "#FFD700" : "none"}
-                  stroke="#FFD700"
-                />
-              ))}
-            </div>
-          )}
-        </div>
+      <div className="flex items-center justify-between p-4">
+        <span className={cn(poppins_400, "text-xs text-ink-muted")}>
+          {book.readCount || 0} readers
+        </span>
+        {avgRating > 0 && (
+          <div className="flex items-center gap-0.5">
+            {[...Array(5)].map((_, i) => (
+              <Star
+                key={`${book._id}-star-${i}`}
+                size={14}
+                className={
+                  i < Math.round(avgRating)
+                    ? "fill-yellow-400 text-yellow-400"
+                    : "text-ink-muted/40"
+                }
+              />
+            ))}
+          </div>
+        )}
       </div>
 
-      <div className="px-4 py-3">
+      <div className="px-4 pb-4">
         <Button
           to={`/dashboard/library/${book._id}`}
           wide
           round
-          className="w-full bg-accent text-white"
+          className={cn(
+            poppins_500,
+            "w-full bg-accent text-sm text-white hover:bg-highlight"
+          )}
         >
           View Book
         </Button>

--- a/components/molecules/dashboard/cards/educators/PublicCourseCard.jsx
+++ b/components/molecules/dashboard/cards/educators/PublicCourseCard.jsx
@@ -1,70 +1,86 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import Button from "@/components/atoms/form/Button";
-import Link from "next/link";
 import Image from "next/image";
 import { Star } from "lucide-react";
 import { getAverageRating } from "@/hooks/getAverageRating";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const PublicCourseCard = ({ course }) => {
   const avgRating = getAverageRating(course?.reviews);
 
   return (
-    <Card className="relative flex flex-col overflow-hidden rounded-2xl bg-muted/30 backdrop-blur-xl shadow-lg hover:shadow-2xl hover:scale-[1.015] transition-all group">
-      <div className="relative h-60 w-full">
+    <div className="group flex flex-col overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl">
+      <div className="relative h-52 w-full overflow-hidden">
         <Image
           src={course.thumbnail || "/images/dnb.png"}
           alt={course.title}
           fill
           className="object-cover transition-transform duration-500 group-hover:scale-105"
-          priority
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/70 to-transparent z-10" />
-        <div className="absolute top-3 left-3 right-3 z-20 flex justify-between">
-          <Badge className="bg-white/80 text-accent font-bold px-3 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider">
-            {course.category || "General"}
-          </Badge>
-        </div>
+        <div className="absolute inset-0 bg-gradient-to-t from-black/50 to-transparent" />
+        <span
+          className={cn(
+            poppins_600,
+            "absolute left-3 top-3 rounded-full bg-white/90 px-3 py-1 text-[11px] uppercase tracking-wider text-accent shadow"
+          )}
+        >
+          {course.category || "General"}
+        </span>
+        <span
+          className={cn(
+            poppins_600,
+            "absolute bottom-3 right-3 rounded-full bg-gradient-to-r from-secondary to-highlight px-3 py-1 text-xs text-white shadow"
+          )}
+        >
+          {course.price ? `$${course.price}` : "Free"}
+        </span>
       </div>
 
-      <CardHeader>
-        <CardTitle className="text-lg font-bold line-clamp-1">
+      <div className="flex flex-1 flex-col p-4">
+        <h3 className={cn(poppins_600, "line-clamp-1 text-base text-ink")}>
           {course.title}
-        </CardTitle>
-        <p className="text-sm text-muted-foreground line-clamp-2">
+        </h3>
+        <p
+          className={cn(
+            poppins_400,
+            "mt-1 line-clamp-2 flex-1 text-sm leading-relaxed text-ink-muted"
+          )}
+        >
           {course.description}
         </p>
-      </CardHeader>
 
-      <CardContent>
-        <div className="flex justify-between items-center gap-3">
-          <div className="flex items-center gap-2">
-            {avgRating > 0 && (
-              <div className="flex items-center gap-0.5 text-yellow-500">
-                <Star size={14} fill="#FFD700" stroke="#FFD700" />
-                <span className="text-xs font-medium text-foreground">
-                  {avgRating.toFixed(1)}
-                </span>
-              </div>
-            )}
-          </div>
-          <div className="bg-gradient-to-r from-highlight to-accent text-white text-xs font-bold px-3 py-1 rounded-full shadow">
-            {course.price ? `$${course.price}` : "Free"}
-          </div>
+        <div className="mt-3">
+          {avgRating > 0 ? (
+            <span className="flex items-center gap-1 text-sm">
+              <Star size={14} className="fill-yellow-400 text-yellow-400" />
+              <span className={cn(poppins_500, "text-ink")}>
+                {avgRating.toFixed(1)}
+              </span>
+            </span>
+          ) : (
+            <span className={cn(poppins_400, "text-xs text-ink-muted")}>
+              New course
+            </span>
+          )}
         </div>
-      </CardContent>
 
-      <div className="px-5 pb-5">
         <Button
           wide
           round
-          className="w-full bg-accent text-white hover:bg-accent/90 text-sm font-semibold"
+          className={cn(
+            poppins_500,
+            "mt-4 w-full bg-accent text-sm text-white hover:bg-highlight"
+          )}
           to={`/dashboard/courses/${course._id}`}
         >
           View Course
         </Button>
       </div>
-    </Card>
+    </div>
   );
 };
 

--- a/components/molecules/dashboard/cards/educators/PublicSpaceCard.jsx
+++ b/components/molecules/dashboard/cards/educators/PublicSpaceCard.jsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { Card, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import Button from "@/components/atoms/form/Button";
 import Image from "next/image";
 import { VideoIcon, Clock } from "lucide-react";
 import { format } from "date-fns";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const PublicSpaceCard = ({ space }) => {
   const {
@@ -28,69 +32,92 @@ const PublicSpaceCard = ({ space }) => {
       : `${hours} hr${hours > 1 ? "s" : ""} ${mins} min${mins > 1 ? "s" : ""}`;
   }
 
-  const formattedTime = eventDate
-    ? format(new Date(eventDate), "PPpp")
-    : "TBD";
+  const formattedTime = eventDate ? format(new Date(eventDate), "PPpp") : "TBD";
 
   return (
-    <Card className="relative flex flex-col overflow-hidden rounded-3xl bg-gradient-to-br from-green-50 via-white to-green-100/80 backdrop-blur-xl shadow-xl hover:shadow-2xl hover:scale-[1.02] transition-all group border-0">
-      <div className="relative h-60 w-full overflow-hidden">
+    <div className="group flex flex-col overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl">
+      <div className="relative h-52 w-full overflow-hidden">
         <Image
           src={thumbnail || "/images/space-placeholder.jpg"}
           alt={title}
           fill
-          className="object-cover transition-transform duration-500 group-hover:scale-110 rounded-t-3xl border-b-4 border-accent/10 shadow-lg will-change-transform"
+          className="object-cover transition-transform duration-500 group-hover:scale-105"
           priority
-          style={{ maxHeight: "15rem" }}
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent z-10 pointer-events-none" />
-        <div className="absolute top-4 left-4 right-4 z-20 flex justify-between items-center">
+        <div className="absolute inset-0 bg-gradient-to-t from-black/65 to-transparent" />
+        <div className="absolute inset-x-3 top-3 flex items-center justify-between">
           {category && (
-            <Badge className="bg-white/80 text-accent font-bold px-3 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider">
+            <span
+              className={cn(
+                poppins_600,
+                "rounded-full bg-white/90 px-3 py-1 text-[11px] uppercase tracking-wider text-accent shadow"
+              )}
+            >
               {category}
-            </Badge>
+            </span>
           )}
           {status && (
-            <div className="px-3 py-1 bg-gradient-to-r from-green-500 to-accent text-white text-xs rounded-full font-semibold shadow-md border-0">
-              {status.toUpperCase()}
-            </div>
+            <span
+              className={cn(
+                poppins_600,
+                "rounded-full bg-gradient-to-r from-secondary to-highlight px-3 py-1 text-[11px] uppercase text-white shadow"
+              )}
+            >
+              {status}
+            </span>
           )}
         </div>
       </div>
 
-      <div className="flex flex-col gap-3 px-6 py-4 flex-1">
-        <div className="mb-2">
-          <CardTitle className="text-lg font-extrabold line-clamp-1 text-accent drop-shadow-sm mb-1">
-            {title}
-          </CardTitle>
-          <p className="text-sm text-muted-foreground line-clamp-2">
-            {description}
-          </p>
-        </div>
+      <div className="flex flex-1 flex-col p-4">
+        <h3 className={cn(poppins_600, "line-clamp-1 text-base text-ink")}>
+          {title}
+        </h3>
+        <p
+          className={cn(
+            poppins_400,
+            "mt-1 line-clamp-2 flex-1 text-sm leading-relaxed text-ink-muted"
+          )}
+        >
+          {description}
+        </p>
 
-        <div className="flex items-center justify-between gap-4 mt-2 mb-4">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <div className="mt-3 flex items-center justify-between gap-3">
+          <span
+            className={cn(
+              poppins_400,
+              "flex items-center gap-1.5 text-xs text-ink-muted"
+            )}
+          >
             <Clock className="h-4 w-4 text-accent" />
-            <span className="font-medium text-accent/90">{formattedTime}</span>
-          </div>
+            {formattedTime}
+          </span>
           {duration && (
-            <div className="bg-gradient-to-r from-highlight to-accent text-white px-2 py-0.5 rounded-full font-bold shadow border-0 text-xs">
+            <span
+              className={cn(
+                poppins_600,
+                "shrink-0 rounded-full bg-secondary/10 px-2.5 py-0.5 text-xs text-accent"
+              )}
+            >
               {formatDuration(duration)}
-            </div>
+            </span>
           )}
         </div>
 
         <Button
           wide
           round
-          className="w-full bg-gradient-to-r from-highlight to-accent text-white hover:brightness-110 text-base font-bold shadow-lg transition-all py-3 mt-auto"
+          className={cn(
+            poppins_500,
+            "mt-4 w-full gap-2 bg-accent text-sm text-white hover:bg-highlight"
+          )}
           to={`/dashboard/spaces/${_id}`}
         >
-          <VideoIcon className="h-5 w-5 mr-2" />
+          <VideoIcon className="h-4 w-4" />
           View Space
         </Button>
       </div>
-    </Card>
+    </div>
   );
 };
 

--- a/components/molecules/dashboard/cards/spaceCard.jsx
+++ b/components/molecules/dashboard/cards/spaceCard.jsx
@@ -1,10 +1,5 @@
 "use client";
 
-import {
-  Card,
-  CardTitle,
-} from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import Button from "@/components/atoms/form/Button";
 import Link from "next/link";
 import Image from "next/image";
@@ -15,6 +10,12 @@ import {
 } from "@/components/ui/avatar";
 import { VideoIcon, Clock, CirclePlus } from "lucide-react";
 import { format } from "date-fns";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const SpaceCard = ({ space }) => {
   const {
@@ -39,27 +40,37 @@ const SpaceCard = ({ space }) => {
   const formattedTime = format(new Date(eventDate), "PPpp");
 
   return (
-    <Card className="relative flex flex-col overflow-hidden rounded-3xl bg-card backdrop-blur-xl shadow-xl hover:shadow-2xl hover:scale-[1.02] transition-all group border-0">
+    <div className="group relative flex flex-col overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-sm transition-all hover:-translate-y-0.5 hover:border-secondary/30 hover:shadow-md">
       {/* Thumbnail */}
       <div className="relative h-60 w-full overflow-hidden">
         <Image
           src={thumbnail || "/images/space-placeholder.jpg"}
           alt={title}
           fill
-          className="object-cover transition-transform duration-500 group-hover:scale-110 rounded-t-3xl border-b-4 border-accent/10 shadow-lg will-change-transform"
+          className="rounded-t-2xl border-b border-accent/10 object-cover shadow-sm transition-transform duration-500 will-change-transform group-hover:scale-110"
           priority
           style={{ maxHeight: '15rem' }} // Ensures the image never exceeds the container height
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent z-10 pointer-events-none" />
+        <div className="pointer-events-none absolute inset-0 z-10 bg-gradient-to-t from-black/80 via-black/10 to-transparent" />
         {/* Category + Status */}
-        <div className="absolute top-4 left-4 right-4 z-20 flex justify-between items-center">
+        <div className="absolute left-4 right-4 top-4 z-20 flex items-center justify-between">
           {category && (
-            <Badge className="bg-card/80 text-brand-text font-bold px-3 py-1 rounded-full shadow border-0 text-xs uppercase tracking-wider">
+            <span
+              className={cn(
+                poppins_600,
+                "rounded-full border border-accent/15 bg-surface-raised/80 px-3 py-1 text-xs uppercase tracking-wider text-ink shadow-sm"
+              )}
+            >
               {category}
-            </Badge>
+            </span>
           )}
           {status && (
-            <div className="px-3 py-1 bg-gradient-to-r from-green-500 to-accent text-white text-xs rounded-full font-semibold shadow-md  border-0">
+            <div
+              className={cn(
+                poppins_500,
+                "rounded-full bg-gradient-to-r from-secondary to-accent px-3 py-1 text-xs text-white shadow-sm"
+              )}
+            >
               🟢 {status.toUpperCase()}
             </div>
           )}
@@ -67,33 +78,48 @@ const SpaceCard = ({ space }) => {
       </div>
 
       {/* New Layout: Host, Title, Description, Meta, Button */}
-      <div className="flex flex-col gap-3 px-6 py-4 flex-1">
+      <div className="flex flex-1 flex-col gap-3 px-6 py-4">
 
         {/* Title & Description */}
         <div className="mb-2">
-          <CardTitle className="text-lg font-extrabold line-clamp-1 text-brand-text drop-shadow-sm mb-1">
+          <h3
+            className={cn(
+              poppins_600,
+              "mb-1 line-clamp-1 text-lg text-ink"
+            )}
+          >
             {title}
-          </CardTitle>
-          <p className="text-sm text-muted-foreground line-clamp-2">
+          </h3>
+          <p className={cn(poppins_400, "line-clamp-2 text-sm text-ink-muted")}>
             {description}
           </p>
         </div>
 
         {/* Meta Info */}
-        <div className="flex items-center justify-between gap-4 mt-2 mb-4">
-          <div className="flex items-center gap-2 text-xs text-muted-foreground">
-            <Clock className="h-4 w-4 text-brand-text" />
-            <span className="font-medium text-brand-text/90">{formattedTime}</span>
+        <div className="mb-4 mt-2 flex items-center justify-between gap-4">
+          <div
+            className={cn(
+              poppins_400,
+              "flex items-center gap-2 text-xs text-ink-muted"
+            )}
+          >
+            <Clock className="h-4 w-4 text-accent" />
+            <span className={cn(poppins_500, "text-ink")}>{formattedTime}</span>
           </div>
-          <div className="bg-gradient-to-r from-highlight to-accent text-white px-2 py-0.5 rounded-full font-bold shadow border-0 text-xs">
+          <div
+            className={cn(
+              poppins_600,
+              "rounded-full bg-gradient-to-r from-highlight to-accent px-2 py-0.5 text-xs text-white shadow-sm"
+            )}
+          >
             {formatDuration(duration)}
           </div>
         </div>
         {/* Host */}
-        <div className="flex items-center justify-between gap-3 mb-2">
+        <div className="mb-2 flex items-center justify-between gap-3">
           <Link
             href={host?._id ? `/educators/${host._id}` : "#"}
-            className="flex gap-2 items-center"
+            className="flex items-center gap-2"
           >
             <Avatar className="h-10 w-10">
               <AvatarImage
@@ -106,13 +132,13 @@ const SpaceCard = ({ space }) => {
             </Avatar>
 
             <div className="flex flex-col">
-              <span className="font-semibold text-brand-text leading-tight text-base">{host?.name || "Ustadh Ahmad"}</span>
-              <span className="text-muted-foreground text-xs">Host</span>
+              <span className={cn(poppins_600, "text-base leading-tight text-ink")}>{host?.name || "Ustadh Ahmad"}</span>
+              <span className={cn(poppins_400, "text-xs text-ink-muted")}>Host</span>
             </div>
           </Link>
 
           <div>
-            <CirclePlus className="w-5 sm:w-8 h-5 sm:h-8  text-brand-text hover:bg-accent hover:text-white rounded-full p-1 transition" />
+            <CirclePlus className="h-5 w-5 rounded-full p-1 text-accent transition hover:bg-accent hover:text-white sm:h-8 sm:w-8" />
           </div>
 
         </div>
@@ -121,14 +147,17 @@ const SpaceCard = ({ space }) => {
         <Button
           wide
           round
-          className="w-full bg-gradient-to-r from-highlight to-accent text-white hover:brightness-110 hover:scale-[1.01] text-base font-bold shadow-lg transition-all py-3 mt-auto"
+          className={cn(
+            poppins_600,
+            "mt-auto w-full bg-gradient-to-r from-highlight to-accent py-3 text-base text-white shadow-sm transition-all hover:brightness-110"
+          )}
           to={`/dashboard/spaces/${_id}`}
         >
-          <VideoIcon className="h-5 w-5 mr-2" />
+          <VideoIcon className="mr-2 h-5 w-5" />
           View Space
         </Button>
       </div>
-    </Card>
+    </div>
   );
 };
 

--- a/components/organisms/account/HealthDashboardDemo.jsx
+++ b/components/organisms/account/HealthDashboardDemo.jsx
@@ -1,0 +1,776 @@
+"use client"
+
+import {
+  Area,
+  AreaChart,
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Label,
+  LabelList,
+  Line,
+  LineChart,
+  PolarAngleAxis,
+  RadialBar,
+  RadialBarChart,
+  Rectangle,
+  ReferenceLine,
+  XAxis,
+  YAxis,
+} from "recharts"
+
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart"
+import { Separator } from "@/components/ui/separator"
+import {
+  ShieldCheck,
+  Activity,
+  Footprints,
+  HeartPulse,
+  Route,
+  Flame,
+  Moon,
+  Target,
+} from "lucide-react"
+import { cn } from "@/lib/utils"
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config"
+
+export const description = "A collection of health charts."
+
+/* ── design-system building blocks ── */
+
+const Panel = ({ className, children }) => (
+  <div
+    className={cn(
+      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
+      className
+    )}
+  >
+    {children}
+  </div>
+)
+
+const IconChip = ({ icon: Icon }) => (
+  <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+    <Icon className="h-5 w-5 text-accent" />
+  </div>
+)
+
+const SectionHeading = ({ icon, title, subtitle, right }) => (
+  <div className="mb-5 flex items-start justify-between gap-3">
+    <div className="flex items-start gap-3">
+      {icon && <IconChip icon={icon} />}
+      <div>
+        <h2 className={cn(poppins_600, "text-base text-ink")}>{title}</h2>
+        {subtitle && (
+          <p className={cn(poppins_400, "mt-0.5 text-sm text-ink-muted")}>
+            {subtitle}
+          </p>
+        )}
+      </div>
+    </div>
+    {right}
+  </div>
+)
+
+const StatValue = ({ value, unit }) => (
+  <p
+    className={cn(
+      poppins_600,
+      "flex items-baseline gap-1 text-3xl tabular-nums leading-none text-ink"
+    )}
+  >
+    {value}
+    {unit && (
+      <span className={cn(poppins_400, "text-sm text-ink-muted")}>{unit}</span>
+    )}
+  </p>
+)
+
+export default function SecurityPage() {
+  return (
+    <div className="min-h-full bg-surface p-4 sm:p-6">
+      <div className="mx-auto max-w-5xl space-y-6">
+        {/* ── Page header ── */}
+        <div className="flex items-center gap-3">
+          <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+            <ShieldCheck className="h-5 w-5 text-accent" />
+          </div>
+          <div>
+            <h1
+              className={cn(
+                poppins_600,
+                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+              )}
+            >
+              Activity Overview
+            </h1>
+            <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+              A snapshot of your recent activity and wellbeing metrics
+            </p>
+          </div>
+        </div>
+
+        {/* ── Steps (2/3) · Heart rate (1/3) ── */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <Panel className="p-6 lg:col-span-2">
+            <SectionHeading
+              icon={Footprints}
+              title="Daily Steps"
+              subtitle="Steps recorded over the past 7 days"
+              right={
+                <div className="text-right">
+                  <StatValue value="12,584" unit="steps" />
+                  <p
+                    className={cn(
+                      poppins_400,
+                      "mt-1 text-xs uppercase tracking-wider text-ink-muted"
+                    )}
+                  >
+                    Today
+                  </p>
+                </div>
+              }
+            />
+            <ChartContainer
+              config={{
+                steps: {
+                  label: "Steps",
+                  color: "hsl(var(--chart-1))",
+                },
+              }}
+              className="h-56 w-full"
+            >
+              <BarChart
+                accessibilityLayer
+                margin={{
+                  left: -4,
+                  right: -4,
+                }}
+                data={[
+                  { date: "2024-01-01", steps: 2000 },
+                  { date: "2024-01-02", steps: 2100 },
+                  { date: "2024-01-03", steps: 2200 },
+                  { date: "2024-01-04", steps: 1300 },
+                  { date: "2024-01-05", steps: 1400 },
+                  { date: "2024-01-06", steps: 2500 },
+                  { date: "2024-01-07", steps: 1600 },
+                ]}
+              >
+                <Bar
+                  dataKey="steps"
+                  fill="var(--color-accent)"
+                  radius={5}
+                  fillOpacity={0.6}
+                  activeBar={<Rectangle fillOpacity={0.8} />}
+                />
+                <XAxis
+                  dataKey="date"
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={4}
+                  tickFormatter={(value) => {
+                    return new Date(value).toLocaleDateString("en-US", {
+                      weekday: "short",
+                    })
+                  }}
+                />
+                <ChartTooltip
+                  defaultIndex={2}
+                  content={
+                    <ChartTooltipContent
+                      hideIndicator
+                      labelFormatter={(value) => {
+                        return new Date(value).toLocaleDateString("en-US", {
+                          day: "numeric",
+                          month: "long",
+                          year: "numeric",
+                        })
+                      }}
+                    />
+                  }
+                  cursor={false}
+                />
+                <ReferenceLine
+                  y={1200}
+                  stroke="var(--color-accent)"
+                  strokeDasharray="3 3"
+                  strokeWidth={1}
+                >
+                  <Label
+                    position="insideBottomLeft"
+                    value="Average Steps"
+                    offset={10}
+                    fill="var(--color-accent)"
+                  />
+                  <Label
+                    position="insideTopLeft"
+                    value="12,343"
+                    className="text-lg"
+                    fill="var(--color-accent))"
+                    offset={10}
+                    startOffset={100}
+                  />
+                </ReferenceLine>
+              </BarChart>
+            </ChartContainer>
+            <div className="mt-5 space-y-1 border-t border-accent/10 pt-4">
+              <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                Over the past 7 days, you have walked{" "}
+                <span className={cn(poppins_500, "text-ink")}>53,305</span>{" "}
+                steps.
+              </p>
+              <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                You need{" "}
+                <span className={cn(poppins_500, "text-ink")}>12,584</span> more
+                steps to reach your goal.
+              </p>
+            </div>
+          </Panel>
+
+          <Panel className="flex flex-col p-6">
+            <SectionHeading
+              icon={HeartPulse}
+              title="Heart Rate"
+              subtitle="Resting rate and variability"
+            />
+            <div className="mb-4 grid grid-cols-2 gap-3">
+              <div className="rounded-xl border border-accent/10 bg-surface px-3 py-2.5">
+                <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                  Resting HR
+                </p>
+                <StatValue value="62" unit="bpm" />
+              </div>
+              <div className="rounded-xl border border-accent/10 bg-surface px-3 py-2.5">
+                <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                  Variability
+                </p>
+                <StatValue value="35" unit="ms" />
+              </div>
+            </div>
+            <ChartContainer
+              config={{
+                resting: {
+                  label: "Resting",
+                  color: "hsl(var(--chart-1))",
+                },
+              }}
+              className="mt-auto w-full"
+            >
+              <LineChart
+                accessibilityLayer
+                margin={{
+                  left: 14,
+                  right: 14,
+                  top: 10,
+                }}
+                data={[
+                  { date: "2024-01-01", resting: 62 },
+                  { date: "2024-01-02", resting: 72 },
+                  { date: "2024-01-03", resting: 35 },
+                  { date: "2024-01-04", resting: 62 },
+                  { date: "2024-01-05", resting: 52 },
+                  { date: "2024-01-06", resting: 62 },
+                  { date: "2024-01-07", resting: 70 },
+                ]}
+              >
+                <CartesianGrid
+                  strokeDasharray="4 4"
+                  vertical={false}
+                  stroke="var(--color-accent)"
+                  strokeOpacity={0.12}
+                />
+                <YAxis hide domain={["dataMin - 10", "dataMax + 10"]} />
+                <XAxis
+                  dataKey="date"
+                  tickLine={false}
+                  axisLine={false}
+                  tickMargin={8}
+                  tickFormatter={(value) => {
+                    return new Date(value).toLocaleDateString("en-US", {
+                      weekday: "short",
+                    })
+                  }}
+                />
+                <Line
+                  dataKey="resting"
+                  type="natural"
+                  fill="var(--color-resting)"
+                  stroke="var(--color-resting)"
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{
+                    fill: "var(--color-resting)",
+                    stroke: "var(--color-resting)",
+                    r: 4,
+                  }}
+                />
+                <ChartTooltip
+                  content={
+                    <ChartTooltipContent
+                      indicator="line"
+                      labelFormatter={(value) => {
+                        return new Date(value).toLocaleDateString("en-US", {
+                          day: "numeric",
+                          month: "long",
+                          year: "numeric",
+                        })
+                      }}
+                    />
+                  }
+                  cursor={false}
+                />
+              </LineChart>
+            </ChartContainer>
+          </Panel>
+        </div>
+
+        {/* ── Progress · Activity rings · Move breakdown ── */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <Panel className="p-6">
+            <SectionHeading
+              icon={Target}
+              title="Yearly Progress"
+              subtitle="More steps a day this year than last"
+            />
+            <div className="grid gap-5">
+              <div className="grid auto-rows-min gap-2">
+                <div className="flex items-baseline gap-1 text-2xl font-bold tabular-nums leading-none text-ink">
+                  12,453
+                  <span className="text-sm font-normal text-ink-muted">
+                    steps/day
+                  </span>
+                </div>
+                <ChartContainer
+                  config={{
+                    steps: {
+                      label: "Steps",
+                      color: "hsl(var(--chart-1))",
+                    },
+                  }}
+                  className="aspect-auto h-[32px] w-full"
+                >
+                  <BarChart
+                    accessibilityLayer
+                    layout="vertical"
+                    margin={{ left: 0, top: 0, right: 0, bottom: 0 }}
+                    data={[{ date: "2024", steps: 12435 }]}
+                  >
+                    <Bar
+                      dataKey="steps"
+                      fill="var(--color-accent)"
+                      radius={4}
+                      barSize={32}
+                    >
+                      <LabelList
+                        position="insideLeft"
+                        dataKey="date"
+                        offset={8}
+                        fontSize={12}
+                        fill="white"
+                      />
+                    </Bar>
+                    <YAxis dataKey="date" type="category" tickCount={1} hide />
+                    <XAxis dataKey="steps" type="number" hide />
+                  </BarChart>
+                </ChartContainer>
+              </div>
+              <div className="grid auto-rows-min gap-2">
+                <div className="flex items-baseline gap-1 text-2xl font-bold tabular-nums leading-none text-ink">
+                  10,103
+                  <span className="text-sm font-normal text-ink-muted">
+                    steps/day
+                  </span>
+                </div>
+                <ChartContainer
+                  config={{
+                    steps: {
+                      label: "Steps",
+                      color: "hsl(var(--muted))",
+                    },
+                  }}
+                  className="aspect-auto h-[32px] w-full"
+                >
+                  <BarChart
+                    accessibilityLayer
+                    layout="vertical"
+                    margin={{ left: 0, top: 0, right: 0, bottom: 0 }}
+                    data={[{ date: "2023", steps: 10103 }]}
+                  >
+                    <Bar
+                      dataKey="steps"
+                      fill="var(--color-accent)"
+                      radius={4}
+                      barSize={32}
+                      fillOpacity={0.4}
+                    >
+                      <LabelList
+                        position="insideLeft"
+                        dataKey="date"
+                        offset={8}
+                        fontSize={12}
+                        fill="white"
+                      />
+                    </Bar>
+                    <YAxis dataKey="date" type="category" tickCount={1} hide />
+                    <XAxis dataKey="steps" type="number" hide />
+                  </BarChart>
+                </ChartContainer>
+              </div>
+            </div>
+          </Panel>
+
+          <Panel className="flex flex-col p-6">
+            <SectionHeading
+              icon={Activity}
+              title="Activity Rings"
+              subtitle="Move, exercise and stand goals"
+            />
+            <ChartContainer
+              config={{
+                move: { label: "Move", color: "hsl(var(--chart-1))" },
+                exercise: { label: "Exercise", color: "hsl(var(--chart-2))" },
+                stand: { label: "Stand", color: "hsl(var(--chart-3))" },
+              }}
+              className="mx-auto my-auto aspect-square w-full max-w-[80%]"
+            >
+              <RadialBarChart
+                margin={{ left: -10, right: -10, top: -10, bottom: -10 }}
+                data={[
+                  {
+                    activity: "stand",
+                    value: (8 / 12) * 100,
+                    fill: "var(--color-accent)",
+                  },
+                  {
+                    activity: "exercise",
+                    value: (46 / 60) * 100,
+                    fill: "var(--color-accent)",
+                  },
+                  {
+                    activity: "move",
+                    value: (245 / 360) * 100,
+                    fill: "var(--color-accent)",
+                  },
+                ]}
+                innerRadius="20%"
+                barSize={24}
+                startAngle={90}
+                endAngle={450}
+              >
+                <PolarAngleAxis
+                  type="number"
+                  domain={[0, 100]}
+                  dataKey="value"
+                  tick={false}
+                />
+                <RadialBar dataKey="value" background cornerRadius={5} />
+              </RadialBarChart>
+            </ChartContainer>
+          </Panel>
+
+          <Panel className="flex flex-col p-6">
+            <SectionHeading
+              icon={Flame}
+              title="Move · Exercise · Stand"
+              subtitle="Today's progress toward your rings"
+            />
+            <ChartContainer
+              config={{
+                move: { label: "Move", color: "hsl(var(--chart-1))" },
+                stand: { label: "Stand", color: "hsl(var(--chart-2))" },
+                exercise: { label: "Exercise", color: "hsl(var(--chart-3))" },
+              }}
+              className="h-[140px] w-full"
+            >
+              <BarChart
+                margin={{ left: 0, right: 0, top: 0, bottom: 10 }}
+                data={[
+                  {
+                    activity: "stand",
+                    value: (8 / 12) * 100,
+                    label: "8/12 hr",
+                    fill: "var(--color-accent)",
+                  },
+                  {
+                    activity: "exercise",
+                    value: (46 / 60) * 100,
+                    label: "46/60 min",
+                    fill: "var(--color-accent)",
+                  },
+                  {
+                    activity: "move",
+                    value: (245 / 360) * 100,
+                    label: "245/360 kcal",
+                    fill: "var(--color-accent)",
+                  },
+                ]}
+                layout="vertical"
+                barSize={32}
+                barGap={2}
+              >
+                <XAxis type="number" dataKey="value" hide />
+                <YAxis
+                  dataKey="activity"
+                  type="category"
+                  tickLine={false}
+                  tickMargin={4}
+                  axisLine={false}
+                  className="capitalize"
+                />
+                <Bar dataKey="value" radius={5}>
+                  <LabelList
+                    position="insideLeft"
+                    dataKey="label"
+                    fill="white"
+                    offset={8}
+                    fontSize={12}
+                  />
+                </Bar>
+              </BarChart>
+            </ChartContainer>
+            <div className="mt-auto flex w-full items-center gap-2 border-t border-accent/10 pt-4">
+              <div className="grid flex-1 auto-rows-min gap-0.5">
+                <div className={cn(poppins_400, "text-xs text-ink-muted")}>
+                  Move
+                </div>
+                <div className="flex items-baseline gap-1 text-xl font-bold tabular-nums leading-none text-ink">
+                  562
+                  <span className="text-xs font-normal text-ink-muted">
+                    kcal
+                  </span>
+                </div>
+              </div>
+              <Separator orientation="vertical" className="mx-1 h-9 w-px" />
+              <div className="grid flex-1 auto-rows-min gap-0.5">
+                <div className={cn(poppins_400, "text-xs text-ink-muted")}>
+                  Exercise
+                </div>
+                <div className="flex items-baseline gap-1 text-xl font-bold tabular-nums leading-none text-ink">
+                  73
+                  <span className="text-xs font-normal text-ink-muted">
+                    min
+                  </span>
+                </div>
+              </div>
+              <Separator orientation="vertical" className="mx-1 h-9 w-px" />
+              <div className="grid flex-1 auto-rows-min gap-0.5">
+                <div className={cn(poppins_400, "text-xs text-ink-muted")}>
+                  Stand
+                </div>
+                <div className="flex items-baseline gap-1 text-xl font-bold tabular-nums leading-none text-ink">
+                  14
+                  <span className="text-xs font-normal text-ink-muted">hr</span>
+                </div>
+              </div>
+            </div>
+          </Panel>
+        </div>
+
+        {/* ── Walking distance · Active energy · Time in bed ── */}
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+          <Panel className="p-6">
+            <SectionHeading
+              icon={Route}
+              title="Walking Distance"
+              subtitle="12.5 miles per day over the last 7 days"
+            />
+            <div className="flex flex-row items-baseline gap-4">
+              <div className="flex items-baseline gap-1 text-3xl font-bold tabular-nums leading-none text-ink">
+                12.5
+                <span className="text-sm font-normal text-ink-muted">
+                  miles/day
+                </span>
+              </div>
+              <ChartContainer
+                config={{
+                  steps: {
+                    label: "Steps",
+                    color: "hsl(var(--chart-1))",
+                  },
+                }}
+                className="ml-auto w-[72px]"
+              >
+                <BarChart
+                  accessibilityLayer
+                  margin={{ left: 0, right: 0, top: 0, bottom: 0 }}
+                  data={[
+                    { date: "2024-01-01", steps: 2000 },
+                    { date: "2024-01-02", steps: 2100 },
+                    { date: "2024-01-03", steps: 2200 },
+                    { date: "2024-01-04", steps: 1300 },
+                    { date: "2024-01-05", steps: 1400 },
+                    { date: "2024-01-06", steps: 2500 },
+                    { date: "2024-01-07", steps: 1600 },
+                  ]}
+                >
+                  <Bar
+                    dataKey="steps"
+                    fill="var(--color-accent)"
+                    radius={2}
+                    fillOpacity={0.2}
+                    activeIndex={6}
+                    activeBar={<Rectangle fillOpacity={0.8} />}
+                  />
+                  <XAxis
+                    dataKey="date"
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={4}
+                    hide
+                  />
+                </BarChart>
+              </ChartContainer>
+            </div>
+          </Panel>
+
+          <Panel className="p-6">
+            <SectionHeading
+              icon={Flame}
+              title="Active Energy"
+              subtitle="Averaging 754 calories per day"
+            />
+            <div className="flex flex-row items-baseline gap-4">
+              <div className="flex items-baseline gap-2 text-3xl font-bold tabular-nums leading-none text-ink">
+                1,254
+                <span className="text-sm font-normal text-ink-muted">
+                  kcal/day
+                </span>
+              </div>
+              <ChartContainer
+                config={{
+                  calories: {
+                    label: "Calories",
+                    color: "hsl(var(--chart-1))",
+                  },
+                }}
+                className="ml-auto w-[64px]"
+              >
+                <BarChart
+                  accessibilityLayer
+                  margin={{ left: 0, right: 0, top: 0, bottom: 0 }}
+                  data={[
+                    { date: "2024-01-01", calories: 354 },
+                    { date: "2024-01-02", calories: 514 },
+                    { date: "2024-01-03", calories: 345 },
+                    { date: "2024-01-04", calories: 734 },
+                    { date: "2024-01-05", calories: 645 },
+                    { date: "2024-01-06", calories: 456 },
+                    { date: "2024-01-07", calories: 345 },
+                  ]}
+                >
+                  <Bar
+                    dataKey="calories"
+                    fill="var(--color-accent)"
+                    radius={2}
+                    fillOpacity={0.2}
+                    activeIndex={6}
+                    activeBar={<Rectangle fillOpacity={0.8} />}
+                  />
+                  <XAxis
+                    dataKey="date"
+                    tickLine={false}
+                    axisLine={false}
+                    tickMargin={4}
+                    hide
+                  />
+                </BarChart>
+              </ChartContainer>
+            </div>
+          </Panel>
+
+          <Panel className="p-6">
+            <SectionHeading
+              icon={Moon}
+              title="Time in Bed"
+              subtitle="Sleep duration this week"
+              right={
+                <div className="flex items-baseline gap-1 text-2xl tabular-nums text-ink">
+                  <span className={cn(poppins_600)}>8</span>
+                  <span
+                    className={cn(poppins_400, "text-sm text-ink-muted")}
+                  >
+                    hr
+                  </span>
+                  <span className={cn(poppins_600)}>35</span>
+                  <span
+                    className={cn(poppins_400, "text-sm text-ink-muted")}
+                  >
+                    min
+                  </span>
+                </div>
+              }
+            />
+            <ChartContainer
+              config={{
+                time: {
+                  label: "Time",
+                  color: "hsl(var(--chart-2))",
+                },
+              }}
+              className="h-32 w-full"
+            >
+              <AreaChart
+                accessibilityLayer
+                data={[
+                  { date: "2024-01-01", time: 8.5 },
+                  { date: "2024-01-02", time: 7.2 },
+                  { date: "2024-01-03", time: 8.1 },
+                  { date: "2024-01-04", time: 6.2 },
+                  { date: "2024-01-05", time: 5.2 },
+                  { date: "2024-01-06", time: 8.1 },
+                  { date: "2024-01-07", time: 7.0 },
+                ]}
+                margin={{ left: 0, right: 0, top: 0, bottom: 0 }}
+              >
+                <XAxis dataKey="date" hide />
+                <YAxis domain={["dataMin - 5", "dataMax + 2"]} hide />
+                <defs>
+                  <linearGradient id="fillTime" x1="0" y1="0" x2="0" y2="1">
+                    <stop
+                      offset="5%"
+                      stopColor="var(--color-accent)"
+                      stopOpacity={0.8}
+                    />
+                    <stop
+                      offset="95%"
+                      stopColor="var(--color-accent)"
+                      stopOpacity={0.1}
+                    />
+                  </linearGradient>
+                </defs>
+                <Area
+                  dataKey="time"
+                  type="natural"
+                  fill="url(#fillTime)"
+                  fillOpacity={0.4}
+                  stroke="var(--color-accent)"
+                />
+                <ChartTooltip
+                  cursor={false}
+                  content={<ChartTooltipContent hideLabel />}
+                  formatter={(value) => (
+                    <div className="flex min-w-[120px] items-center text-xs text-ink-muted">
+                      Time in bed
+                      <div className="ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums text-ink">
+                        {value}
+                        <span className="font-normal text-ink-muted">hr</span>
+                      </div>
+                    </div>
+                  )}
+                />
+              </AreaChart>
+            </ChartContainer>
+          </Panel>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/organisms/account/profile/ProfileContent.jsx
+++ b/components/organisms/account/profile/ProfileContent.jsx
@@ -38,7 +38,7 @@ export default ProfileContent;
 
 // Temporary placeholder components
 const Placeholder = ({ title }) => (
-  <div className="p-6 text-center text-muted-foreground text-lg">
+  <div className="p-6 text-center text-ink-muted text-lg">
     No {title} yet. Stay tuned!
   </div>
 );
@@ -333,14 +333,14 @@ const FollowersTab = ({ profileId }) => {
           {[...Array(6)].map((_, idx) => (
             <div
               key={idx}
-              className="flex items-center gap-4 p-4 bg-muted/30 rounded-lg animate-pulse"
+              className="flex items-center gap-4 p-4 bg-surface/30 rounded-lg animate-pulse"
             >
-              <div className="h-12 w-12 bg-muted rounded-full"></div>
+              <div className="h-12 w-12 bg-surface rounded-full"></div>
               <div className="flex-1 space-y-2">
-                <div className="h-4 bg-muted rounded w-1/3"></div>
-                <div className="h-3 bg-muted rounded w-1/2"></div>
+                <div className="h-4 bg-surface rounded w-1/3"></div>
+                <div className="h-3 bg-surface rounded w-1/2"></div>
               </div>
-              <div className="h-8 w-20 bg-muted rounded"></div>
+              <div className="h-8 w-20 bg-surface rounded"></div>
             </div>
           ))}
         </div>
@@ -454,14 +454,14 @@ const FollowingTab = ({ profileId }) => {
           {[...Array(6)].map((_, idx) => (
             <div
               key={idx}
-              className="flex items-center gap-4 p-4 bg-muted/30 rounded-lg animate-pulse"
+              className="flex items-center gap-4 p-4 bg-surface/30 rounded-lg animate-pulse"
             >
-              <div className="h-12 w-12 bg-muted rounded-full"></div>
+              <div className="h-12 w-12 bg-surface rounded-full"></div>
               <div className="flex-1 space-y-2">
-                <div className="h-4 bg-muted rounded w-1/3"></div>
-                <div className="h-3 bg-muted rounded w-1/2"></div>
+                <div className="h-4 bg-surface rounded w-1/3"></div>
+                <div className="h-3 bg-surface rounded w-1/2"></div>
               </div>
-              <div className="h-8 w-20 bg-muted rounded"></div>
+              <div className="h-8 w-20 bg-surface rounded"></div>
             </div>
           ))}
         </div>

--- a/components/organisms/account/profile/ProfileHeader.jsx
+++ b/components/organisms/account/profile/ProfileHeader.jsx
@@ -1,25 +1,25 @@
-'use client';
+"use client";
 
-import React from 'react';
-import {
-    Avatar,
-    AvatarFallback,
-    AvatarImage,
-} from "@/components/ui/avatar";
+import React from "react";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 
 const ProfileHeader = ({ avatar }) => {
-    return (
-        <div className="relative w-full">
-            <div className="bg-accent h-40 w-full rounded-t-xl" />
-            <div className="absolute -bottom-10 left-6">
-                <Avatar className="h-24 w-24 border-4 border-background shadow-lg">
-                    <AvatarImage src={avatar} alt="profile-user-image" />
-                    <AvatarFallback>CN</AvatarFallback>
-                </Avatar>
-            </div>
-        </div>
-    );
+  return (
+    <div className="relative w-full">
+      <div className="relative h-40 w-full overflow-hidden bg-gradient-to-br from-secondary via-highlight to-accent">
+        <div className="pointer-events-none absolute -right-8 -top-10 h-40 w-40 rounded-full bg-white/10 blur-2xl" />
+        <div className="pointer-events-none absolute -bottom-12 left-16 h-40 w-40 rounded-full bg-basic/20 blur-2xl" />
+      </div>
+      <div className="absolute -bottom-12 left-6">
+        <Avatar className="h-28 w-28 border-4 border-surface-raised shadow-xl">
+          <AvatarImage src={avatar} alt="profile-user-image" />
+          <AvatarFallback className="bg-accent text-xl text-white">
+            CN
+          </AvatarFallback>
+        </Avatar>
+      </div>
+    </div>
+  );
 };
 
 export default ProfileHeader;
-

--- a/components/organisms/account/profile/ProfileTabs.jsx
+++ b/components/organisms/account/profile/ProfileTabs.jsx
@@ -1,6 +1,8 @@
 "use client";
 import React from "react";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+import { poppins_500 } from "@/lib/config/font.config";
 
 const tabs = [
   { value: "courses", label: "Courses" },
@@ -12,14 +14,17 @@ const tabs = [
 
 const ProfileTabs = ({ selectedTab, onChange }) => {
   return (
-    <div className="w-full mt-6 overflow-auto overscroll-x-auto">
+    <div className="mt-6 w-full overflow-x-auto">
       <Tabs defaultValue={selectedTab} onValueChange={onChange}>
-        <TabsList className="w-full flex flex-wrap justify-start gap-2 bg-card rounded-full">
+        <TabsList className="flex w-full flex-wrap justify-start gap-1.5 rounded-full border border-accent/10 bg-surface-raised p-1">
           {tabs.map((tab) => (
             <TabsTrigger
               key={tab.value}
               value={tab.value}
-              className="px-4 py-2 rounded-full text-sm font-medium data-[state=active]:bg-accent data-[state=active]:text-white font-stretch-125%"
+              className={cn(
+                poppins_500,
+                "rounded-full px-4 py-2 text-sm text-ink-muted transition-colors hover:text-ink data-[state=active]:bg-accent data-[state=active]:text-white"
+              )}
             >
               {tab.label}
             </TabsTrigger>

--- a/components/organisms/account/profile/ProfileUserInfo.jsx
+++ b/components/organisms/account/profile/ProfileUserInfo.jsx
@@ -3,7 +3,11 @@
 import React, { useState, useEffect } from "react";
 import Button from "@/components/atoms/form/Button";
 import { cn } from "@/lib/utils";
-import { Inter_800 } from "@/lib/config/font.config";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 import { useAuth } from "@/hooks/useAuth";
 import { useRouter } from "next/navigation";
 import {
@@ -110,27 +114,35 @@ const ProfileUserInfo = ({ user }) => {
   };
 
   return (
-    <div className="pt-16  pb-6">
-      <div className="flex justify-between items-center gap-4 pb-3">
-        <h1 className={cn("text-3xl sm:text-4xl font-bold", Inter_800)}>
-          {user?.name}
-        </h1>
+    <div className="px-4 pb-5 pt-16 sm:px-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className={cn(poppins_600, "text-2xl text-ink sm:text-3xl")}>
+            {user?.name}
+          </h1>
+          {user?.role && (
+            <span
+              className={cn(
+                poppins_500,
+                "mt-1 inline-block rounded-full bg-secondary/10 px-3 py-0.5 text-xs capitalize text-accent"
+              )}
+            >
+              {user.role}
+            </span>
+          )}
+        </div>
+
         {currentUser?._id === user?._id ? (
-          <Button
-            to={"/profile-setup"}
-            outlined
-            round
-            className="text-sm px-6 py-2"
-          >
+          <Button to={"/profile-setup"} outlined round className="px-6 py-2 text-sm">
             Edit Profile
           </Button>
         ) : (
-          <div className="space-x-2 flex justify-center items-center">
+          <div className="flex items-center gap-2">
             <Button
               outlined
               round
               loading={loading}
-              className="text-sm px-6 py-2"
+              className="px-6 py-2 text-sm"
               onClick={handleStartConversation}
             >
               Message
@@ -140,8 +152,8 @@ const ProfileUserInfo = ({ user }) => {
               round
               loading={followLoading}
               className={cn(
-                "text-sm px-6 py-2",
-                following && "bg-accent text-white hover:bg-accent/90"
+                "px-6 py-2 text-sm",
+                following && "bg-accent text-white hover:bg-highlight"
               )}
               onClick={handleFollowToggle}
             >
@@ -151,28 +163,29 @@ const ProfileUserInfo = ({ user }) => {
         )}
       </div>
 
-      <div>
-        {/* Follower/Following Stats */}
-        {/* <div className="flex flex-row gap-6 mb-3">
-          <div className="flex text-center">
-            <span className="text-lg font-semibold text-brand-text">
-              {followersCount}
-            </span>
-            <p className="text-sm text-muted-foreground">Followers</p>
-          </div>
-
-          <div className="flex text-center">
-            <span className="text-lg font-semibold text-brand-text">
-              {followingCount}
-            </span>
-            <p className="text-sm text-muted-foreground">Following</p>
-          </div>
-        </div> */}
-
-        <p className="mt-2 text-md font-stretch-110% w-full">
-          {user?.bio || "No bio"}
-        </p>
+      {/* Stats */}
+      <div className="mt-4 flex items-center gap-6">
+        <div className="flex items-baseline gap-1.5">
+          <span className={cn(poppins_600, "text-lg text-ink")}>
+            {followersCount}
+          </span>
+          <span className={cn(poppins_400, "text-sm text-ink-muted")}>
+            Followers
+          </span>
+        </div>
+        <div className="flex items-baseline gap-1.5">
+          <span className={cn(poppins_600, "text-lg text-ink")}>
+            {followingCount}
+          </span>
+          <span className={cn(poppins_400, "text-sm text-ink-muted")}>
+            Following
+          </span>
+        </div>
       </div>
+
+      <p className={cn(poppins_400, "mt-3 max-w-2xl leading-relaxed text-ink-muted")}>
+        {user?.bio || "No bio yet."}
+      </p>
     </div>
   );
 };

--- a/components/organisms/dashboard/CommandPalette.jsx
+++ b/components/organisms/dashboard/CommandPalette.jsx
@@ -12,6 +12,12 @@ import {
   CommandSeparator,
 } from "@/components/ui/command";
 import { searchQuery } from "@/hooks/useSearch";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 import {
   LaptopMinimal,
   Book,
@@ -66,7 +72,7 @@ const getTypeIcon = (type) => {
     case "reel":
       return <Play className="h-4 w-4 text-pink-500" />;
     default:
-      return <Search className="h-4 w-4 text-muted-foreground" />;
+      return <Search className="h-4 w-4 text-ink-muted" />;
   }
 };
 
@@ -288,7 +294,12 @@ export function CommandPalette() {
       <CommandList>
         {/* Loading state */}
         {loading && (
-          <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+          <div
+            className={cn(
+              poppins_400,
+              "flex items-center justify-center gap-2 py-6 text-sm text-ink-muted"
+            )}
+          >
             <Loader2 className="h-4 w-4 animate-spin text-accent" />
             <span>Searching...</span>
           </div>
@@ -296,7 +307,12 @@ export function CommandPalette() {
 
         {/* Error state */}
         {!loading && error && (
-          <div className="flex items-center justify-center gap-2 py-6 text-sm text-red-500">
+          <div
+            className={cn(
+              poppins_400,
+              "flex items-center justify-center gap-2 py-6 text-sm text-red-600"
+            )}
+          >
             <AlertCircle className="h-4 w-4" />
             <span>Failed to load search results. Please try again.</span>
           </div>
@@ -304,7 +320,9 @@ export function CommandPalette() {
 
         {/* Empty state when query produces 0 results */}
         {!loading && !error && hasSearchTerm && results.length === 0 && (
-          <CommandEmpty>No results found for &quot;{query}&quot;</CommandEmpty>
+          <CommandEmpty className={cn(poppins_400, "text-ink-muted")}>
+            No results found for &quot;{query}&quot;
+          </CommandEmpty>
         )}
 
         {/* Search Results (Grouped by type) */}
@@ -325,15 +343,27 @@ export function CommandPalette() {
                     >
                       {getTypeIcon("course")}
                       <div className="flex flex-col flex-1 min-w-0">
-                        <span className="truncate font-medium">{title}</span>
+                        <span className={cn(poppins_500, "truncate text-ink")}>
+                          {title}
+                        </span>
                         {item.description && (
-                          <span className="truncate text-xs text-muted-foreground">
+                          <span
+                            className={cn(
+                              poppins_400,
+                              "truncate text-xs text-ink-muted"
+                            )}
+                          >
                             {item.description}
                           </span>
                         )}
                       </div>
                       {item.price !== undefined && (
-                        <span className="ml-auto text-xs text-muted-foreground">
+                        <span
+                          className={cn(
+                            poppins_500,
+                            "ml-auto text-xs text-ink-muted"
+                          )}
+                        >
                           {item.price ? `$${item.price}` : "Free"}
                         </span>
                       )}
@@ -358,9 +388,16 @@ export function CommandPalette() {
                     >
                       {getTypeIcon("book")}
                       <div className="flex flex-col flex-1 min-w-0">
-                        <span className="truncate font-medium">{title}</span>
+                        <span className={cn(poppins_500, "truncate text-ink")}>
+                          {title}
+                        </span>
                         {item.author && (
-                          <span className="truncate text-xs text-muted-foreground">
+                          <span
+                            className={cn(
+                              poppins_400,
+                              "truncate text-xs text-ink-muted"
+                            )}
+                          >
                             By {typeof item.author === "object" ? item.author.name : item.author}
                           </span>
                         )}
@@ -386,9 +423,16 @@ export function CommandPalette() {
                     >
                       {getTypeIcon("user")}
                       <div className="flex flex-col flex-1 min-w-0">
-                        <span className="truncate font-medium">{title}</span>
+                        <span className={cn(poppins_500, "truncate text-ink")}>
+                          {title}
+                        </span>
                         {item.role && (
-                          <span className="truncate text-xs text-muted-foreground">
+                          <span
+                            className={cn(
+                              poppins_400,
+                              "truncate text-xs text-ink-muted"
+                            )}
+                          >
                             {item.role}
                           </span>
                         )}
@@ -414,9 +458,16 @@ export function CommandPalette() {
                     >
                       {getTypeIcon("space")}
                       <div className="flex flex-col flex-1 min-w-0">
-                        <span className="truncate font-medium">{title}</span>
+                        <span className={cn(poppins_500, "truncate text-ink")}>
+                          {title}
+                        </span>
                         {item.description && (
-                          <span className="truncate text-xs text-muted-foreground">
+                          <span
+                            className={cn(
+                              poppins_400,
+                              "truncate text-xs text-ink-muted"
+                            )}
+                          >
                             {item.description}
                           </span>
                         )}
@@ -442,7 +493,7 @@ export function CommandPalette() {
                     query.trim()
                   )
                 }
-                className="cursor-pointer text-accent font-medium"
+                className={cn(poppins_500, "cursor-pointer text-accent")}
               >
                 <Search className="h-4 w-4 mr-2" />
                 <span>See all results for &quot;{query}&quot;</span>
@@ -464,7 +515,10 @@ export function CommandPalette() {
                     <button
                       type="button"
                       onClick={clearRecentSearches}
-                      className="text-xs text-muted-foreground hover:text-red-500 transition-colors cursor-pointer flex items-center gap-1 font-normal"
+                      className={cn(
+                        poppins_400,
+                        "text-xs text-ink-muted hover:text-red-600 transition-colors cursor-pointer flex items-center gap-1"
+                      )}
                     >
                       <Trash2 className="h-3 w-3" />
                       Clear all
@@ -481,8 +535,8 @@ export function CommandPalette() {
                     }}
                     className="cursor-pointer"
                   >
-                    <Clock className="h-4 w-4 text-muted-foreground" />
-                    <span>{term}</span>
+                    <Clock className="h-4 w-4 text-ink-muted" />
+                    <span className={cn(poppins_400, "text-ink")}>{term}</span>
                   </CommandItem>
                 ))}
               </CommandGroup>
@@ -500,7 +554,9 @@ export function CommandPalette() {
                   className="cursor-pointer"
                 >
                   <dest.icon className="h-4 w-4 text-accent" />
-                  <span>{dest.name}</span>
+                  <span className={cn(poppins_500, "text-ink")}>
+                    {dest.name}
+                  </span>
                 </CommandItem>
               ))}
             </CommandGroup>
@@ -517,7 +573,9 @@ export function CommandPalette() {
                   className="cursor-pointer"
                 >
                   <action.icon className="h-4 w-4 text-accent" />
-                  <span>{action.name}</span>
+                  <span className={cn(poppins_500, "text-ink")}>
+                    {action.name}
+                  </span>
                 </CommandItem>
               ))}
             </CommandGroup>

--- a/components/organisms/dashboard/PrayerTimesWidget.jsx
+++ b/components/organisms/dashboard/PrayerTimesWidget.jsx
@@ -23,6 +23,12 @@ import {
 } from "lucide-react";
 import Button from "@/components/atoms/form/Button";
 import Modal from "@/components/molecules/Modal";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const PRAYER_ICONS = {
   Fajr: Sunrise,
@@ -170,15 +176,20 @@ export default function PrayerTimesWidget() {
 
   return (
     <>
-      <div className="bg-card text-card-foreground border rounded-2xl p-4 sm:p-6 shadow-sm space-y-4 w-full">
+      <div className="w-full space-y-4 rounded-2xl border border-accent/10 bg-surface-raised p-4 text-ink shadow-sm sm:p-6">
         {/* Top Header: Dates & Location */}
-        <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 border-b pb-4">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="bg-accent/10 text-brand-text font-semibold text-xs sm:text-sm px-3 py-1 rounded-full flex items-center gap-1.5 border border-accent/20">
-              <Moon className="w-3.5 h-3.5 fill-accent" />
+        <div className="flex flex-col items-start justify-between gap-3 border-b border-accent/10 pb-4 sm:flex-row sm:items-center">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className={cn(
+                poppins_600,
+                "flex items-center gap-1.5 rounded-full border border-secondary/20 bg-secondary/10 px-3 py-1 text-xs text-accent sm:text-sm"
+              )}
+            >
+              <Moon className="h-3.5 w-3.5 fill-accent" />
               {data?.hijriDate || "Hijri Date"}
             </span>
-            <span className="text-xs sm:text-sm text-muted-foreground">
+            <span className={cn(poppins_400, "text-xs text-ink-muted sm:text-sm")}>
               {data?.gregorianDate}
             </span>
           </div>
@@ -187,31 +198,34 @@ export default function PrayerTimesWidget() {
           <button
             type="button"
             onClick={() => setIsModalOpen(true)}
-            className="flex items-center gap-1.5 text-xs sm:text-sm text-muted-foreground hover:text-foreground bg-muted/60 hover:bg-muted px-3 py-1 rounded-full transition-all cursor-pointer border"
+            className={cn(
+              poppins_500,
+              "flex cursor-pointer items-center gap-1.5 rounded-full border border-accent/15 bg-surface px-3 py-1 text-xs text-ink-muted transition-all hover:bg-accent/10 hover:text-ink sm:text-sm"
+            )}
             title="Change location"
           >
-            <MapPin className="w-3.5 h-3.5 text-brand-text" />
-            <span className="font-medium truncate max-w-[180px]">
+            <MapPin className="h-3.5 w-3.5 text-accent" />
+            <span className="max-w-[180px] truncate">
               {data?.locationName || "Location"}
             </span>
-            <Search className="w-3 h-3 ml-1 opacity-60" />
+            <Search className="ml-1 h-3 w-3 opacity-60" />
           </button>
         </div>
 
         {/* Loading State */}
         {loading ? (
           <div className="animate-pulse space-y-3 py-4">
-            <div className="h-16 bg-muted rounded-xl w-full" />
+            <div className="h-16 w-full rounded-xl bg-accent/10" />
             <div className="grid grid-cols-5 gap-2">
               {[...Array(5)].map((_, i) => (
-                <div key={`skel-pr-${i}`} className="h-20 bg-muted rounded-xl" />
+                <div key={`skel-pr-${i}`} className="h-20 rounded-xl bg-accent/10" />
               ))}
             </div>
           </div>
         ) : error ? (
           /* Error State */
-          <div className="text-center py-6 space-y-2">
-            <p className="text-sm text-destructive font-medium">
+          <div className="space-y-2 py-6 text-center">
+            <p className={cn(poppins_500, "text-sm text-red-600")}>
               Unable to load prayer times.
             </p>
             <Button
@@ -220,37 +234,47 @@ export default function PrayerTimesWidget() {
               className="text-xs"
               onClick={() => loadData(location)}
             >
-              <RefreshCw className="w-3.5 h-3.5 mr-1" /> Retry
+              <RefreshCw className="mr-1 h-3.5 w-3.5" /> Retry
             </Button>
           </div>
         ) : (
           <>
             {/* Next Prayer Live Banner */}
             {nextPrayerInfo && (
-              <div className="bg-gradient-to-r from-accent via-accent/90 to-highlight text-white rounded-xl p-3.5 sm:p-4 flex flex-col sm:flex-row justify-between items-start sm:items-center gap-2 shadow-sm">
+              <div className="flex flex-col items-start justify-between gap-2 rounded-xl bg-gradient-to-r from-accent via-accent/90 to-highlight p-3.5 text-white shadow-sm sm:flex-row sm:items-center sm:p-4">
                 <div className="flex items-center gap-2.5">
-                  <div className="bg-white/20 p-2 rounded-lg backdrop-blur-md">
-                    <Clock className="w-5 h-5" />
+                  <div className="rounded-lg bg-white/20 p-2 backdrop-blur-md">
+                    <Clock className="h-5 w-5" />
                   </div>
                   <div>
-                    <p className="text-xs text-white/80 uppercase tracking-wider font-semibold">
+                    <p
+                      className={cn(
+                        poppins_600,
+                        "text-xs uppercase tracking-wider text-white/80"
+                      )}
+                    >
                       {nextPrayerInfo.isTomorrow ? "Tomorrow's Next Prayer" : "Upcoming Prayer"}
                     </p>
-                    <h4 className="text-base sm:text-lg font-bold">
+                    <h4 className={cn(poppins_600, "text-base sm:text-lg")}>
                       {nextPrayerInfo.nextPrayerName} at {nextPrayerInfo.nextPrayerTimeFormatted}
                     </h4>
                   </div>
                 </div>
 
                 {/* Countdown Badge */}
-                <div className="bg-white/20 backdrop-blur-md px-3.5 py-1.5 rounded-full text-xs sm:text-sm font-bold tracking-wide flex items-center gap-1.5 self-end sm:self-center">
+                <div
+                  className={cn(
+                    poppins_600,
+                    "flex items-center gap-1.5 self-end rounded-full bg-white/20 px-3.5 py-1.5 text-xs tracking-wide backdrop-blur-md sm:self-center sm:text-sm"
+                  )}
+                >
                   <span>In {countdownText}</span>
                 </div>
               </div>
             )}
 
             {/* 5 Daily Prayer Cards */}
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-2.5 pt-1">
+            <div className="grid grid-cols-2 gap-2.5 pt-1 sm:grid-cols-3 md:grid-cols-5">
               {["Fajr", "Dhuhr", "Asr", "Maghrib", "Isha"].map((name) => {
                 const IconComponent = PRAYER_ICONS[name] || Sun;
                 const rawTime = data?.timings?.[name];
@@ -260,21 +284,23 @@ export default function PrayerTimesWidget() {
                 return (
                   <div
                     key={name}
-                    className={`flex flex-col items-center justify-center p-3 rounded-xl border transition-all text-center ${
+                    className={cn(
+                      "flex flex-col items-center justify-center rounded-xl border p-3 text-center transition-all",
                       isNext
-                        ? "bg-accent/10 border-accent text-brand-text font-bold ring-2 ring-accent/30 shadow-sm"
-                        : "bg-muted/30 border-border text-foreground hover:bg-muted/60"
-                    }`}
+                        ? "border-accent bg-accent/10 text-ink shadow-sm ring-2 ring-accent/30"
+                        : "border-accent/10 bg-surface text-ink hover:bg-accent/5"
+                    )}
                   >
                     <IconComponent
-                      className={`w-5 h-5 mb-1 ${
-                        isNext ? "text-brand-text" : "text-muted-foreground"
-                      }`}
+                      className={cn(
+                        "mb-1 h-5 w-5",
+                        isNext ? "text-accent" : "text-ink-muted"
+                      )}
                     />
-                    <span className="text-xs font-semibold uppercase tracking-wider">
+                    <span className={cn(poppins_600, "text-xs uppercase tracking-wider")}>
                       {name}
                     </span>
-                    <span className="text-xs sm:text-sm font-medium mt-0.5">
+                    <span className={cn(poppins_500, "mt-0.5 text-xs sm:text-sm")}>
                       {formattedTime}
                     </span>
                   </div>
@@ -294,27 +320,33 @@ export default function PrayerTimesWidget() {
       >
         <form onSubmit={handleLocationSubmit} className="space-y-4 pt-2">
           <div className="space-y-1.5">
-            <label htmlFor="prayer-city" className="text-xs font-medium text-muted-foreground">City</label>
+            <label htmlFor="prayer-city" className={cn(poppins_500, "text-xs text-ink-muted")}>City</label>
             <input
               id="prayer-city"
               type="text"
               placeholder="e.g. London, Dallas, Cairo"
               value={cityInput}
               onChange={(e) => setCityInput(e.target.value)}
-              className="w-full px-3 py-2 text-sm rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-accent"
+              className={cn(
+                poppins_400,
+                "w-full rounded-lg border border-accent/15 bg-surface px-3 py-2 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent"
+              )}
               required
             />
           </div>
 
           <div className="space-y-1.5">
-            <label htmlFor="prayer-country" className="text-xs font-medium text-muted-foreground">Country (Optional)</label>
+            <label htmlFor="prayer-country" className={cn(poppins_500, "text-xs text-ink-muted")}>Country (Optional)</label>
             <input
               id="prayer-country"
               type="text"
               placeholder="e.g. UK, USA, Egypt"
               value={countryInput}
               onChange={(e) => setCountryInput(e.target.value)}
-              className="w-full px-3 py-2 text-sm rounded-lg border bg-background focus:outline-none focus:ring-2 focus:ring-accent"
+              className={cn(
+                poppins_400,
+                "w-full rounded-lg border border-accent/15 bg-surface px-3 py-2 text-sm text-ink focus:outline-none focus:ring-2 focus:ring-accent"
+              )}
             />
           </div>
 
@@ -329,7 +361,7 @@ export default function PrayerTimesWidget() {
               onClick={handleAutoDetectGPS}
               className="w-full flex items-center justify-center gap-1.5 text-xs"
             >
-              <Navigation className="w-3.5 h-3.5 text-brand-text" /> Use Auto GPS
+              <Navigation className="h-3.5 w-3.5 text-accent" /> Use Auto GPS
             </Button>
           </div>
         </form>

--- a/components/organisms/dashboard/RecentChats.jsx
+++ b/components/organisms/dashboard/RecentChats.jsx
@@ -4,7 +4,11 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { cn } from "@/lib/utils";
-import { Inter_500 } from "@/lib/config/font.config";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 import useAuth from "@/hooks/useAuth";
 import { useUnreadMessages } from "@/hooks/useUnreadMessages";
 import { collection, onSnapshot, query, where } from "firebase/firestore";
@@ -111,16 +115,16 @@ const RecentChats = () => {
           {[...Array(4)].map((_, index) => (
             <li
               key={index}
-              className="flex items-center justify-between rounded-lg bg-muted/60 p-2.5"
+              className="flex items-center justify-between rounded-xl border border-accent/10 bg-surface p-2.5"
             >
               <div className="flex items-center gap-3">
-                <div className="h-10 w-10 rounded-lg bg-muted" />
+                <div className="h-10 w-10 rounded-lg bg-accent/10" />
                 <div className="space-y-2">
-                  <div className="h-3 w-24 rounded-full bg-muted" />
-                  <div className="h-3 w-32 rounded-full bg-muted" />
+                  <div className="h-3 w-24 rounded-full bg-accent/10" />
+                  <div className="h-3 w-32 rounded-full bg-accent/10" />
                 </div>
               </div>
-              <div className="h-5 w-5 rounded-full bg-muted" />
+              <div className="h-5 w-5 rounded-full bg-accent/10" />
             </li>
           ))}
         </ul>
@@ -129,7 +133,12 @@ const RecentChats = () => {
 
     if (sortedConversations.length === 0) {
       return (
-        <div className="rounded-lg border border-dashed border-muted p-6 text-center text-sm text-muted-foreground">
+        <div
+          className={cn(
+            poppins_400,
+            "rounded-xl border border-dashed border-accent/15 p-6 text-center text-sm text-ink-muted"
+          )}
+        >
           No recent conversations yet.
         </div>
       );
@@ -168,10 +177,10 @@ const RecentChats = () => {
               <Link
                 href={`/dashboard/messages/${conversation._id}`}
                 className={cn(
-                  "flex items-center justify-between gap-2 rounded-lg p-0.5 transition-colors flex-nowrap",
+                  "flex items-center justify-between gap-2 rounded-xl p-2 transition-colors flex-nowrap",
                   unreadCount
                     ? "bg-accent/10 hover:bg-accent/20"
-                    : "hover:bg-muted/60"
+                    : "hover:bg-surface"
                 )}
               >
                 <div className="flex items-center gap-3 flex-1 min-w-0">
@@ -182,7 +191,12 @@ const RecentChats = () => {
                         alt={otherParticipant.name}
                       />
                     ) : (
-                      <AvatarFallback className="rounded-lg">
+                      <AvatarFallback
+                        className={cn(
+                          poppins_600,
+                          "rounded-lg border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10 text-accent"
+                        )}
+                      >
                         {otherParticipant?.name?.[0]?.toUpperCase() || "?"}
                       </AvatarFallback>
                     )}
@@ -190,11 +204,21 @@ const RecentChats = () => {
 
                   <div className="flex flex-col flex-1 min-w-0">
                     <div className="flex items-center justify-between gap-2">
-                      <span className="text-base font-semibold truncate font-stretch-125%">
+                      <span
+                        className={cn(
+                          poppins_600,
+                          "text-base truncate text-ink"
+                        )}
+                      >
                         {otherParticipant?.name || "Loading..."}
                       </span>
                       {timeLabel && (
-                        <span className="text-xs text-muted-foreground whitespace-nowrap">
+                        <span
+                          className={cn(
+                            poppins_400,
+                            "text-xs text-ink-muted whitespace-nowrap"
+                          )}
+                        >
                           {timeLabel}
                         </span>
                       )}
@@ -203,8 +227,8 @@ const RecentChats = () => {
                       className={cn(
                         "max-w-[200px] truncate text-sm md:max-w-xs",
                         unreadCount
-                          ? "font-semibold text-foreground"
-                          : "text-muted-foreground"
+                          ? cn(poppins_600, "text-ink")
+                          : cn(poppins_400, "text-ink-muted")
                       )}
                     >
                       {lastMessageText}
@@ -213,7 +237,12 @@ const RecentChats = () => {
                 </div>
 
                 {unreadCount > 0 && (
-                  <span className="flex h-5 min-w-[20px] items-center justify-center rounded-full bg-accent px-1.5 text-[11px] font-semibold text-white">
+                  <span
+                    className={cn(
+                      poppins_600,
+                      "flex h-5 min-w-[20px] items-center justify-center rounded-full bg-accent px-1.5 text-[11px] text-white"
+                    )}
+                  >
                     {unreadCount}
                   </span>
                 )}
@@ -226,14 +255,17 @@ const RecentChats = () => {
   };
 
   return (
-    <div className="rounded-xl bg-card p-4 shadow-sm">
+    <div className="rounded-2xl border border-accent/10 bg-surface-raised p-4 shadow-sm">
       <div className="mb-4 flex items-center justify-between">
-        <h3 className={cn("text-xl font-semibold", Inter_500)}>
+        <h3 className={cn(poppins_600, "text-xl text-ink")}>
           Recent Conversations
         </h3>
         <Link
           href="/dashboard/messages"
-          className="text-xs font-medium text-brand-text hover:text-highlight"
+          className={cn(
+            poppins_500,
+            "text-xs text-secondary hover:text-highlight"
+          )}
         >
           View all
         </Link>

--- a/components/organisms/dashboard/ReviewsSection.jsx
+++ b/components/organisms/dashboard/ReviewsSection.jsx
@@ -5,6 +5,12 @@ import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
 import Link from "next/link";
 import { getAverageRating } from "@/hooks/getAverageRating";
 import StarRate from "@/components/atoms/form/StarRate";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 const REVIEWS_PER_PAGE = 5;
 
@@ -45,15 +51,15 @@ export default function ReviewsSection({
   if (loading) {
     return (
       <div className="space-y-4 animate-pulse">
-        <div className="h-6 w-48 bg-gray-200 rounded" />
-        <div className="h-4 w-32 bg-gray-200 rounded" />
+        <div className="h-6 w-48 rounded bg-accent/10" />
+        <div className="h-4 w-32 rounded bg-accent/10" />
         <div className="space-y-3">
           {[1, 2, 3].map((i) => (
             <div key={i} className="flex items-start gap-3">
-              <div className="h-10 w-10 rounded-full bg-gray-200" />
+              <div className="h-10 w-10 rounded-full bg-accent/10" />
               <div className="flex-1 space-y-2">
-                <div className="h-4 w-24 bg-gray-200 rounded" />
-                <div className="h-3 w-full bg-gray-200 rounded" />
+                <div className="h-4 w-24 rounded bg-accent/10" />
+                <div className="h-3 w-full rounded bg-accent/10" />
               </div>
             </div>
           ))}
@@ -67,16 +73,12 @@ export default function ReviewsSection({
       {/* Summary Header */}
       <div className="flex flex-col sm:flex-row sm:items-center gap-4">
         <div className="flex items-center gap-3">
-          <span className="text-3xl font-bold">
+          <span className={cn(poppins_600, "text-3xl text-ink")}>
             {totalReviews > 0 ? averageRating.toFixed(1) : "—"}
           </span>
           <div>
-            <StarRate
-              value={averageRating}
-              maxStars={5}
-              editable={false}
-            />
-            <span className="text-sm text-muted-foreground">
+            <StarRate value={averageRating} maxStars={5} editable={false} />
+            <span className={cn(poppins_400, "text-sm text-ink-muted")}>
               {totalReviews} review{totalReviews !== 1 ? "s" : ""}
             </span>
           </div>
@@ -87,18 +89,19 @@ export default function ReviewsSection({
       {totalReviews > 0 && (
         <div className="space-y-1.5 max-w-sm">
           {distribution.map(({ star, count, percentage }) => (
-            <div key={star} className="flex items-center gap-2 text-sm">
-              <span className="w-6 text-right text-muted-foreground">
-                {star}
-              </span>
-              <Star className="w-4 h-4 text-yellow-500 fill-yellow-500" />
-              <div className="flex-1 h-2.5 bg-gray-200 rounded-full overflow-hidden">
+            <div
+              key={star}
+              className={cn(poppins_400, "flex items-center gap-2 text-sm")}
+            >
+              <span className="w-6 text-right text-ink-muted">{star}</span>
+              <Star className="w-4 h-4 text-amber-500 fill-amber-500" />
+              <div className="flex-1 h-2.5 overflow-hidden rounded-full bg-accent/10">
                 <div
-                  className="h-full bg-yellow-500 rounded-full transition-all"
+                  className="h-full rounded-full bg-amber-500 transition-all"
                   style={{ width: `${percentage}%` }}
                 />
               </div>
-              <span className="w-6 text-right text-muted-foreground tabular-nums">
+              <span className="w-6 text-right tabular-nums text-ink-muted">
                 {count}
               </span>
             </div>
@@ -107,11 +110,16 @@ export default function ReviewsSection({
       )}
 
       {/* Divider */}
-      <hr className="border-gray-200" />
+      <hr className="border-accent/10" />
 
       {/* Review List */}
       {totalReviews === 0 ? (
-        <p className="text-muted-foreground text-center py-8">
+        <p
+          className={cn(
+            poppins_400,
+            "py-8 text-center text-ink-muted"
+          )}
+        >
           No reviews yet — be the first!
         </p>
       ) : (
@@ -137,10 +145,15 @@ export default function ReviewsSection({
                       </AvatarFallback>
                     </Avatar>
                     <div>
-                      <p className="font-semibold text-sm group-hover:underline">
+                      <p
+                        className={cn(
+                          poppins_600,
+                          "text-sm text-ink group-hover:underline"
+                        )}
+                      >
                         {review.user?.name || "Anonymous"}
                       </p>
-                      <p className="text-xs text-muted-foreground">
+                      <p className={cn(poppins_400, "text-xs text-ink-muted")}>
                         {review.createdAt
                           ? new Date(review.createdAt).toLocaleDateString(
                               "en-US",
@@ -160,14 +173,20 @@ export default function ReviewsSection({
                       <button
                         type="button"
                         onClick={() => onEditReview?.(review)}
-                        className="text-xs text-muted-foreground hover:text-brand-text px-2 py-1 rounded hover:bg-muted transition"
+                        className={cn(
+                          poppins_500,
+                          "rounded px-2 py-1 text-xs text-ink-muted transition hover:bg-surface hover:text-ink"
+                        )}
                       >
                         Edit
                       </button>
                       <button
                         type="button"
                         onClick={() => onDeleteReview?.(review._id)}
-                        className="text-xs text-red-500 hover:text-red-700 px-2 py-1 rounded hover:bg-red-50 transition"
+                        className={cn(
+                          poppins_500,
+                          "rounded px-2 py-1 text-xs text-red-600 transition hover:bg-red-50 hover:text-red-700"
+                        )}
                       >
                         Delete
                       </button>
@@ -182,15 +201,20 @@ export default function ReviewsSection({
                       size={14}
                       className={
                         i <= review.rating
-                          ? "fill-yellow-500 text-yellow-500"
-                          : "text-gray-300"
+                          ? "fill-amber-500 text-amber-500"
+                          : "text-accent/20"
                       }
                     />
                   ))}
                 </div>
 
                 {review.comment && (
-                  <p className="text-sm text-gray-700 leading-relaxed">
+                  <p
+                    className={cn(
+                      poppins_400,
+                      "text-sm leading-relaxed text-ink-muted"
+                    )}
+                  >
                     {review.comment}
                   </p>
                 )}
@@ -205,7 +229,10 @@ export default function ReviewsSection({
                 <button
                   type="button"
                   onClick={handleShowMore}
-                  className="inline-flex items-center gap-1 text-sm text-brand-text hover:underline font-medium"
+                  className={cn(
+                    poppins_500,
+                    "inline-flex items-center gap-1 text-sm text-secondary hover:text-highlight"
+                  )}
                 >
                   Show more
                   <ChevronDown className="w-4 h-4" />
@@ -214,7 +241,10 @@ export default function ReviewsSection({
                 <button
                   type="button"
                   onClick={handleShowLess}
-                  className="inline-flex items-center gap-1 text-sm text-brand-text hover:underline font-medium"
+                  className={cn(
+                    poppins_500,
+                    "inline-flex items-center gap-1 text-sm text-secondary hover:text-highlight"
+                  )}
                 >
                   Show less
                   <ChevronUp className="w-4 h-4" />

--- a/components/organisms/dashboard/StreamingAIChat.jsx
+++ b/components/organisms/dashboard/StreamingAIChat.jsx
@@ -15,7 +15,6 @@ import {
   StopCircle,
   Sparkles,
 } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import Button from "@/components/atoms/form/Button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -34,6 +33,12 @@ import {
 import { useState, useRef, useEffect } from "react";
 import ReactMarkdown from "react-markdown";
 import Image from "next/image";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
 
 export default function StreamingAIChat({ chatData, onChatUpdate }) {
   const { user } = useAuth();
@@ -130,11 +135,16 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
   };
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full bg-surface">
       <div className="grid flex-1 gap-4 overflow-y-auto">
-        <div className="relative flex flex-col rounded-xl bg-muted/50 p-4 lg:col-span-2">
+        <div className="relative flex flex-col rounded-2xl border border-accent/10 bg-surface-raised p-4 shadow-sm lg:col-span-2">
           <div className="absolute right-3 top-3 flex gap-2">
-            <Badge variant="outline" className="border-accent">
+            <span
+              className={cn(
+                poppins_500,
+                "inline-flex items-center rounded-full border border-secondary/20 bg-secondary/10 px-3 py-1 text-xs text-accent"
+              )}
+            >
               {isStreaming ? (
                 <span className="flex items-center gap-1">
                   <Sparkles className="w-3 h-3 animate-pulse" />
@@ -143,11 +153,11 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
               ) : (
                 "Ready"
               )}
-            </Badge>
+            </span>
             {messages.length > 0 && (
               <Button
                 onClick={handleNewConversation}
-                className="text-xs p-1.5 h-auto"
+                className={cn(poppins_500, "text-xs p-1.5 h-auto")}
               >
                 New Chat
               </Button>
@@ -161,8 +171,8 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
                 {/* AI Image with stunning effects */}
                 <div className="relative mb-8 group">
                   <div className="relative">
-                    <div className="absolute inset-0 bg-gradient-to-br from-accent/20 to-highlight/20 rounded-full blur-2xl"></div>
-                    <div className="relative bg-gradient-to-br from-background to-muted p-2 rounded-full border-4 border-accent/30 shadow-2xl group-hover:scale-105 transition-transform duration-300">
+                    <div className="absolute inset-0 bg-gradient-to-br from-secondary/20 to-highlight/20 rounded-full blur-2xl"></div>
+                    <div className="relative bg-gradient-to-br from-surface to-surface-raised p-2 rounded-full border-4 border-accent/30 shadow-2xl group-hover:scale-105 transition-transform duration-300">
                       <Image
                         src="/images/ai.png"
                         alt="DeenBridge AI Assistant"
@@ -182,27 +192,47 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
 
                 {/* Welcome Text with gradient */}
                 <div className="mb-10 space-y-4 max-w-2xl">
-                  <h1 className="text-5xl md:text-6xl font-bold mb-3">
-                    <span className="bg-gradient-to-r from-accent via-highlight to-accent bg-clip-text text-transparent">
+                  <h1 className={cn(poppins_600, "text-5xl md:text-6xl mb-3")}>
+                    <span className="bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-transparent">
                       Assalamu Alaikum!
                     </span>
                   </h1>
-                  <p className="text-lg md:text-xl text-muted-foreground max-w-xl mx-auto leading-relaxed">
+                  <p
+                    className={cn(
+                      poppins_400,
+                      "text-lg md:text-xl text-ink-muted max-w-xl mx-auto leading-relaxed"
+                    )}
+                  >
                     I'm your Islamic AI assistant powered by knowledge of the{" "}
-                    <span className="font-semibold text-brand-text">Quran</span> and{" "}
-                    <span className="font-semibold text-highlight">Hadith</span>
+                    <span className={cn(poppins_600, "text-ink")}>Quran</span> and{" "}
+                    <span className={cn(poppins_600, "text-highlight")}>Hadith</span>
                     . Experience real-time streaming responses!
                   </p>
 
                   {/* AI Features badges */}
                   <div className="flex flex-wrap gap-2 justify-center mt-6">
-                    <span className="px-3 py-1 bg-accent/10 text-highlight text-xs font-medium rounded-full border border-highlight/20">
+                    <span
+                      className={cn(
+                        poppins_500,
+                        "px-3 py-1 bg-secondary/10 text-highlight text-xs rounded-full border border-highlight/20"
+                      )}
+                    >
                       ⚡ Real-time Streaming
                     </span>
-                    <span className="px-3 py-1 bg-accent/10 text-highlight text-xs font-medium rounded-full border border-highlight/20">
+                    <span
+                      className={cn(
+                        poppins_500,
+                        "px-3 py-1 bg-secondary/10 text-highlight text-xs rounded-full border border-highlight/20"
+                      )}
+                    >
                       📖 Islamic Knowledge
                     </span>
-                    <span className="px-3 py-1 bg-accent/10 text-highlight text-xs font-medium rounded-full border border-highlight/20">
+                    <span
+                      className={cn(
+                        poppins_500,
+                        "px-3 py-1 bg-secondary/10 text-highlight text-xs rounded-full border border-highlight/20"
+                      )}
+                    >
                       💬 Conversation History
                     </span>
                   </div>
@@ -210,7 +240,12 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
 
                 {/* Quick Questions */}
                 <div className="w-full max-w-4xl">
-                  <h3 className="text-sm font-semibold text-muted-foreground mb-4 uppercase tracking-wider">
+                  <h3
+                    className={cn(
+                      poppins_600,
+                      "text-sm text-ink-muted mb-4 uppercase tracking-wider"
+                    )}
+                  >
                     Popular Questions
                   </h3>
                   <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -243,22 +278,27 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
                       <button
                         key={i}
                         onClick={() => setInputMessage(item.question)}
-                        className="group relative p-5 text-left border-2 border-muted/50 rounded-2xl hover:border-accent hover:shadow-lg hover:shadow-accent/20 transition-all duration-300 hover:-translate-y-1 bg-background overflow-hidden"
+                        className="group relative p-5 text-left border border-accent/15 rounded-2xl hover:border-secondary/50 hover:shadow-lg hover:shadow-secondary/20 transition-all duration-300 hover:-translate-y-1 bg-surface overflow-hidden"
                       >
-                        <div className="absolute inset-0 bg-gradient-to-br from-accent/10 to-highlight/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
+                        <div className="absolute inset-0 bg-gradient-to-br from-secondary/10 to-highlight/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
 
                         <div className="relative flex items-start gap-3">
                           <span className="text-3xl group-hover:scale-110 transition-transform duration-300">
                             {item.emoji}
                           </span>
-                          <span className="text-sm font-medium leading-relaxed flex-1">
+                          <span
+                            className={cn(
+                              poppins_500,
+                              "text-sm leading-relaxed flex-1 text-ink"
+                            )}
+                          >
                             {item.question}
                           </span>
                         </div>
 
                         <div className="absolute bottom-3 right-3 opacity-0 group-hover:opacity-100 transition-opacity">
                           <svg
-                            className="w-4 h-4 text-brand-text"
+                            className="w-4 h-4 text-ink"
                             fill="none"
                             stroke="currentColor"
                             viewBox="0 0 24 24"
@@ -291,7 +331,12 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
                   {message.role === "user" ? (
                     <Avatar className="h-10 w-10 rounded-lg mt-2">
                       <AvatarImage src={user?.avatar} alt={user?.name} />
-                      <AvatarFallback className="bg-accent text-white text-sm">
+                      <AvatarFallback
+                        className={cn(
+                          poppins_500,
+                          "bg-accent text-white text-sm"
+                        )}
+                      >
                         {user?.name?.charAt(0) || "U"}
                       </AvatarFallback>
                     </Avatar>
@@ -310,8 +355,10 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
 
                 {/* Message Content */}
                 <div
-                  className={`p-4 rounded-lg max-w-[80%] ${
-                    message.role === "user" ? "bg-accent/10" : "bg-background"
+                  className={`p-4 rounded-xl max-w-[80%] ${
+                    message.role === "user"
+                      ? "bg-accent/10"
+                      : "border border-accent/10 bg-surface"
                   } ${message.isStreaming ? "animate-pulse" : ""}`}
                 >
                   {message.role === "assistant" ? (
@@ -319,28 +366,32 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
                       <ReactMarkdown
                         components={{
                           p: ({ children }) => (
-                            <p className="text-sm mb-2">{children}</p>
+                            <p className={cn(poppins_400, "text-sm mb-2 text-ink")}>
+                              {children}
+                            </p>
                           ),
                           h1: ({ children }) => (
-                            <h1 className="text-xl font-bold mb-2">
+                            <h1 className={cn(poppins_600, "text-xl mb-2 text-ink")}>
                               {children}
                             </h1>
                           ),
                           h2: ({ children }) => (
-                            <h2 className="text-lg font-bold mb-2">
+                            <h2 className={cn(poppins_600, "text-lg mb-2 text-ink")}>
                               {children}
                             </h2>
                           ),
                           h3: ({ children }) => (
-                            <h3 className="text-base font-bold mb-2">
+                            <h3 className={cn(poppins_600, "text-base mb-2 text-ink")}>
                               {children}
                             </h3>
                           ),
                           ul: ({ children }) => (
-                            <ul className="list-disc pl-4 mb-2">{children}</ul>
+                            <ul className={cn(poppins_400, "list-disc pl-4 mb-2 text-ink")}>
+                              {children}
+                            </ul>
                           ),
                           ol: ({ children }) => (
-                            <ol className="list-decimal pl-4 mb-2">
+                            <ol className={cn(poppins_400, "list-decimal pl-4 mb-2 text-ink")}>
                               {children}
                             </ol>
                           ),
@@ -348,12 +399,12 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
                             <li className="mb-1">{children}</li>
                           ),
                           code: ({ children }) => (
-                            <code className="bg-muted px-1 py-0.5 rounded text-xs">
+                            <code className="bg-accent/10 px-1 py-0.5 rounded text-xs">
                               {children}
                             </code>
                           ),
                           pre: ({ children }) => (
-                            <pre className="bg-muted p-2 rounded text-xs overflow-x-auto mb-2">
+                            <pre className="bg-accent/10 p-2 rounded text-xs overflow-x-auto mb-2">
                               {children}
                             </pre>
                           ),
@@ -366,7 +417,12 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
                       )}
                     </div>
                   ) : (
-                    <p className="text-sm whitespace-pre-line">
+                    <p
+                      className={cn(
+                        poppins_400,
+                        "text-sm whitespace-pre-line text-ink"
+                      )}
+                    >
                       {message.content}
                     </p>
                   )}
@@ -376,8 +432,13 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
 
             {isStreaming &&
               messages[messages.length - 1]?.role !== "assistant" && (
-                <div className="flex items-center gap-2 text-sm text-muted-foreground bg-accent/10 p-4 rounded-lg w-fit">
-                  <Bot className="size-4 animate-bounce" />
+                <div
+                  className={cn(
+                    poppins_400,
+                    "flex items-center gap-2 text-sm text-ink-muted bg-accent/10 p-4 rounded-xl w-fit"
+                  )}
+                >
+                  <Bot className="size-4 animate-bounce text-accent" />
                   AI is thinking...
                 </div>
               )}
@@ -387,7 +448,7 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
 
           <form
             onSubmit={handleSubmit}
-            className="bottom-0 overflow-hidden rounded-lg border bg-background focus-within:ring-1 focus-within:ring-accent"
+            className="bottom-0 overflow-hidden rounded-xl border border-accent/15 bg-surface focus-within:ring-1 focus-within:ring-secondary"
           >
             <Label htmlFor="message" className="sr-only">
               Message
@@ -395,7 +456,10 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
             <Textarea
               id="message"
               placeholder="Type your message here... (Press Enter to send)"
-              className="min-h-12 resize-none border-0 p-3 shadow-none focus-visible:ring-0"
+              className={cn(
+                poppins_400,
+                "min-h-12 resize-none border-0 p-3 shadow-none focus-visible:ring-0"
+              )}
               value={inputMessage}
               onChange={(e) => setInputMessage(e.target.value)}
               onKeyDown={handleKeyDown}
@@ -444,7 +508,7 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
                     type="button"
                     onClick={stopStreaming}
                     round
-                    className="text-sm gap-1.5 text-white flex bg-error hover:bg-error/90"
+                    className="text-sm gap-1.5 text-white flex bg-red-600 hover:bg-red-600/90"
                   >
                     <StopCircle className="size-3.5" />
                   </Button>

--- a/components/organisms/dashboard/ai/Ai-Sidebar.jsx
+++ b/components/organisms/dashboard/ai/Ai-Sidebar.jsx
@@ -3,10 +3,10 @@ import * as React from "react";
 import { useState, useEffect } from "react";
 import { Plus, Trash2, MessageSquare } from "lucide-react";
 import { toast } from "sonner";
-import { formatDistanceToNow } from "date-fns";
-import Button from "@/components/atoms/form/Button";
 import { config } from "@/lib/config/env";
 import { useAuth } from "@/hooks/useAuth";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500 } from "@/lib/config/font.config";
 
 export function AiSidebar({ onChatSelect, currentChatId, onNewChat }) {
   const { user } = useAuth();
@@ -24,7 +24,6 @@ export function AiSidebar({ onChatSelect, currentChatId, onNewChat }) {
     try {
       setLoadingHistory(true);
       const response = await fetch(`${AI_API_URL}/user/${userId}/chats`);
-
       if (response.ok) {
         const data = await response.json();
         setChatHistory(data.chats || []);
@@ -38,19 +37,15 @@ export function AiSidebar({ onChatSelect, currentChatId, onNewChat }) {
 
   const deleteChat = async (chatIdToDelete, e) => {
     e.stopPropagation();
-
     try {
       const response = await fetch(`${AI_API_URL}/chat/${chatIdToDelete}`, {
         method: "DELETE",
       });
-
       if (response.ok) {
         toast.success("Chat deleted");
         setChatHistory((prev) =>
           prev.filter((chat) => chat.chat_id !== chatIdToDelete)
         );
-
-        // If we deleted the current chat, trigger new chat
         if (currentChatId === chatIdToDelete && onNewChat) {
           onNewChat();
         }
@@ -91,80 +86,84 @@ export function AiSidebar({ onChatSelect, currentChatId, onNewChat }) {
   };
 
   return (
-    <div className="grid w-fit items-start gap-6 h-full">
-      <fieldset className="grid gap-4 rounded-lg border p-4 h-full overflow-y-auto">
-        <legend className="-ml-1 px-1 text-md font-medium">History</legend>
+    <div className="flex h-full flex-col p-3">
+      {/* New chat */}
+      <button
+        onClick={handleNewChat}
+        className={cn(
+          poppins_500,
+          "mb-3 flex w-full items-center justify-center gap-2 rounded-xl border border-accent/15 bg-surface px-4 py-2.5 text-sm text-ink transition-colors hover:border-secondary/40 hover:bg-secondary/5"
+        )}
+      >
+        <Plus className="h-4 w-4 text-accent" />
+        New chat
+      </button>
 
-        {/* New Chat Button */}
-        <Button
-          onClick={handleNewChat}
-          className="w-full flex items-center justify-center gap-2 bg-accent text-white hover:bg-highlight"
-        >
-          <Plus className="w-4 h-4" />
-          <span>New Chat</span>
-        </Button>
+      <p
+        className={cn(
+          poppins_500,
+          "px-1 pb-2 pt-1 text-[11px] uppercase tracking-wider text-ink-muted"
+        )}
+      >
+        Recent chats
+      </p>
 
-        {/* Chat History */}
+      {/* History */}
+      <div className="-mx-1 flex-1 space-y-1 overflow-y-auto px-1">
         {loadingHistory ? (
           <div className="flex items-center justify-center py-8">
-            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-accent"></div>
+            <div className="h-6 w-6 animate-spin rounded-full border-b-2 border-accent" />
           </div>
         ) : chatHistory.length === 0 ? (
-          <div className="text-center py-8 px-2">
-            <MessageSquare className="w-10 h-10 mx-auto text-muted-foreground mb-2" />
-            <p className="text-sm text-muted-foreground">No chat history yet</p>
-            <p className="text-xs text-muted-foreground mt-1">
+          <div className="px-2 py-10 text-center">
+            <div className="mx-auto mb-3 flex size-11 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+              <MessageSquare className="h-5 w-5 text-accent" />
+            </div>
+            <p className={cn(poppins_500, "text-sm text-ink")}>
+              No chat history yet
+            </p>
+            <p className={cn(poppins_400, "mt-1 text-xs text-ink-muted")}>
               Start a conversation
             </p>
           </div>
         ) : (
-          <div className="space-y-2">
-            {chatHistory.map((chat) => (
+          chatHistory.map((chat) => (
+            <div
+              key={chat.chat_id}
+              className={cn(
+                "group relative flex items-center rounded-lg transition-colors",
+                chat.chat_id === currentChatId
+                  ? "bg-accent/10"
+                  : "hover:bg-secondary/5"
+              )}
+            >
               <button
-                key={chat.chat_id}
                 onClick={() => handleChatSelect(chat.chat_id)}
-                className={`w-full text-left p-3 rounded-lg border transition-colors group relative ${
-                  chat.chat_id === currentChatId
-                    ? "bg-accent/10 border-accent/20"
-                    : "hover:bg-muted border-transparent"
-                }`}
+                className="flex min-w-0 flex-1 items-center gap-2.5 px-2.5 py-2 text-left"
               >
-                <div className="flex items-start justify-between gap-2">
-                  <div className="flex-1 min-w-0">
-                    <p className="text-sm font-medium truncate">
-                      {chat.title || "New conversation"}
-                    </p>
-                    {chat.snippet && (
-                      <p className="text-xs text-muted-foreground truncate mt-0.5">
-                        {chat.snippet}
-                      </p>
-                    )}
-                    <div className="flex items-center gap-2 mt-1">
-                      <p className="text-xs text-muted-foreground">
-                        {chat.message_count} messages
-                      </p>
-                      {chat.created_at && (
-                        <p className="text-xs text-muted-foreground">
-                          •{" "}
-                          {formatDistanceToNow(new Date(chat.created_at * 1000), {
-                            addSuffix: true,
-                          })}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                  <button
-                    onClick={(e) => deleteChat(chat.chat_id, e)}
-                    className="opacity-0 group-hover:opacity-100 p-1 hover:bg-destructive/10 rounded transition-opacity"
-                  >
-                    <Trash2 className="w-4 h-4 text-destructive" />
-                  </button>
-                </div>
+                <MessageSquare
+                  className={cn(
+                    "h-4 w-4 shrink-0",
+                    chat.chat_id === currentChatId
+                      ? "text-accent"
+                      : "text-ink-muted"
+                  )}
+                />
+                <span className={cn(poppins_500, "truncate text-sm text-ink")}>
+                  {chat.title || "New conversation"}
+                </span>
               </button>
-            ))}
-          </div>
+              <button
+                onClick={(e) => deleteChat(chat.chat_id, e)}
+                className="mr-1 shrink-0 rounded p-1.5 text-ink-muted opacity-0 transition-opacity hover:bg-red-600/10 hover:text-red-600 group-hover:opacity-100"
+                aria-label="Delete chat"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          ))
         )}
-      </fieldset>
+      </div>
     </div>
   );
 }

--- a/components/organisms/educators/EducatorProfileHeader.jsx
+++ b/components/organisms/educators/EducatorProfileHeader.jsx
@@ -1,21 +1,36 @@
 "use client";
 
 import React from "react";
-import Link from "next/link";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import Button from "@/components/atoms/form/Button";
 import { cn } from "@/lib/utils";
 import {
-  Copy,
   Share2,
   Users,
   BookOpen,
   GraduationCap,
   Star,
   Calendar,
-  ArrowLeft,
+  BadgeCheck,
 } from "lucide-react";
 import { format } from "date-fns";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+
+const StatChip = ({ icon: Icon, value, label, gold }) => (
+  <div className="flex items-center gap-2 rounded-xl border border-white/10 bg-white/5 px-3.5 py-2 backdrop-blur">
+    <Icon
+      className={cn("h-4 w-4", gold ? "fill-yellow-400 text-yellow-400" : "text-secondary")}
+    />
+    <span className={cn(poppins_600, "text-sm text-ink-inverse")}>{value}</span>
+    <span className={cn(poppins_400, "text-xs text-ink-inverse-muted")}>
+      {label}
+    </span>
+  </div>
+);
 
 const EducatorProfileHeader = ({
   educator,
@@ -30,58 +45,96 @@ const EducatorProfileHeader = ({
 }) => {
   return (
     <div className="relative w-full">
-      <div className="bg-accent h-40 sm:h-48 w-full" />
+      {/* Cover banner */}
+      <div className="relative h-44 w-full overflow-hidden bg-gradient-to-br from-secondary via-highlight to-accent sm:h-56">
+        <div className="pointer-events-none absolute -right-10 -top-16 h-56 w-56 rounded-full bg-white/15 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-20 left-1/3 h-56 w-56 rounded-full bg-basic/30 blur-3xl" />
+        <div
+          className="absolute inset-0 opacity-20"
+          style={{
+            backgroundImage:
+              "linear-gradient(rgba(255,255,255,0.15) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.15) 1px, transparent 1px)",
+            backgroundSize: "42px 42px",
+          }}
+        />
+      </div>
 
-      <div className="max-w-6xl mx-auto px-4 sm:px-6">
-        <div className="relative -mt-12 sm:-mt-14">
-          <Avatar className="h-24 w-24 sm:h-28 sm:w-28 border-4 border-background shadow-lg">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        {/* Avatar */}
+        <div className="relative -mt-14 sm:-mt-16">
+          <Avatar className="h-28 w-28 border-4 border-basic shadow-2xl sm:h-32 sm:w-32">
             <AvatarImage src={educator?.avatar} alt={educator?.name} />
-            <AvatarFallback className="text-2xl">
+            <AvatarFallback
+              className={cn(poppins_600, "bg-accent text-3xl text-white")}
+            >
               {educator?.name?.charAt(0) || "E"}
             </AvatarFallback>
           </Avatar>
         </div>
 
-        <div className="mt-4 pb-6 border-b">
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-            <div className="space-y-1">
-              <h1 className="text-2xl sm:text-3xl font-bold">
-                {educator?.name}
-              </h1>
+        <div className="mt-4 border-b border-white/10 pb-6">
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0 space-y-2">
+              <div className="flex flex-wrap items-center gap-2">
+                <h1
+                  className={cn(
+                    poppins_600,
+                    "text-2xl text-ink-inverse sm:text-3xl"
+                  )}
+                >
+                  {educator?.name}
+                </h1>
+                {educator?.isVerified && (
+                  <span className="inline-flex items-center gap-1 rounded-full bg-secondary/20 px-2.5 py-0.5 text-xs text-secondary">
+                    <BadgeCheck className="h-3.5 w-3.5" />
+                    Verified
+                  </span>
+                )}
+              </div>
               {educator?.role && (
-                <p className="text-muted-foreground text-sm">{educator.role}</p>
+                <span
+                  className={cn(
+                    poppins_500,
+                    "inline-block rounded-full border border-white/15 bg-white/5 px-3 py-0.5 text-xs capitalize text-ink-inverse-muted"
+                  )}
+                >
+                  {educator.role}
+                </span>
               )}
               {educator?.bio && (
-                <p className="text-foreground/80 max-w-2xl mt-2">
+                <p
+                  className={cn(
+                    poppins_400,
+                    "max-w-2xl leading-relaxed text-ink-inverse-muted"
+                  )}
+                >
                   {educator.bio}
                 </p>
               )}
               {educator?.createdAt && (
-                <p className="text-muted-foreground text-xs flex items-center gap-1 mt-2">
+                <p
+                  className={cn(
+                    poppins_400,
+                    "flex items-center gap-1.5 text-xs text-ink-inverse-muted/80"
+                  )}
+                >
                   <Calendar className="h-3 w-3" />
-                  Joined{" "}
-                  {format(new Date(educator.createdAt), "MMMM yyyy")}
+                  Joined {format(new Date(educator.createdAt), "MMMM yyyy")}
                 </p>
               )}
             </div>
 
-            <div className="flex items-center gap-2 shrink-0">
+            <div className="flex shrink-0 items-center gap-2">
               <Button
                 round
-                outlined
-                className="text-sm px-3 gap-1.5"
+                className="gap-1.5 border border-white/20 bg-white/5 px-4 text-sm text-ink-inverse hover:bg-white/15"
                 onClick={onShare}
               >
                 <Share2 className="h-4 w-4" />
                 Share
               </Button>
               {isOwnProfile ? (
-                <Button
-                  to="/profile-setup"
-                  round
-                  outlined
-                  className="text-sm px-4"
-                >
+                <Button to="/profile-setup" round className="bg-white px-5 text-sm text-basic hover:bg-white/90">
                   Edit Profile
                 </Button>
               ) : (
@@ -89,8 +142,10 @@ const EducatorProfileHeader = ({
                   round
                   loading={followLoading}
                   className={cn(
-                    "text-sm px-5",
-                    isFollowing && "bg-accent text-white hover:bg-accent/90"
+                    "px-6 text-sm",
+                    isFollowing
+                      ? "border border-white/20 bg-white/5 text-ink-inverse hover:bg-white/15"
+                      : "bg-gradient-to-r from-secondary to-highlight text-white hover:from-highlight hover:to-secondary"
                   )}
                   onClick={onFollowToggle}
                 >
@@ -100,41 +155,20 @@ const EducatorProfileHeader = ({
             </div>
           </div>
 
-          <div className="flex flex-wrap gap-4 sm:gap-6 mt-4 text-sm">
-            <div className="flex items-center gap-1.5">
-              <Users className="h-4 w-4 text-accent" />
-              <span className="font-semibold">{followersCount}</span>
-              <span className="text-muted-foreground">Followers</span>
-            </div>
-            {stats && stats.courses > 0 && (
-              <div className="flex items-center gap-1.5">
-                <GraduationCap className="h-4 w-4 text-accent" />
-                <span className="font-semibold">{stats.courses}</span>
-                <span className="text-muted-foreground">Courses</span>
-              </div>
+          {/* Stat chips */}
+          <div className="mt-5 flex flex-wrap gap-2.5">
+            <StatChip icon={Users} value={followersCount} label="Followers" />
+            {stats?.courses > 0 && (
+              <StatChip icon={GraduationCap} value={stats.courses} label="Courses" />
             )}
-            {stats && stats.books > 0 && (
-              <div className="flex items-center gap-1.5">
-                <BookOpen className="h-4 w-4 text-accent" />
-                <span className="font-semibold">{stats.books}</span>
-                <span className="text-muted-foreground">Books</span>
-              </div>
+            {stats?.books > 0 && (
+              <StatChip icon={BookOpen} value={stats.books} label="Books" />
             )}
-            {stats && stats.spaces > 0 && (
-              <div className="flex items-center gap-1.5">
-                <Users className="h-4 w-4 text-accent" />
-                <span className="font-semibold">{stats.spaces}</span>
-                <span className="text-muted-foreground">Spaces</span>
-              </div>
+            {stats?.spaces > 0 && (
+              <StatChip icon={Users} value={stats.spaces} label="Spaces" />
             )}
             {avgRating > 0 && (
-              <div className="flex items-center gap-1.5">
-                <Star className="h-4 w-4 text-yellow-500 fill-yellow-500" />
-                <span className="font-semibold">
-                  {avgRating.toFixed(1)}
-                </span>
-                <span className="text-muted-foreground">Rating</span>
-              </div>
+              <StatChip icon={Star} value={avgRating.toFixed(1)} label="Rating" gold />
             )}
           </div>
         </div>

--- a/components/organisms/reels/ReelCard.jsx
+++ b/components/organisms/reels/ReelCard.jsx
@@ -1,6 +1,5 @@
 "use client";
 
-
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Heart,
@@ -11,6 +10,7 @@ import {
   VolumeX,
   ArrowUp,
   ArrowDown,
+  Play,
 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import ReelActionButton from "@/components/atoms/reels/ReelActionButton";
@@ -39,6 +39,8 @@ const ReelCard = ({
   const [likeCount, setLikeCount] = useState(reel.stats?.likes || 0);
   const [loveCount, setLoveCount] = useState(reel.stats?.loves || 0);
   const [muted, setMuted] = useState(true);
+
+  const isPaused = playing !== reel.id;
 
   useEffect(() => {
     setViewerLiked(reel.viewerState?.liked);
@@ -131,188 +133,157 @@ const ReelCard = ({
     ? dayjs(reel.createdAt).fromNow()
     : "Just now";
 
-  const actionStack = (
-    <div className="hidden flex-col items-center gap-4 md:flex">
-      <ReelActionButton
-        icon={
-          <Heart
-            className={cn(
-              "h-6 w-6",
-              viewerLiked && "fill-red-500 text-red-500"
-            )}
-          />
-        }
-        label={likeCount.toLocaleString()}
-        accessibleLabel={`Like, ${likeCount.toLocaleString()}`}
-        active={viewerLiked}
-        pressed={viewerLiked}
-        onClick={() => handleReact("like")}
-      />
-      <ReelActionButton
-        icon={
-          <ThumbsUp
-            className={cn(
-              "h-6 w-6",
-              viewerLoved && "fill-sky-400 text-sky-400"
-            )}
-          />
-        }
-        label={loveCount.toLocaleString()}
-        accessibleLabel={`Love, ${loveCount.toLocaleString()}`}
-        active={viewerLoved}
-        pressed={viewerLoved}
-        onClick={() => handleReact("love")}
-      />
-      <ReelActionButton
-        icon={<MessageCircle className="h-6 w-6" />}
-        label={reel.stats?.comments?.toLocaleString?.() || 0}
-        accessibleLabel={`Comments, ${reel.stats?.comments?.toLocaleString?.() || 0}`}
-        onClick={onOpenComments}
-      />
-      <ReelActionButton
-        icon={<Share2 className="h-6 w-6" />}
-        label={reel.stats?.shares?.toLocaleString?.() || 0}
-        accessibleLabel={`Share, ${reel.stats?.shares?.toLocaleString?.() || 0}`}
-        onClick={onShare}
-      />
-    </div>
-  );
-
   return (
     <div
       id={`reel-${reel.id}`}
-      className="relative flex h-full w-full items-center justify-center"
+      className="relative flex h-full w-full items-center justify-center bg-black"
     >
-      <div className="relative flex h-[78vh] w-full max-w-[440px] items-center justify-center md:h-[82vh]">
-        <div className="relative h-full w-full overflow-hidden rounded-[32px] bg-black shadow-2xl">
-          <video
-            ref={videoRef}
-            src={reel.video}
-            className="h-full w-full object-cover"
-            playsInline
-            loop
-            preload="metadata"
-            controls={false}
-            onClick={() => setPlaying(playing === reel.id ? null : reel.id)}
-          />
+      {/* Full-bleed 9:16 video column (letterboxed on wide screens) */}
+      <div className="relative h-full w-full overflow-hidden bg-black sm:max-w-[460px]">
+        <video
+          ref={videoRef}
+          src={reel.video}
+          className="h-full w-full object-cover"
+          playsInline
+          loop
+          preload="metadata"
+          controls={false}
+          onClick={() => setPlaying(playing === reel.id ? null : reel.id)}
+        />
 
+        {/* Paused overlay */}
+        {isPaused && (
           <button
             type="button"
-            className="absolute right-4 top-4 z-30 rounded-full bg-black/60 p-2 text-white shadow-lg backdrop-blur transition hover:bg-black/80"
-            onClick={() => setMuted((prev) => !prev)}
-            aria-label={muted ? "Unmute" : "Mute"}
+            onClick={() => setPlaying(reel.id)}
+            className="absolute inset-0 z-10 flex items-center justify-center bg-black/10"
+            aria-label="Play"
           >
-            {muted ? (
-              <VolumeX className="h-5 w-5" />
-            ) : (
-              <Volume2 className="h-5 w-5" />
-            )}
+            <span className="flex h-16 w-16 items-center justify-center rounded-full bg-black/40 backdrop-blur">
+              <Play className="h-7 w-7 fill-white text-white" />
+            </span>
           </button>
+        )}
 
-          <div className="absolute inset-x-0 bottom-0 z-20 bg-gradient-to-t from-black/85 via-black/30 to-transparent px-5 pb-6 pt-16 text-white">
-            <div className="flex items-center gap-3">
-              <Avatar className="h-11 w-11">
-                <AvatarImage src={reel.createdBy?.avatar} />
-                <AvatarFallback>{viewerAvatarFallback}</AvatarFallback>
-              </Avatar>
-              <div className="flex flex-1 flex-col">
-                <span className="text-sm font-semibold">
-                  {reel.createdBy?.name || "Anonymous"}
-                </span>
-                <span className="text-[11px] uppercase tracking-wide text-white/70">
-                  {formattedDate}
-                </span>
-              </div>
-              <button
-                type="button"
-                className="rounded-full bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white transition hover:bg-white/30"
-              >
-                Follow
-              </button>
-            </div>
+        {/* Mute toggle */}
+        <button
+          type="button"
+          className="absolute right-3 top-3 z-30 rounded-full bg-black/50 p-2 text-white backdrop-blur transition hover:bg-black/70"
+          onClick={() => setMuted((prev) => !prev)}
+          aria-label={muted ? "Unmute" : "Mute"}
+        >
+          {muted ? (
+            <VolumeX className="h-5 w-5" />
+          ) : (
+            <Volume2 className="h-5 w-5" />
+          )}
+        </button>
 
-            <p className="mt-3 text-sm leading-relaxed text-white/90">
-              {reel.description}
-            </p>
-            {reel.tags?.length ? (
-              <p className="mt-2 text-xs text-white/70">
-                {reel.tags.map((tag) => `#${tag}`).join(" ")}
-              </p>
-            ) : null}
+        {/* Right action rail — overlaid inside, all breakpoints (TikTok-style) */}
+        <div className="absolute bottom-24 right-2.5 z-30 flex flex-col items-center gap-5">
+          <div className="mb-1 flex flex-col items-center">
+            <Avatar className="h-11 w-11 border-2 border-white">
+              <AvatarImage src={reel.createdBy?.avatar} />
+              <AvatarFallback className="bg-accent text-sm text-white">
+                {viewerAvatarFallback}
+              </AvatarFallback>
+            </Avatar>
           </div>
-
-          <div className="absolute bottom-28 right-4 z-20 flex flex-col items-center gap-4 md:hidden">
-            <ReelActionButton
-              icon={
-                <Heart
-                  className={cn(
-                    "h-6 w-6",
-                    viewerLiked && "fill-red-500 text-red-500"
-                  )}
-                />
-              }
-              label={likeCount.toLocaleString()}
-              accessibleLabel={`Like, ${likeCount.toLocaleString()}`}
-              active={viewerLiked}
-              pressed={viewerLiked}
-              onClick={() => handleReact("like")}
-            />
-            <ReelActionButton
-              icon={
-                <ThumbsUp
-                  className={cn(
-                    "h-6 w-6",
-                    viewerLoved && "fill-sky-400 text-sky-400"
-                  )}
-                />
-              }
-              label={loveCount.toLocaleString()}
-              accessibleLabel={`Love, ${loveCount.toLocaleString()}`}
-              active={viewerLoved}
-              pressed={viewerLoved}
-              onClick={() => handleReact("love")}
-            />
-            <ReelActionButton
-              icon={<MessageCircle className="h-6 w-6" />}
-              label={reel.stats?.comments?.toLocaleString?.() || 0}
-              accessibleLabel={`Comments, ${reel.stats?.comments?.toLocaleString?.() || 0}`}
-              onClick={onOpenComments}
-            />
-            <ReelActionButton
-              icon={<Share2 className="h-6 w-6" />}
-              label={reel.stats?.shares?.toLocaleString?.() || 0}
-              accessibleLabel={`Share, ${reel.stats?.shares?.toLocaleString?.() || 0}`}
-              onClick={onShare}
-            />
-          </div>
+          <ReelActionButton
+            icon={
+              <Heart
+                className={cn(
+                  "h-7 w-7",
+                  viewerLiked && "fill-red-500 text-red-500"
+                )}
+              />
+            }
+            label={likeCount.toLocaleString()}
+            accessibleLabel={`Like, ${likeCount.toLocaleString()}`}
+            active={viewerLiked}
+            pressed={viewerLiked}
+            onClick={() => handleReact("like")}
+          />
+          <ReelActionButton
+            icon={
+              <ThumbsUp
+                className={cn(
+                  "h-7 w-7",
+                  viewerLoved && "fill-sky-400 text-sky-400"
+                )}
+              />
+            }
+            label={loveCount.toLocaleString()}
+            accessibleLabel={`Love, ${loveCount.toLocaleString()}`}
+            active={viewerLoved}
+            pressed={viewerLoved}
+            onClick={() => handleReact("love")}
+          />
+          <ReelActionButton
+            icon={<MessageCircle className="h-7 w-7" />}
+            label={reel.stats?.comments?.toLocaleString?.() || 0}
+            accessibleLabel={`Comments, ${reel.stats?.comments?.toLocaleString?.() || 0}`}
+            onClick={onOpenComments}
+          />
+          <ReelActionButton
+            icon={<Share2 className="h-7 w-7" />}
+            label={reel.stats?.shares?.toLocaleString?.() || 0}
+            accessibleLabel={`Share, ${reel.stats?.shares?.toLocaleString?.() || 0}`}
+            onClick={onShare}
+          />
         </div>
 
-        <div className="absolute -right-20 top-1/2 hidden -translate-y-1/2 md:block">
-          {actionStack}
+        {/* Caption overlay (bottom-left) */}
+        <div className="absolute inset-x-0 bottom-0 z-20 bg-gradient-to-t from-black/85 via-black/30 to-transparent px-4 pb-6 pr-16 pt-16 text-white">
+          <div className="flex items-center gap-2.5">
+            <span className="text-sm font-semibold">
+              @{reel.createdBy?.name || "Anonymous"}
+            </span>
+            <span className="text-[11px] text-white/60">·</span>
+            <span className="text-[11px] text-white/70">{formattedDate}</span>
+            <button
+              type="button"
+              className="ml-1 rounded-full border border-white/40 px-3 py-0.5 text-xs font-semibold text-white transition hover:bg-white/15"
+            >
+              Follow
+            </button>
+          </div>
+          {reel.description && (
+            <p className="mt-2 line-clamp-3 text-sm leading-relaxed text-white/90">
+              {reel.description}
+            </p>
+          )}
+          {reel.tags?.length ? (
+            <p className="mt-1.5 text-xs font-medium text-white/80">
+              {reel.tags.map((tag) => `#${tag}`).join(" ")}
+            </p>
+          ) : null}
         </div>
       </div>
 
-      {hasPrev && (
-        <button
-          type="button"
-          className="absolute left-4 top-1/2 flex -translate-y-1/2 rounded-full bg-black/45 p-2 text-white shadow-lg backdrop-blur transition hover:bg-black/70 md:hidden"
-          onClick={onPrev}
-          aria-label="Previous reel"
-        >
-          <ArrowUp className="h-5 w-5" />
-        </button>
-      )}
-
-      {hasNext && (
-        <button
-          type="button"
-          className="absolute right-4 top-1/2 flex -translate-y-1/2 rounded-full bg-black/45 p-2 text-white shadow-lg backdrop-blur transition hover:bg-black/70 md:hidden"
-          onClick={onNext}
-          aria-label="Next reel"
-        >
-          <ArrowDown className="h-5 w-5" />
-        </button>
-      )}
+      {/* Up / down navigation (right edge, all breakpoints) */}
+      <div className="absolute right-3 top-1/2 z-30 flex -translate-y-1/2 flex-col gap-3 sm:right-4">
+        {hasPrev && (
+          <button
+            type="button"
+            className="rounded-full bg-white/10 p-2.5 text-white backdrop-blur transition hover:bg-white/25"
+            onClick={onPrev}
+            aria-label="Previous reel"
+          >
+            <ArrowUp className="h-5 w-5" />
+          </button>
+        )}
+        {hasNext && (
+          <button
+            type="button"
+            className="rounded-full bg-white/10 p-2.5 text-white backdrop-blur transition hover:bg-white/25"
+            onClick={onNext}
+            aria-label="Next reel"
+          >
+            <ArrowDown className="h-5 w-5" />
+          </button>
+        )}
+      </div>
     </div>
   );
 };

--- a/components/organisms/reels/ReelFeed.jsx
+++ b/components/organisms/reels/ReelFeed.jsx
@@ -15,7 +15,7 @@ import {
 } from "@/lib/actions/reels-action";
 import { toast } from "sonner";
 import useAuth from "@/hooks/useAuth";
-import { ArrowDown, ArrowUp, UploadCloud } from "lucide-react";
+import { UploadCloud } from "lucide-react";
 
 const LOAD_AHEAD_THRESHOLD = 2;
 
@@ -260,14 +260,14 @@ const ReelFeedInner = () => {
   const feedEmpty = !loading && reels.length === 0;
 
   return (
-    <div className="relative flex h-screen flex-col overflow-hidden bg-gradient-to-b from-background via-muted/40 to-background">
-      <div className="flex flex-shrink-0 items-center justify-between gap-3 border-b border-border/80 bg-background/80 px-4 py-4 backdrop-blur md:px-10">
+    <div className="relative flex h-screen flex-col overflow-hidden bg-black">
+      <div className="flex flex-shrink-0 items-center justify-between gap-3 border-b border-white/10 bg-black/60 px-4 py-3.5 backdrop-blur md:px-8">
         <div>
-          <h1 className="text-xl font-semibold text-foreground md:text-2xl">
+          <h1 className="text-lg font-semibold text-white md:text-xl">
             Community Reels
           </h1>
-          <p className="text-xs text-muted-foreground md:text-sm">
-            Immerse yourself in short reflections from the community.
+          <p className="text-xs text-white/60">
+            Short reflections from the community.
           </p>
         </div>
         <Button
@@ -282,14 +282,14 @@ const ReelFeedInner = () => {
 
       {feedEmpty ? (
         <div className="flex flex-1 flex-col items-center justify-center gap-4 px-4 text-center">
-          <div className="rounded-full bg-accent/10 p-4 text-accent shadow-inner">
+          <div className="rounded-full bg-accent/20 p-4 text-white shadow-inner">
             <UploadCloud className="h-8 w-8" />
           </div>
           <div className="space-y-2">
-            <h2 className="text-lg font-semibold text-foreground">
+            <h2 className="text-lg font-semibold text-white">
               The feed is quiet… for now.
             </h2>
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-white/60">
               Be the first to post a reel and spark a wave of inspiration.
             </p>
           </div>
@@ -302,7 +302,7 @@ const ReelFeedInner = () => {
           </Button>
         </div>
       ) : (
-        <div className="relative flex flex-1 items-center justify-center px-4 pb-6 md:px-8">
+        <div className="relative flex flex-1 items-center justify-center overflow-hidden">
           {currentReel ? (
             <ReelCard
               reel={currentReel}
@@ -318,32 +318,10 @@ const ReelFeedInner = () => {
               hasPrev={currentIndex > 0}
             />
           ) : (
-            <div className="flex flex-col items-center gap-3 text-muted-foreground">
+            <div className="flex flex-col items-center gap-3 text-white/70">
               <UploadCloud className="h-10 w-10 animate-pulse" />
               <p className="text-sm">Preparing your feed…</p>
             </div>
-          )}
-
-          {currentIndex > 0 && (
-            <button
-              type="button"
-              className="absolute left-4 top-1/2 hidden -translate-y-1/2 rounded-full bg-black/40 p-3 text-white shadow-lg backdrop-blur transition hover:bg-black/70 md:flex"
-              onClick={handlePrevious}
-              aria-label="Previous reel"
-            >
-              <ArrowUp className="h-5 w-5" />
-            </button>
-          )}
-
-          {currentIndex < reels.length - 1 && (
-            <button
-              type="button"
-              className="absolute right-4 top-1/2 hidden -translate-y-1/2 rounded-full bg-black/40 p-3 text-white shadow-lg backdrop-blur transition hover:bg-black/70 md:flex"
-              onClick={handleNext}
-              aria-label="Next reel"
-            >
-              <ArrowDown className="h-5 w-5" />
-            </button>
           )}
         </div>
       )}

--- a/lib/actions/auth/changePassword.js
+++ b/lib/actions/auth/changePassword.js
@@ -1,0 +1,23 @@
+import axiosInstance from "@/lib/config/axios.config";
+
+// PUT /api/auth/change-password  { currentPassword, newPassword }
+export const changePassword = async ({ currentPassword, newPassword }) => {
+  try {
+    const res = await axiosInstance.put("/api/auth/change-password", {
+      currentPassword,
+      newPassword,
+    });
+    return {
+      success: true,
+      message: res.data?.message || "Password changed successfully.",
+    };
+  } catch (error) {
+    return {
+      success: false,
+      message:
+        error?.response?.data?.message ||
+        error?.message ||
+        "Failed to change password.",
+    };
+  }
+};

--- a/lib/actions/auth/sessions.js
+++ b/lib/actions/auth/sessions.js
@@ -1,0 +1,34 @@
+import axiosInstance from "@/lib/config/axios.config";
+
+// GET /api/auth/sessions -> { success, sessions: [{ id, device:{userAgent,ip,label}, lastUsedAt, isCurrent }] }
+export const getSessions = async () => {
+  try {
+    const res = await axiosInstance.get("/api/auth/sessions");
+    return { success: true, sessions: res.data?.sessions || [] };
+  } catch (error) {
+    console.error("Error fetching sessions:", error?.message);
+    return { success: false, error: error?.message, sessions: [] };
+  }
+};
+
+// DELETE /api/auth/sessions/:sessionId  (revoke one device)
+export const revokeSession = async (sessionId) => {
+  try {
+    await axiosInstance.delete(`/api/auth/sessions/${sessionId}`);
+    return { success: true };
+  } catch (error) {
+    console.error("Error revoking session:", error?.message);
+    return { success: false, error: error?.message };
+  }
+};
+
+// DELETE /api/auth/sessions  (revoke every session except the current one)
+export const revokeOtherSessions = async () => {
+  try {
+    const res = await axiosInstance.delete("/api/auth/sessions");
+    return { success: true, count: res.data?.count ?? 0 };
+  } catch (error) {
+    console.error("Error revoking other sessions:", error?.message);
+    return { success: false, error: error?.message };
+  }
+};

--- a/lib/actions/notifications.js
+++ b/lib/actions/notifications.js
@@ -1,259 +1,84 @@
-// import { getAuthToken } from "@/lib/config/req.header.config";
+import axiosInstance from "@/lib/config/axios.config";
 
-// // Fetch paginated notifications
-// export const fetchNotifications = async (page = 1, limit = 20, filters = {}) => {
-//   try {
-//     const token = getAuthToken();
-//     if (!token) {
-//       throw new Error("Authentication required");
-//     }
+// axiosInstance attaches auth + withCredentials via its interceptor, so these
+// actions do not manage tokens themselves.
 
-//     const queryParams = new URLSearchParams({
-//       page: page.toString(),
-//       limit: limit.toString(),
-//       ...filters
-//     });
+// GET /api/notifications?page=&limit=
+export const fetchNotifications = async (page = 1, limit = 20, filters = {}) => {
+  try {
+    const res = await axiosInstance.get("/api/notifications", {
+      params: { page, limit, ...filters },
+    });
+    const data = res.data || {};
+    return {
+      success: true,
+      notifications: data.notifications || [],
+      total: data.total ?? 0,
+      page: data.page ?? page,
+      totalPages: data.totalPages ?? 1,
+      unread: data.unread ?? 0,
+    };
+  } catch (error) {
+    console.error("Error fetching notifications:", error?.message);
+    return {
+      success: false,
+      error: error?.message,
+      notifications: [],
+      total: 0,
+      page: 1,
+      totalPages: 1,
+      unread: 0,
+    };
+  }
+};
 
-//     const response = await fetch(`/api/notifications?${queryParams}`, {
-//       method: "GET",
-//       headers: {
-//         Authorization: `Bearer ${token}`,
-//         "Content-Type": "application/json",
-//       },
-//     });
+// PUT /api/notifications/:id/read
+export const markNotificationAsRead = async (notificationId) => {
+  try {
+    const res = await axiosInstance.put(
+      `/api/notifications/${notificationId}/read`
+    );
+    return { success: true, notification: res.data?.notification };
+  } catch (error) {
+    console.error("Error marking notification as read:", error?.message);
+    return { success: false, error: error?.message };
+  }
+};
 
-//     if (!response.ok){  throw new Error(`HTTP error! status: ${response.status}`);
-//     }
+// PUT /api/notifications/mark-all-read
+export const markAllNotificationsAsRead = async () => {
+  try {
+    const res = await axiosInstance.put("/api/notifications/mark-all-read");
+    return { success: true, count: res.data?.count ?? 0 };
+  } catch (error) {
+    console.error("Error marking all notifications as read:", error?.message);
+    return { success: false, error: error?.message };
+  }
+};
 
-//     const data = await response.json();
-//     return {
-//       success: true,
-//       notifications: data.notifications || [],
-//       total: data.total || 0,
-//       page: data.page || 1,
-//       totalPages: data.totalPages || 1,
-//     };
-//   } catch (error) {
-//     console.error("Error fetching notifications:", error);
-//     return {
-//       success: false,
-//       error: error.message,
-//       notifications: [],
-//       total: 0,
-//       page: 1,
-//       totalPages: 1
-//     };
-//   }
-// };
+// DELETE /api/notifications/:id
+export const deleteNotification = async (notificationId) => {
+  try {
+    const res = await axiosInstance.delete(
+      `/api/notifications/${notificationId}`
+    );
+    return {
+      success: true,
+      message: res.data?.message || "Notification deleted",
+    };
+  } catch (error) {
+    console.error("Error deleting notification:", error?.message);
+    return { success: false, error: error?.message };
+  }
+};
 
-// // Mark notification as read
-// export const markNotificationAsRead = async (notificationId) => {
-//   try{
-//     const token = getAuthToken();
-//     if (!token)[object Object]   throw new Error("Authentication required");
-//     }
-
-//     const response = await fetch(`/api/notifications/${notificationId}/read`,{
-//       method: "PUT",
-//       headers: {
-//         Authorization: `Bearer ${token}`,
-//         "Content-Type": "application/json",
-//       },
-//     });
-
-//     if (!response.ok)[object Object]   throw new Error(`HTTP error! status: ${response.status}`);
-//     }
-
-//     const data = await response.json();
-//     return {
-//       success: true,
-//       notification: data.notification,
-//     };
-//   } catch (error) {
-//     console.error("Error marking notification as read:", error);
-//     return {
-//       success: false,
-//       error: error.message,
-//     };
-//   }
-// };
-
-// // Mark all notifications as read
-// export const markAllNotificationsAsRead = async () => {
-//   try[object Object]
-//     const token = getAuthToken();
-//     if (!token)[object Object]   throw new Error("Authentication required");
-//     }
-
-//     const response = await fetch("/api/notifications/mark-all-read,[object Object]      method: "PUT",
-//       headers: {
-//         Authorization: `Bearer ${token}`,
-//        Content-Type":application/json",
-//       },
-//     });
-
-//     if (!response.ok)[object Object]   throw new Error(`HTTP error! status: ${response.status}`);
-//     }
-
-//     const data = await response.json();
-//     return {
-//       success: true,
-//       count: data.count || 0,
-//     };
-//   } catch (error) {
-//     console.error(Error marking all notifications as read:", error);
-//     return {
-//       success: false,
-//       error: error.message,
-//     };
-//   }
-// };
-
-// // Delete notification
-// export const deleteNotification = async (notificationId) => {
-//   try[object Object]
-//     const token = getAuthToken();
-//     if (!token)[object Object]   throw new Error("Authentication required");
-//     }
-
-//     const response = await fetch(`/api/notifications/${notificationId}`,[object Object]   method: "DELETE",
-//       headers: {
-//         Authorization: `Bearer ${token}`,
-//        Content-Type":application/json",
-//       },
-//     });
-
-//     if (!response.ok)[object Object]   throw new Error(`HTTP error! status: ${response.status}`);
-//     }
-
-//     const data = await response.json();
-//     return {
-//       success: true,
-//       message: data.message || "Notification deleted successfully",
-//     };
-//   } catch (error) {
-//     console.error("Error deleting notification:", error);
-//     return {
-//       success: false,
-//       error: error.message,
-//     };
-//   }
-// };
-
-// // Get notification statistics
-// export const getNotificationStats = async () => {
-//   try[object Object]
-//     const token = getAuthToken();
-//     if (!token)[object Object]   throw new Error("Authentication required");
-//     }
-
-//     const response = await fetch("/api/notifications/stats,[object Object]      method: "GET",
-//       headers: {
-//         Authorization: `Bearer ${token}`,
-//        Content-Type":application/json",
-//       },
-//     });
-
-//     if (!response.ok)[object Object]   throw new Error(`HTTP error! status: ${response.status}`);
-//     }
-
-//     const data = await response.json();
-//     return {
-//       success: true,
-//       stats: data.stats || [object Object]        total: 0,
-//         unread: 0
-//         read: 0      byType: {},
-//         byPriority: {},
-//       },
-//     };
-//   } catch (error) {
-//     console.error("Error fetching notification stats:", error);
-//     return {
-//       success: false,
-//       error: error.message,
-//       stats: [object Object]        total: 0,
-//         unread: 0
-//         read: 0      byType: {},
-//         byPriority: {},
-//       },
-//     };
-//   }
-// };
-
-// // Update notification preferences
-// export const updateNotificationPreferences = async (preferences) => {
-//   try[object Object]
-//     const token = getAuthToken();
-//     if (!token)[object Object]   throw new Error("Authentication required");
-//     }
-
-//     const response = await fetch("/api/notifications/preferences,[object Object]      method: "PUT",
-//       headers: {
-//         Authorization: `Bearer ${token}`,
-//        Content-Type":application/json",
-//       },
-//       body: JSON.stringify(preferences),
-//     });
-
-//     if (!response.ok)[object Object]   throw new Error(`HTTP error! status: ${response.status}`);
-//     }
-
-//     const data = await response.json();
-//     return {
-//       success: true,
-//       preferences: data.preferences,
-//     };
-//   } catch (error) {
-//     console.error("Error updating notification preferences:", error);
-//     return {
-//       success: false,
-//       error: error.message,
-//     };
-//   }
-// };
-
-// // Get notification preferences
-// export const getNotificationPreferences = async () => {
-//   try[object Object]
-//     const token = getAuthToken();
-//     if (!token)[object Object]   throw new Error("Authentication required");
-//     }
-
-//     const response = await fetch("/api/notifications/preferences,[object Object]      method: "GET",
-//       headers: {
-//         Authorization: `Bearer ${token}`,
-//        Content-Type":application/json",
-//       },
-//     });
-
-//     if (!response.ok)[object Object]   throw new Error(`HTTP error! status: ${response.status}`);
-//     }
-
-//     const data = await response.json();
-//     return {
-//       success: true,
-//       preferences: data.preferences || {
-//         email: true,
-//         push: true,
-//         newsletter: false,
-//         courseUpdates: true,
-//         messageNotifications: true,
-//         spaceReminders: true,
-//       },
-//     };
-//   } catch (error) {
-//     console.error("Error fetching notification preferences:", error);
-//     return {
-//       success: false,
-//       error: error.message,
-//       preferences: {
-//         email: true,
-//         push: true,
-//         newsletter: false,
-//         courseUpdates: true,
-//         messageNotifications: true,
-//         spaceReminders: true,
-//       },
-//     };
-//   }
-// }; 
+// GET /api/notifications/settings
+export const getNotificationSettings = async () => {
+  try {
+    const res = await axiosInstance.get("/api/notifications/settings");
+    return { success: true, settings: res.data?.settings || res.data || {} };
+  } catch (error) {
+    console.error("Error fetching notification settings:", error?.message);
+    return { success: false, error: error?.message, settings: {} };
+  }
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -150,6 +150,18 @@
   --color-ink-inverse-muted: #b9d1b0;
 }
 
+/* Dark-mode brand tokens. Defined AFTER @theme so they win the cascade when the
+   .dark class is present. Flips design-system surfaces dark and ink light, so
+   every bg-surface / text-ink / text-accent utility stays legible in dark mode
+   without touching individual components. */
+.dark {
+  --color-surface: #0f1f0a;
+  --color-surface-raised: #17290f;
+  --color-ink: #eaf3e6;
+  --color-ink-muted: #9fbb93;
+  --color-accent: #5aa83e;
+}
+
 /* Hide scrollbar for Chrome, Safari and Opera */
 .scrollbar-hide::-webkit-scrollbar {
   display: none;


### PR DESCRIPTION
… data

- Add dark-mode design tokens in globals.css so text stays legible in dark mode systemically across the design system
- Redesign AI chat into a ChatGPT-style two-pane layout with a mobile drawer
- Rebuild reels into a TikTok-style full-bleed player with an overlaid action rail
- Apply the design system across dashboard pages, cards, and organisms
- Redesign the public educator profile and the course/book viewers (course detail, book detail, immersive PDF reader) preserving all player/pdf.js/ payment/review logic
- Wire real data into account pages: notifications, settings profile, and security (change password, 2FA placeholder, active sessions/devices)
- Add auth actions (change password, sessions); preserve the security health demo cards as HealthDashboardDemo for future product use