### PR TITLE
feat(design-system): add layout primitives and reconcile dashboard pa…

### DIFF
--- a/app/dashboard/courses/page.jsx
+++ b/app/dashboard/courses/page.jsx
@@ -3,18 +3,17 @@ import { useEffect, useState } from "react";
 import { GraduationCap, Bookmark, Plus } from "lucide-react";
 import CourseCard from "@/components/molecules/dashboard/cards/courseCard";
 import CourseCardSkeleton from "@/components/atoms/skeletons/CourseCardSkeleton";
-import Button from "@/components/atoms/form/Button";
+import { Button } from "@/components/ui/button";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { CardGrid } from "@/components/ui/card-grid";
+import { EmptyState } from "@/components/ui/empty-state";
 import { fetchCourses } from "@/lib/actions/courses/fetch-courses";
 import { getBookmarkedCourses } from "@/lib/actions/courses/bookmark-course";
 import useAuth from "@/hooks/useAuth";
 import { useAllCourseProgress } from "@/hooks/useCourseProgress";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
 import { cn } from "@/lib/utils";
-import {
-  poppins_400,
-  poppins_500,
-  poppins_600,
-} from "@/lib/config/font.config";
 
 export default function CoursesPage() {
   const { user } = useAuth();
@@ -56,91 +55,68 @@ export default function CoursesPage() {
   }
 
   return (
-    <div className="space-y-6 bg-surface p-4 sm:p-6">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex items-center gap-3">
-          <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-            <GraduationCap className="h-5 w-5 text-accent" />
-          </div>
-          <div>
-            <h1
-              className={cn(
-                poppins_600,
-                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
-              )}
+    <PageShell>
+      <PageHeader
+        icon={GraduationCap}
+        title={showBookmarks ? "My Bookmarked Courses" : "All Courses"}
+        subtitle={
+          showBookmarks
+            ? "Courses you've saved for later"
+            : "Browse and enroll in courses"
+        }
+        actions={
+          <>
+            <Button
+              variant="outline"
+              className="rounded-full"
+              onClick={() => (window.location.href = "/dashboard/courses/create")}
             >
-              {showBookmarks ? "My Bookmarked Courses" : "All Courses"}
-            </h1>
-            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
-              {showBookmarks
-                ? "Courses you've saved for later"
-                : "Browse and enroll in courses"}
-            </p>
-          </div>
-        </div>
-        <div className="flex gap-2">
-          <Button
-            round
-            outlined
-            onClick={() => (window.location.href = "/dashboard/courses/create")}
-          >
-            <Plus className="h-4 w-4 mr-1" />
-            Create
-          </Button>
-          <Button
-            round
-            outlined={!showBookmarks}
-            className={showBookmarks ? "bg-accent text-white" : ""}
-            onClick={() => setShowBookmarks(!showBookmarks)}
-          >
-            <Bookmark className="h-4 w-4 mr-1" />
-            {showBookmarks ? "Show All" : "Bookmarks"}
-          </Button>
-        </div>
-      </div>
+              <Plus className="h-4 w-4 mr-1" />
+              Create
+            </Button>
+            <Button
+              variant={showBookmarks ? "default" : "outline"}
+              className={cn("rounded-full", showBookmarks && "bg-accent text-white hover:bg-accent/90")}
+              onClick={() => setShowBookmarks(!showBookmarks)}
+            >
+              <Bookmark className="h-4 w-4 mr-1" />
+              {showBookmarks ? "Show All" : "Bookmarks"}
+            </Button>
+          </>
+        }
+      />
 
       {loading ? (
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        <CardGrid>
           {[...Array(6)].map((_, idx) => (
             <CourseCardSkeleton key={`skeleton-${idx}`} />
           ))}
-        </div>
+        </CardGrid>
       ) : courses.length === 0 ? (
-        <div className="rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
-          <div className="flex flex-col items-center justify-center space-y-4 py-16 text-center">
-            <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
-              <GraduationCap className="h-7 w-7 text-accent" />
-            </div>
-            <div>
-              <h3 className={cn(poppins_600, "text-lg text-ink")}>
-                {showBookmarks ? "No Bookmarked Courses" : "No Courses Yet"}
-              </h3>
-              <p
-                className={cn(
-                  poppins_400,
-                  "mt-1 max-w-md text-sm text-ink-muted"
-                )}
-              >
-                {showBookmarks
-                  ? "Start bookmarking courses you're interested in!"
-                  : "No courses available at the moment."}
-              </p>
-            </div>
-            {!showBookmarks && (
+        <EmptyState
+          icon={GraduationCap}
+          title={showBookmarks ? "No Bookmarked Courses" : "No Courses Yet"}
+          description={
+            showBookmarks
+              ? "Start bookmarking courses you're interested in!"
+              : "No courses available at the moment."
+          }
+          action={
+            !showBookmarks && (
               <Button
-                round
-                outlined
+                variant="outline"
+                className="rounded-full"
                 onClick={() =>
                   (window.location.href = "/dashboard/courses/create")
                 }
               >
                 Create Course
               </Button>
-            )}
-          </div>
-        </div>
+            )
+          }
+        />
       ) : (
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        <CardGrid>
           {courses
             .filter(
               (course) =>
@@ -158,8 +134,8 @@ export default function CoursesPage() {
                 }}
               />
             ))}
-        </div>
+        </CardGrid>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/app/dashboard/earnings/page.jsx
+++ b/app/dashboard/earnings/page.jsx
@@ -8,7 +8,10 @@ import {
   Wallet,
 } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
-import Button from "@/components/atoms/form/Button";
+import { Button } from "@/components/ui/button";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { EmptyState } from "@/components/ui/empty-state";
 import {
   ChartContainer,
   ChartTooltip,
@@ -46,33 +49,12 @@ const Panel = ({ className, children }) => (
   </div>
 );
 
-const PageHeader = () => (
-  <div className="flex items-center gap-3">
-    <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-      <DollarSign className="h-5 w-5 text-accent" />
-    </div>
-    <div>
-      <h1
-        className={cn(
-          poppins_600,
-          "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
-        )}
-      >
-        Earnings Dashboard
-      </h1>
-      <p className={cn(poppins_400, "text-sm text-ink-muted")}>
-        Track your sales, revenue, and payout analytics
-      </p>
-    </div>
-  </div>
-);
-
 const SectionHeading = ({ title, subtitle, right }) => (
   <div className="mb-5 flex items-start justify-between gap-3">
     <div>
-      <h2 className={cn(poppins_600, "text-lg text-ink")}>{title}</h2>
+      <h2 className={cn(poppins_600.className, "text-lg text-ink")}>{title}</h2>
       {subtitle && (
-        <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+        <p className={cn(poppins_400.className, "mt-1 text-sm text-ink-muted")}>
           {subtitle}
         </p>
       )}
@@ -84,7 +66,7 @@ const SectionHeading = ({ title, subtitle, right }) => (
 const StatusBadge = ({ status, small }) => (
   <span
     className={cn(
-      poppins_500,
+      poppins_500.className,
       "inline-flex items-center rounded-full border capitalize",
       small ? "px-2 py-0.5 text-[11px]" : "px-3 py-1 text-xs",
       statusStyles[status] || statusStyles.expired
@@ -101,15 +83,15 @@ function SummaryTile({ icon: Icon, label, value, subtext, trend, trendLabel }) {
         <div className="space-y-1">
           <p
             className={cn(
-              poppins_500,
+              poppins_500.className,
               "text-xs uppercase tracking-wider text-ink-muted"
             )}
           >
             {label}
           </p>
-          <p className={cn(poppins_600, "text-3xl text-ink")}>{value}</p>
+          <p className={cn(poppins_600.className, "text-3xl text-ink")}>{value}</p>
           {subtext && (
-            <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+            <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
               {subtext}
             </p>
           )}
@@ -119,7 +101,7 @@ function SummaryTile({ icon: Icon, label, value, subtext, trend, trendLabel }) {
         </div>
       </div>
       {trend !== undefined && (
-        <div className={cn(poppins_500, "mt-4 flex items-center gap-1 text-sm")}>
+        <div className={cn(poppins_500.className, "mt-4 flex items-center gap-1 text-sm")}>
           {trend >= 0 ? (
             <TrendingUp className="h-4 w-4 text-secondary" />
           ) : (
@@ -128,7 +110,7 @@ function SummaryTile({ icon: Icon, label, value, subtext, trend, trendLabel }) {
           <span className={trend >= 0 ? "text-secondary" : "text-red-600"}>
             {Math.abs(trend)}%
           </span>
-          <span className={cn(poppins_400, "ml-1 text-ink-muted")}>
+          <span className={cn(poppins_400.className, "ml-1 text-ink-muted")}>
             {trendLabel}
           </span>
         </div>
@@ -172,48 +154,46 @@ export default function EarningsPage() {
 
   if (!hasWallet && !isLoading) {
     return (
-      <div className="space-y-6 bg-surface p-4 sm:p-6">
-        <PageHeader />
-        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
-            <Wallet className="h-7 w-7 text-accent" />
-          </div>
-          <div>
-            <h3 className={cn(poppins_600, "text-lg text-ink")}>
-              Connect Your Wallet
-            </h3>
-            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
-              Connect your Stellar wallet to view your earnings and sales
-              analytics
-            </p>
-          </div>
-          <WalletConnectButton />
-        </Panel>
-      </div>
+      <PageShell>
+        <PageHeader
+          icon={DollarSign}
+          title="Earnings Dashboard"
+          subtitle="Track your sales, revenue, and payout analytics"
+        />
+        <EmptyState
+          icon={Wallet}
+          title="Connect Your Wallet"
+          description="Connect your Stellar wallet to view your earnings and sales analytics"
+          action={<WalletConnectButton />}
+        />
+      </PageShell>
     );
   }
 
   if (error) {
     return (
-      <div className="space-y-6 bg-surface p-4 sm:p-6">
-        <PageHeader />
-        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-red-50">
-            <TrendingDown className="h-7 w-7 text-red-600" />
-          </div>
-          <div>
-            <h3 className={cn(poppins_600, "text-lg text-ink")}>
-              Failed to Load Data
-            </h3>
-            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
-              {error}
-            </p>
-          </div>
-          <Button round outlined onClick={() => window.location.reload()}>
-            Try Again
-          </Button>
-        </Panel>
-      </div>
+      <PageShell>
+        <PageHeader
+          icon={DollarSign}
+          title="Earnings Dashboard"
+          subtitle="Track your sales, revenue, and payout analytics"
+        />
+        <EmptyState
+          icon={TrendingDown}
+          iconContainerClassName="bg-red-50"
+          title="Failed to Load Data"
+          description={error}
+          action={
+            <Button
+              variant="outline"
+              className="rounded-full"
+              onClick={() => window.location.reload()}
+            >
+              Try Again
+            </Button>
+          }
+        />
+      </PageShell>
     );
   }
 
@@ -222,8 +202,12 @@ export default function EarningsPage() {
   };
 
   return (
-    <div className="space-y-6 bg-surface p-4 sm:p-6">
-      <PageHeader />
+    <PageShell>
+      <PageHeader
+        icon={DollarSign}
+        title="Earnings Dashboard"
+        subtitle="Track your sales, revenue, and payout analytics"
+      />
 
       {isLoading ? (
         <>
@@ -246,20 +230,11 @@ export default function EarningsPage() {
       ) : totalEarned === 0 && salesCount === 0 ? (
         <>
           <SummarySkeleton />
-          <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
-            <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
-              <DollarSign className="h-7 w-7 text-accent" />
-            </div>
-            <div>
-              <h3 className={cn(poppins_600, "text-lg text-ink")}>
-                No Sales Yet
-              </h3>
-              <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
-                Your earnings will appear here once students purchase your
-                courses or books
-              </p>
-            </div>
-          </Panel>
+          <EmptyState
+            icon={DollarSign}
+            title="No Sales Yet"
+            description="Your earnings will appear here once students purchase your courses or books"
+          />
         </>
       ) : (
         <>
@@ -304,7 +279,7 @@ export default function EarningsPage() {
                       key={range}
                       onClick={() => setChartRange(range)}
                       className={cn(
-                        poppins_500,
+                        poppins_500.className,
                         "rounded-lg px-3 py-1.5 text-sm transition-all",
                         chartRange === range
                           ? "bg-accent text-white shadow-sm"
@@ -320,7 +295,7 @@ export default function EarningsPage() {
             {chartData.length === 0 ? (
               <div
                 className={cn(
-                  poppins_400,
+                  poppins_400.className,
                   "flex h-64 items-center justify-center text-ink-muted"
                 )}
               >
@@ -383,7 +358,7 @@ export default function EarningsPage() {
               {topItems.length === 0 ? (
                 <p
                   className={cn(
-                    poppins_400,
+                    poppins_400.className,
                     "py-8 text-center text-sm text-ink-muted"
                   )}
                 >
@@ -401,7 +376,7 @@ export default function EarningsPage() {
                           <div className="flex min-w-0 flex-1 items-center gap-2">
                             <span
                               className={cn(
-                                poppins_600,
+                                poppins_600.className,
                                 "text-sm text-ink-muted"
                               )}
                             >
@@ -412,7 +387,7 @@ export default function EarningsPage() {
                                 <Link
                                   href={link}
                                   className={cn(
-                                    poppins_500,
+                                    poppins_500.className,
                                     "block truncate text-sm text-ink hover:text-secondary hover:underline"
                                   )}
                                 >
@@ -421,7 +396,7 @@ export default function EarningsPage() {
                               ) : (
                                 <p
                                   className={cn(
-                                    poppins_500,
+                                    poppins_500.className,
                                     "truncate text-sm text-ink"
                                   )}
                                 >
@@ -430,7 +405,7 @@ export default function EarningsPage() {
                               )}
                               <span
                                 className={cn(
-                                  poppins_400,
+                                  poppins_400.className,
                                   "text-xs capitalize text-ink-muted"
                                 )}
                               >
@@ -439,12 +414,12 @@ export default function EarningsPage() {
                             </div>
                           </div>
                           <div className="ml-4 flex-shrink-0 text-right">
-                            <p className={cn(poppins_600, "text-sm text-ink")}>
+                            <p className={cn(poppins_600.className, "text-sm text-ink")}>
                               ${item.revenue.toFixed(2)}
                             </p>
                             <p
                               className={cn(
-                                poppins_400,
+                                poppins_400.className,
                                 "text-xs text-ink-muted"
                               )}
                             >
@@ -481,13 +456,13 @@ export default function EarningsPage() {
                       className="flex items-center justify-between rounded-xl border border-accent/10 bg-surface p-3"
                     >
                       <StatusBadge status={status} />
-                      <span className={cn(poppins_600, "text-ink")}>{count}</span>
+                      <span className={cn(poppins_600.className, "text-ink")}>{count}</span>
                     </div>
                   ))}
                 {Object.values(statusBreakdown).every((c) => c === 0) && (
                   <p
                     className={cn(
-                      poppins_400,
+                      poppins_400.className,
                       "py-8 text-center text-sm text-ink-muted"
                     )}
                   >
@@ -498,11 +473,11 @@ export default function EarningsPage() {
               <div className="mt-4 rounded-xl border border-accent/10 bg-surface p-3">
                 <p
                   className={cn(
-                    poppins_400,
+                    poppins_400.className,
                     "flex flex-wrap items-center gap-1 text-xs text-ink-muted"
                   )}
                 >
-                  <strong className={cn(poppins_500, "text-ink")}>Note:</strong>{" "}
+                  <strong className={cn(poppins_500.className, "text-ink")}>Note:</strong>{" "}
                   Only <StatusBadge status="confirmed" small /> transactions
                   count toward your earnings totals.
                 </p>
@@ -511,6 +486,6 @@ export default function EarningsPage() {
           </div>
         </>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/app/dashboard/library/page.jsx
+++ b/app/dashboard/library/page.jsx
@@ -9,7 +9,11 @@ import React, {
 import { useRouter, useSearchParams } from "next/navigation";
 import { BookOpen, Bookmark, Plus } from "lucide-react";
 import LibraryBookCard from "@/components/molecules/dashboard/cards/libraryCard";
-import Button from "@/components/atoms/form/Button";
+import { Button } from "@/components/ui/button";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { CardGrid } from "@/components/ui/card-grid";
+import { EmptyState } from "@/components/ui/empty-state";
 import Modal from "@/components/molecules/Modal";
 import BookCreateForm from "@/components/organisms/create/book-create-form";
 import { fetchBooks } from "@/lib/actions/library/fetch-books";
@@ -29,11 +33,6 @@ import {
   PaginationPrevious,
 } from "@/components/ui/pagination";
 import { cn } from "@/lib/utils";
-import {
-  poppins_400,
-  poppins_500,
-  poppins_600,
-} from "@/lib/config/font.config";
 
 const PAGE_SIZE = 9;
 
@@ -54,25 +53,12 @@ const createdAtOf = (book) => {
 
 const priceOf = (book) => Number(book?.price) || 0;
 
-/* ── building blocks (design-system consistent) ── */
-
-const Panel = ({ className, children }) => (
-  <div
-    className={cn(
-      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
-      className
-    )}
-  >
-    {children}
-  </div>
-);
-
 const BookGridSkeleton = () => (
-  <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+  <CardGrid>
     {[...Array(6)].map((_, idx) => (
       <LibraryBookSkeleton key={`skeleton-${idx}`} />
     ))}
-  </div>
+  </CardGrid>
 );
 
 const LibraryPageContent = () => {
@@ -257,44 +243,36 @@ const LibraryPageContent = () => {
   }
 
   return (
-    <div className="space-y-6 bg-surface p-4 sm:p-6">
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex items-center gap-3">
-          <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-            <BookOpen className="h-5 w-5 text-accent" />
-          </div>
-          <div>
-            <h1
-              className={cn(
-                poppins_600,
-                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
-              )}
+    <PageShell>
+      <PageHeader
+        icon={BookOpen}
+        title={showBookmarks ? "My Bookmarked Books" : "All Books"}
+        subtitle={
+          showBookmarks
+            ? "Books you've saved for later"
+            : "Browse and read Islamic books"
+        }
+        actions={
+          <>
+            <Button
+              variant="outline"
+              className="rounded-full"
+              onClick={() => setModalOpen(true)}
             >
-              {showBookmarks ? "My Bookmarked Books" : "All Books"}
-            </h1>
-            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
-              {showBookmarks
-                ? "Books you've saved for later"
-                : "Browse and read Islamic books"}
-            </p>
-          </div>
-        </div>
-        <div className="flex gap-2">
-          <Button round outlined onClick={() => setModalOpen(true)}>
-            <Plus className="h-4 w-4 mr-1" />
-            Create
-          </Button>
-          <Button
-            round
-            outlined={!showBookmarks}
-            className={showBookmarks ? "bg-accent text-white" : ""}
-            onClick={() => setShowBookmarks((prev) => !prev)}
-          >
-            <Bookmark className="h-4 w-4 mr-1" />
-            {showBookmarks ? "Show All" : "Bookmarks"}
-          </Button>
-        </div>
-      </div>
+              <Plus className="h-4 w-4 mr-1" />
+              Create
+            </Button>
+            <Button
+              variant={showBookmarks ? "default" : "outline"}
+              className={cn("rounded-full", showBookmarks && "bg-accent text-white hover:bg-accent/90")}
+              onClick={() => setShowBookmarks((prev) => !prev)}
+            >
+              <Bookmark className="h-4 w-4 mr-1" />
+              {showBookmarks ? "Show All" : "Bookmarks"}
+            </Button>
+          </>
+        }
+      />
 
       {!loading && (
         <LibraryToolbar
@@ -316,46 +294,47 @@ const LibraryPageContent = () => {
       {loading ? (
         <BookGridSkeleton />
       ) : filteredBooks.length === 0 ? (
-        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
-            <BookOpen className="h-7 w-7 text-accent" />
-          </div>
-          <div>
-            <h3 className={cn(poppins_600, "text-lg text-ink")}>
-              {isFiltered
-                ? "No Matching Books"
-                : showBookmarks
-                ? "No Bookmarked Books"
-                : "No Books Yet"}
-            </h3>
-            <p
-              className={cn(
-                poppins_400,
-                "mt-1 max-w-md text-sm text-ink-muted"
-              )}
-            >
-              {isFiltered
-                ? "No books match the current filters. Try widening your search."
-                : showBookmarks
-                ? "Save titles you want to revisit!"
-                : "No books available at the moment."}
-            </p>
-          </div>
-          {isFiltered ? (
-            <Button round outlined onClick={handleClearFilters}>
-              Clear filters
-            </Button>
-          ) : (
-            !showBookmarks && (
-              <Button round outlined onClick={() => setModalOpen(true)}>
-                Create Book
+        <EmptyState
+          icon={BookOpen}
+          title={
+            isFiltered
+              ? "No Matching Books"
+              : showBookmarks
+              ? "No Bookmarked Books"
+              : "No Books Yet"
+          }
+          description={
+            isFiltered
+              ? "No books match the current filters. Try widening your search."
+              : showBookmarks
+              ? "Save titles you want to revisit!"
+              : "No books available at the moment."
+          }
+          action={
+            isFiltered ? (
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={handleClearFilters}
+              >
+                Clear filters
               </Button>
+            ) : (
+              !showBookmarks && (
+                <Button
+                  variant="outline"
+                  className="rounded-full"
+                  onClick={() => setModalOpen(true)}
+                >
+                  Create Book
+                </Button>
+              )
             )
-          )}
-        </Panel>
+          }
+        />
       ) : (
         <>
-          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          <CardGrid>
             {pagedBooks.map((book) => (
               <LibraryBookCard
                 key={book._id}
@@ -365,7 +344,7 @@ const LibraryPageContent = () => {
                 }
               />
             ))}
-          </div>
+          </CardGrid>
 
           {totalPages > 1 && (
             <Pagination>
@@ -417,7 +396,7 @@ const LibraryPageContent = () => {
       >
         <BookCreateForm onBookCreated={handleBookCreated} />
       </Modal>
-    </div>
+    </PageShell>
   );
 };
 
@@ -426,9 +405,9 @@ const LibraryPageContent = () => {
 const LibraryPage = () => (
   <Suspense
     fallback={
-      <div className="bg-surface p-4 sm:p-6">
+      <PageShell>
         <BookGridSkeleton />
-      </div>
+      </PageShell>
     }
   >
     <LibraryPageContent />

--- a/app/dashboard/page.jsx
+++ b/app/dashboard/page.jsx
@@ -1,4 +1,4 @@
-// app/dashboard/page.jsx
+import { PageShell } from "@/components/ui/page-shell";
 import GreetingCard from "@/components/organisms/dashboard/GreetingCard";
 import PrayerTimesWidget from "@/components/organisms/dashboard/PrayerTimesWidget";
 import StatsOverview from "@/components/organisms/dashboard/StatsOverview";
@@ -15,7 +15,7 @@ import VerificationBanner from "@/components/organisms/dashboard/VerificationBan
 
 export default function Dashboard() {
   return (
-    <div className="p-4 sm:p-6 space-y-6">
+    <PageShell>
       {/* Educator verification CTA — status-aware, dismissible, resumable */}
       <VerificationBanner />
       <GreetingCard />
@@ -34,6 +34,6 @@ export default function Dashboard() {
           <SupportPalestine />
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/dashboard/purchases/page.jsx
+++ b/app/dashboard/purchases/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import Image from "next/image";
+import Link from "next/link";
 import {
   BookOpen,
   GraduationCap,
@@ -11,7 +12,11 @@ import {
   CircleAlert,
 } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
-import Button from "@/components/atoms/form/Button";
+import { Button } from "@/components/ui/button";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { CardGrid } from "@/components/ui/card-grid";
+import { EmptyState } from "@/components/ui/empty-state";
 import {
   Dialog,
   DialogContent,
@@ -36,19 +41,6 @@ const statusColors = {
   expired: "bg-accent/10 text-ink-muted",
 };
 
-/* ── building blocks (design-system consistent) ── */
-
-const Panel = ({ className, children }) => (
-  <div
-    className={cn(
-      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
-      className
-    )}
-  >
-    {children}
-  </div>
-);
-
 function truncateAddress(addr) {
   if (!addr) return "";
   return `${addr.slice(0, 8)}...${addr.slice(-8)}`;
@@ -62,12 +54,12 @@ function ReceiptModal({ open, onClose, item, receipt, itemType }) {
       <DialogContent className="border border-accent/10 bg-surface-raised sm:max-w-md">
         <DialogHeader>
           <DialogTitle
-            className={cn(poppins_600, "flex items-center gap-2 text-ink")}
+            className={cn(poppins_600.className, "flex items-center gap-2 text-ink")}
           >
             <Receipt className="h-5 w-5 text-accent" />
             Payment Receipt
           </DialogTitle>
-          <DialogDescription className={cn(poppins_400, "text-ink-muted")}>
+          <DialogDescription className={cn(poppins_400.className, "text-ink-muted")}>
             Transaction details for your purchase
           </DialogDescription>
         </DialogHeader>
@@ -80,11 +72,11 @@ function ReceiptModal({ open, onClose, item, receipt, itemType }) {
               ) : (
                 <GraduationCap className="h-4 w-4 text-ink-muted" />
               )}
-              <h4 className={cn(poppins_600, "text-ink")}>{item?.title}</h4>
+              <h4 className={cn(poppins_600.className, "text-ink")}>{item?.title}</h4>
             </div>
             <span
               className={cn(
-                poppins_500,
+                poppins_500.className,
                 "inline-flex items-center rounded-full border border-accent/15 bg-surface-raised px-3 py-0.5 text-xs capitalize text-accent"
               )}
             >
@@ -95,22 +87,22 @@ function ReceiptModal({ open, onClose, item, receipt, itemType }) {
           {receipt ? (
             <div className="space-y-3">
               <div className="flex items-center justify-between rounded-xl border border-secondary/20 bg-secondary/5 p-3">
-                <span className={cn(poppins_500, "text-sm text-secondary")}>
+                <span className={cn(poppins_500.className, "text-sm text-secondary")}>
                   Amount Paid
                 </span>
-                <span className={cn(poppins_600, "text-xl text-secondary")}>
+                <span className={cn(poppins_600.className, "text-xl text-secondary")}>
                   ${receipt.amount?.toFixed(2)} USDC
                 </span>
               </div>
 
               <div className="grid grid-cols-2 gap-3">
                 <div className="rounded-xl border border-accent/10 p-3">
-                  <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                  <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
                     Status
                   </p>
                   <span
                     className={cn(
-                      poppins_500,
+                      poppins_500.className,
                       "mt-1 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs capitalize",
                       statusColors[receipt.status] || statusColors.expired
                     )}
@@ -119,26 +111,26 @@ function ReceiptModal({ open, onClose, item, receipt, itemType }) {
                   </span>
                 </div>
                 <div className="rounded-xl border border-accent/10 p-3">
-                  <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                  <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
                     Date
                   </p>
-                  <p className={cn(poppins_500, "mt-1 text-sm text-ink")}>
+                  <p className={cn(poppins_500.className, "mt-1 text-sm text-ink")}>
                     {dayjs(receipt.createdAt).format("MMM D, YYYY")}
                   </p>
                 </div>
               </div>
 
               <div className="rounded-xl border border-accent/10 p-3">
-                <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
                   Paid To (Creator)
                 </p>
-                <p className={cn(poppins_500, "mt-1 text-sm text-ink")}>
+                <p className={cn(poppins_500.className, "mt-1 text-sm text-ink")}>
                   {receipt.creatorName || "Creator"}
                 </p>
                 {receipt.creatorWallet && (
                   <p
                     className={cn(
-                      poppins_400,
+                      poppins_400.className,
                       "mt-0.5 font-mono text-xs text-ink-muted"
                     )}
                   >
@@ -148,11 +140,11 @@ function ReceiptModal({ open, onClose, item, receipt, itemType }) {
               </div>
 
               <div className="rounded-xl border border-accent/10 p-3">
-                <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
                   Your Wallet
                 </p>
                 {receipt.buyerWallet && (
-                  <p className={cn(poppins_500, "mt-1 font-mono text-sm text-ink")}>
+                  <p className={cn(poppins_500.className, "mt-1 font-mono text-sm text-ink")}>
                     {truncateAddress(receipt.buyerWallet)}
                   </p>
                 )}
@@ -164,7 +156,7 @@ function ReceiptModal({ open, onClose, item, receipt, itemType }) {
                   target="_blank"
                   rel="noopener noreferrer"
                   className={cn(
-                    poppins_500,
+                    poppins_500.className,
                     "inline-flex items-center gap-1 text-sm text-secondary hover:text-highlight"
                   )}
                 >
@@ -175,10 +167,10 @@ function ReceiptModal({ open, onClose, item, receipt, itemType }) {
             </div>
           ) : (
             <div className="rounded-xl border border-accent/15 bg-secondary/5 p-4 text-center">
-              <p className={cn(poppins_500, "text-sm text-accent")}>
+              <p className={cn(poppins_500.className, "text-sm text-accent")}>
                 Free Enrollment
               </p>
-              <p className={cn(poppins_400, "mt-1 text-xs text-ink-muted")}>
+              <p className={cn(poppins_400.className, "mt-1 text-xs text-ink-muted")}>
                 This item was free or enrolled without a Stellar payment. No
                 on-chain transaction receipt is available.
               </p>
@@ -205,7 +197,7 @@ function PurchaseCard({ item, itemType, getReceipt }) {
 
   return (
     <>
-      <Panel className="group relative flex flex-col overflow-hidden transition-all hover:-translate-y-0.5 hover:border-secondary/30 hover:shadow-md">
+      <div className="group relative flex flex-col overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-sm transition-all hover:-translate-y-0.5 hover:border-secondary/30 hover:shadow-md">
         <div className="relative h-48 w-full">
           <Image
             src={thumbnail}
@@ -217,7 +209,7 @@ function PurchaseCard({ item, itemType, getReceipt }) {
           <div className="absolute left-3 top-3">
             <span
               className={cn(
-                poppins_600,
+                poppins_600.className,
                 "inline-flex items-center rounded-full bg-white/80 px-3 py-1 text-xs uppercase tracking-wider text-ink shadow"
               )}
             >
@@ -227,7 +219,7 @@ function PurchaseCard({ item, itemType, getReceipt }) {
           <div className="absolute bottom-3 left-3 right-3 flex items-center justify-between">
             <span
               className={cn(
-                poppins_500,
+                poppins_500.className,
                 "inline-flex items-center rounded-full bg-black/60 px-3 py-1 text-xs text-white"
               )}
             >
@@ -236,7 +228,7 @@ function PurchaseCard({ item, itemType, getReceipt }) {
             {receipt ? (
               <span
                 className={cn(
-                  poppins_500,
+                  poppins_500.className,
                   "inline-flex items-center rounded-full bg-secondary/80 px-3 py-1 text-xs text-white"
                 )}
               >
@@ -245,7 +237,7 @@ function PurchaseCard({ item, itemType, getReceipt }) {
             ) : (
               <span
                 className={cn(
-                  poppins_500,
+                  poppins_500.className,
                   "inline-flex items-center rounded-full bg-accent/80 px-3 py-1 text-xs text-white"
                 )}
               >
@@ -256,10 +248,10 @@ function PurchaseCard({ item, itemType, getReceipt }) {
         </div>
 
         <div className="px-6 pb-2 pt-4">
-          <h3 className={cn(poppins_600, "line-clamp-1 text-base text-ink")}>
+          <h3 className={cn(poppins_600.className, "line-clamp-1 text-base text-ink")}>
             {title}
           </h3>
-          <p className={cn(poppins_400, "line-clamp-2 text-xs text-ink-muted")}>
+          <p className={cn(poppins_400.className, "line-clamp-2 text-xs text-ink-muted")}>
             {item.description || item.author?.name || ""}
           </p>
         </div>
@@ -275,30 +267,40 @@ function PurchaseCard({ item, itemType, getReceipt }) {
               />
             </div>
             <div className="text-xs">
-              <p className={cn(poppins_500, "text-ink")}>{authorName}</p>
-              <p className={cn(poppins_400, "text-ink-muted")}>
+              <p className={cn(poppins_500.className, "text-ink")}>{authorName}</p>
+              <p className={cn(poppins_400.className, "text-ink-muted")}>
                 {itemType === "course" ? "Instructor" : "Author"}
               </p>
             </div>
           </div>
 
           <div className="flex gap-2">
-            <Button round to={actionHref} className="flex-1">
-              {itemType === "course" ? (
-                <GraduationCap className="mr-1 h-4 w-4" />
-              ) : (
-                <BookOpen className="mr-1 h-4 w-4" />
-              )}
-              {actionLabel}
+            <Button
+              className="flex-1 rounded-full bg-accent text-white hover:bg-accent/90"
+              asChild
+            >
+              <Link href={actionHref}>
+                {itemType === "course" ? (
+                  <GraduationCap className="mr-1 h-4 w-4" />
+                ) : (
+                  <BookOpen className="mr-1 h-4 w-4" />
+                )}
+                {actionLabel}
+              </Link>
             </Button>
             {receipt && (
-              <Button round outlined onClick={() => setReceiptOpen(true)}>
+              <Button
+                variant="outline"
+                size="icon"
+                className="rounded-full"
+                onClick={() => setReceiptOpen(true)}
+              >
                 <Receipt className="h-4 w-4" />
               </Button>
             )}
           </div>
         </div>
-      </Panel>
+      </div>
 
       <ReceiptModal
         open={receiptOpen}
@@ -313,9 +315,9 @@ function PurchaseCard({ item, itemType, getReceipt }) {
 
 function LoadingGrid() {
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <CardGrid>
       {[...Array(6)].map((_, i) => (
-        <Panel key={i} className="overflow-hidden">
+        <div key={i} className="overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
           <Skeleton className="h-48 w-full rounded-none" />
           <div className="px-6 pb-2 pt-4">
             <Skeleton className="h-5 w-3/4" />
@@ -331,30 +333,11 @@ function LoadingGrid() {
             </div>
             <Skeleton className="h-9 w-full" />
           </div>
-        </Panel>
+        </div>
       ))}
-    </div>
+    </CardGrid>
   );
 }
-
-const PageHeader = ({ subtitle }) => (
-  <div className="flex items-center gap-3">
-    <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-      <Library className="h-5 w-5 text-accent" />
-    </div>
-    <div>
-      <h1
-        className={cn(
-          poppins_600,
-          "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
-        )}
-      >
-        My Purchases
-      </h1>
-      <p className={cn(poppins_400, "text-sm text-ink-muted")}>{subtitle}</p>
-    </div>
-  </div>
-);
 
 export default function PurchasesPage() {
   const { courses, books, isLoading, error, getReceipt, isEmpty } = usePurchases();
@@ -362,78 +345,80 @@ export default function PurchasesPage() {
 
   if (error) {
     return (
-      <div className="space-y-6 bg-surface p-4 sm:p-6">
-        <PageHeader subtitle="Your owned courses and books" />
-        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-red-50">
-            <CircleAlert className="h-7 w-7 text-red-600" />
-          </div>
-          <div>
-            <h3 className={cn(poppins_600, "text-lg text-ink")}>
-              Failed to Load
-            </h3>
-            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
-              {error}
-            </p>
-          </div>
-          <Button round outlined onClick={() => window.location.reload()}>
-            Try Again
-          </Button>
-        </Panel>
-      </div>
+      <PageShell>
+        <PageHeader
+          icon={Library}
+          title="My Purchases"
+          subtitle="Your owned courses and books"
+        />
+        <EmptyState
+          icon={CircleAlert}
+          iconContainerClassName="bg-red-50"
+          title="Failed to Load"
+          description={error}
+          action={
+            <Button
+              variant="outline"
+              className="rounded-full"
+              onClick={() => window.location.reload()}
+            >
+              Try Again
+            </Button>
+          }
+        />
+      </PageShell>
     );
   }
 
   return (
-    <div className="space-y-6 bg-surface p-4 sm:p-6">
-      <PageHeader subtitle="All your courses and books in one place" />
+    <PageShell>
+      <PageHeader
+        icon={Library}
+        title="My Purchases"
+        subtitle="All your courses and books in one place"
+      />
 
       {isLoading ? (
         <LoadingGrid />
       ) : isEmpty ? (
-        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
-            <Wallet className="h-7 w-7 text-accent" />
-          </div>
-          <div>
-            <h3 className={cn(poppins_600, "text-lg text-ink")}>
-              No Purchases Yet
-            </h3>
-            <p
-              className={cn(
-                poppins_400,
-                "mx-auto mt-1 max-w-md text-sm text-ink-muted"
-              )}
-            >
-              You haven&apos;t purchased any courses or books yet. Browse our
-              library and enroll to get started.
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <Button round to="/dashboard/courses">
-              Browse Courses
-            </Button>
-            <Button round outlined to="/dashboard/library">
-              Browse Books
-            </Button>
-          </div>
-        </Panel>
+        <EmptyState
+          icon={Wallet}
+          title="No Purchases Yet"
+          description="You haven't purchased any courses or books yet. Browse our library and enroll to get started."
+          action={
+            <>
+              <Button
+                className="rounded-full bg-accent text-white hover:bg-accent/90"
+                asChild
+              >
+                <Link href="/dashboard/courses">Browse Courses</Link>
+              </Button>
+              <Button variant="outline" className="rounded-full" asChild>
+                <Link href="/dashboard/library">Browse Books</Link>
+              </Button>
+            </>
+          }
+        />
       ) : (
         <>
           {/* Tab Toggle */}
           <div className="flex gap-2">
             <Button
-              round
-              outlined={tab !== "courses"}
-              className={tab === "courses" ? "bg-accent text-white" : ""}
+              variant={tab === "courses" ? "default" : "outline"}
+              className={cn(
+                "rounded-full",
+                tab === "courses" && "bg-accent text-white hover:bg-accent/90"
+              )}
               onClick={() => setTab("courses")}
             >
               Courses ({courses.length})
             </Button>
             <Button
-              round
-              outlined={tab !== "books"}
-              className={tab === "books" ? "bg-accent text-white" : ""}
+              variant={tab === "books" ? "default" : "outline"}
+              className={cn(
+                "rounded-full",
+                tab === "books" && "bg-accent text-white hover:bg-accent/90"
+              )}
               onClick={() => setTab("books")}
             >
               Books ({books.length})
@@ -442,17 +427,17 @@ export default function PurchasesPage() {
 
           {tab === "courses" ? (
             courses.length === 0 ? (
-              <Panel className="flex flex-col items-center justify-center gap-3 py-12 text-center">
-                <GraduationCap className="h-10 w-10 text-ink-muted" />
-                <p className={cn(poppins_400, "text-ink-muted")}>
-                  No courses purchased yet
-                </p>
-                <Button round outlined to="/dashboard/courses">
-                  Browse Courses
-                </Button>
-              </Panel>
+              <EmptyState
+                icon={GraduationCap}
+                description="No courses purchased yet"
+                action={
+                  <Button variant="outline" className="rounded-full" asChild>
+                    <Link href="/dashboard/courses">Browse Courses</Link>
+                  </Button>
+                }
+              />
             ) : (
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <CardGrid>
                 {courses.map((course) => (
                   <PurchaseCard
                     key={course._id}
@@ -461,20 +446,20 @@ export default function PurchasesPage() {
                     getReceipt={getReceipt}
                   />
                 ))}
-              </div>
+              </CardGrid>
             )
           ) : books.length === 0 ? (
-            <Panel className="flex flex-col items-center justify-center gap-3 py-12 text-center">
-              <BookOpen className="h-10 w-10 text-ink-muted" />
-              <p className={cn(poppins_400, "text-ink-muted")}>
-                No books purchased yet
-              </p>
-              <Button round outlined to="/dashboard/library">
-                Browse Books
-              </Button>
-            </Panel>
+            <EmptyState
+              icon={BookOpen}
+              description="No books purchased yet"
+              action={
+                <Button variant="outline" className="rounded-full" asChild>
+                  <Link href="/dashboard/library">Browse Books</Link>
+                </Button>
+              }
+            />
           ) : (
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            <CardGrid>
               {books.map((book) => (
                 <PurchaseCard
                   key={book._id}
@@ -483,10 +468,10 @@ export default function PurchasesPage() {
                   getReceipt={getReceipt}
                 />
               ))}
-            </div>
+            </CardGrid>
           )}
         </>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/app/dashboard/sadaqah/page.jsx
+++ b/app/dashboard/sadaqah/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState, useEffect, useCallback } from "react";
-import Button from "@/components/atoms/form/Button";
+import { Button } from "@/components/ui/button";
+import { PageShell } from "@/components/ui/page-shell";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   HeartHandshake,
@@ -14,8 +15,6 @@ import {
   Sparkles,
   ShieldCheck,
   Coins,
-  TrendingUp,
-  Users,
   MousePointerClick,
   PenLine,
   Landmark,
@@ -66,7 +65,7 @@ const Panel = ({ className, children }) => (
 const Chip = ({ icon: Icon, children }) => (
   <span
     className={cn(
-      poppins_500,
+      poppins_500.className,
       "inline-flex items-center gap-1.5 rounded-full border border-secondary/20 bg-secondary/10 px-3 py-1 text-xs text-accent"
     )}
   >
@@ -77,9 +76,9 @@ const Chip = ({ icon: Icon, children }) => (
 
 const SectionHeading = ({ title, subtitle }) => (
   <div className="mb-5">
-    <h2 className={cn(poppins_600, "text-lg text-ink")}>{title}</h2>
+    <h2 className={cn(poppins_600.className, "text-lg text-ink")}>{title}</h2>
     {subtitle && (
-      <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+      <p className={cn(poppins_400.className, "mt-1 text-sm text-ink-muted")}>
         {subtitle}
       </p>
     )}
@@ -214,19 +213,19 @@ export default function SadaqahPage() {
       ) : statsUnconfigured ? (
         <div className="flex items-center gap-2 text-ink-inverse-muted">
           <AlertCircle className="h-4 w-4 shrink-0" />
-          <p className={cn(poppins_400, "text-sm")}>
+          <p className={cn(poppins_400.className, "text-sm")}>
             Fund not configured yet — check back soon, insha&apos;Allah.
           </p>
         </div>
       ) : statsError ? (
         <div className="space-y-3">
-          <p className={cn(poppins_400, "text-sm text-ink-inverse-muted")}>
+          <p className={cn(poppins_400.className, "text-sm text-ink-inverse-muted")}>
             {statsError}
           </p>
           <button
             onClick={fetchStats}
             className={cn(
-              poppins_500,
+              poppins_500.className,
               "inline-flex items-center gap-2 text-sm text-ink-inverse hover:opacity-80"
             )}
           >
@@ -237,34 +236,34 @@ export default function SadaqahPage() {
         <>
           <p
             className={cn(
-              poppins_500,
+              poppins_500.className,
               "text-xs uppercase tracking-wider text-ink-inverse-muted"
             )}
           >
             Scholarship Pool Balance
           </p>
-          <p className={cn(poppins_600, "mt-1 text-4xl leading-none")}>
+          <p className={cn(poppins_600.className, "mt-1 text-4xl leading-none")}>
             ${formatAmount(stats?.poolBalance)}
             <span
-              className={cn(poppins_500, "ml-1 text-lg text-ink-inverse-muted")}
+              className={cn(poppins_500.className, "ml-1 text-lg text-ink-inverse-muted")}
             >
               USDC
             </span>
           </p>
           <div className="mt-5 grid grid-cols-2 gap-3">
             <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">
-              <p className={cn(poppins_400, "text-[11px] text-ink-inverse-muted")}>
+              <p className={cn(poppins_400.className, "text-[11px] text-ink-inverse-muted")}>
                 Total donated
               </p>
-              <p className={cn(poppins_600, "text-base text-ink-inverse")}>
+              <p className={cn(poppins_600.className, "text-base text-ink-inverse")}>
                 ${formatAmount(stats?.totalDonated)}
               </p>
             </div>
             <div className="rounded-xl border border-white/10 bg-white/5 px-3 py-2">
-              <p className={cn(poppins_400, "text-[11px] text-ink-inverse-muted")}>
+              <p className={cn(poppins_400.className, "text-[11px] text-ink-inverse-muted")}>
                 Donations
               </p>
-              <p className={cn(poppins_600, "text-base text-ink-inverse")}>
+              <p className={cn(poppins_600.className, "text-base text-ink-inverse")}>
                 {stats?.donationCount ?? 0}
               </p>
             </div>
@@ -275,7 +274,7 @@ export default function SadaqahPage() {
   );
 
   return (
-    <div className="space-y-6 bg-surface p-4 sm:p-6">
+    <PageShell>
       {/* ── Hero + featured pool (2/3 · 1/3) ── */}
       <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
         <Panel className="relative overflow-hidden bg-gradient-to-br from-secondary/10 via-surface-raised to-highlight/10 p-6 sm:p-8 lg:col-span-2">
@@ -287,7 +286,7 @@ export default function SadaqahPage() {
               </div>
               <h1
                 className={cn(
-                  poppins_600,
+                  poppins_600.className,
                   "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent sm:text-3xl"
                 )}
               >
@@ -296,7 +295,7 @@ export default function SadaqahPage() {
             </div>
             <p
               className={cn(
-                poppins_400,
+                poppins_400.className,
                 "mt-3 max-w-xl leading-relaxed text-ink-muted"
               )}
             >
@@ -353,7 +352,7 @@ export default function SadaqahPage() {
                       type="button"
                       onClick={() => handlePresetSelect(preset)}
                       className={cn(
-                        poppins_600,
+                        poppins_600.className,
                         "flex h-16 flex-col items-center justify-center rounded-xl border text-lg transition-all",
                         presetActive(preset)
                           ? "border-accent bg-accent text-white shadow-md"
@@ -363,7 +362,7 @@ export default function SadaqahPage() {
                       ${preset}
                       <span
                         className={cn(
-                          poppins_400,
+                          poppins_400.className,
                           "text-[10px] uppercase tracking-wider",
                           presetActive(preset)
                             ? "text-white/70"
@@ -379,14 +378,14 @@ export default function SadaqahPage() {
                 <div className="space-y-1.5">
                   <label
                     htmlFor="custom-amount"
-                    className={cn(poppins_500, "text-sm text-ink-muted")}
+                    className={cn(poppins_500.className, "text-sm text-ink-muted")}
                   >
                     Or enter a custom amount
                   </label>
                   <div className="relative">
                     <span
                       className={cn(
-                        poppins_600,
+                        poppins_600.className,
                         "pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-ink-muted"
                       )}
                     >
@@ -400,13 +399,13 @@ export default function SadaqahPage() {
                       value={customAmount}
                       onChange={handleCustomChange}
                       className={cn(
-                        poppins_500,
+                        poppins_500.className,
                         "w-full rounded-xl border border-accent/15 bg-surface py-3 pl-8 pr-16 text-ink outline-none transition-colors placeholder:text-ink-muted/60 focus:border-secondary focus:ring-2 focus:ring-secondary/20"
                       )}
                     />
                     <span
                       className={cn(
-                        poppins_500,
+                        poppins_500.className,
                         "pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-xs uppercase tracking-wider text-ink-muted"
                       )}
                     >
@@ -417,13 +416,12 @@ export default function SadaqahPage() {
 
                 {!connectedWallet ? (
                   <div className="rounded-xl border border-secondary/20 bg-secondary/5 p-4">
-                    <p className={cn(poppins_500, "mb-3 text-sm text-accent")}>
+                    <p className={cn(poppins_500.className, "mb-3 text-sm text-accent")}>
                       Connect your Stellar wallet to donate
                     </p>
                     <Button
-                      round
+                      className="w-full rounded-full bg-accent text-white hover:bg-accent/90"
                       onClick={connectWallet}
-                      wide
                       disabled={isConnecting}
                     >
                       {isConnecting ? (
@@ -443,12 +441,12 @@ export default function SadaqahPage() {
                   <div className="flex flex-wrap items-center justify-between gap-3 rounded-xl border border-accent/10 bg-surface px-4 py-3">
                     <div className="flex items-center gap-2">
                       <Wallet className="h-4 w-4 text-accent" />
-                      <span className={cn(poppins_400, "text-sm text-ink-muted")}>
+                      <span className={cn(poppins_400.className, "text-sm text-ink-muted")}>
                         Balance
                       </span>
                       <span
                         className={cn(
-                          poppins_600,
+                          poppins_600.className,
                           "text-sm",
                           hasInsufficientBalance ? "text-red-600" : "text-ink"
                         )}
@@ -458,7 +456,7 @@ export default function SadaqahPage() {
                     </div>
                     <span
                       className={cn(
-                        poppins_500,
+                        poppins_500.className,
                         "rounded-full border border-accent/15 bg-surface-raised px-3 py-0.5 text-xs capitalize text-accent"
                       )}
                     >
@@ -468,15 +466,14 @@ export default function SadaqahPage() {
                 )}
 
                 {connectedWallet && hasInsufficientBalance && (
-                  <p className={cn(poppins_400, "text-sm text-red-600")}>
+                  <p className={cn(poppins_400.className, "text-sm text-red-600")}>
                     Insufficient USDC balance for this amount.
                   </p>
                 )}
 
                 {connectedWallet && (
                   <Button
-                    round
-                    wide
+                    className="w-full rounded-full bg-accent text-white hover:bg-accent/90"
                     onClick={handleInitiate}
                     disabled={
                       !isValidAmount || hasInsufficientBalance || isProcessing
@@ -499,14 +496,14 @@ export default function SadaqahPage() {
             {step === "confirm" && donationData && (
               <>
                 <div className="space-y-1 rounded-xl border border-secondary/20 bg-secondary/5 p-4">
-                  <p className={cn(poppins_500, "text-sm text-accent")}>
+                  <p className={cn(poppins_500.className, "text-sm text-accent")}>
                     Please confirm the transaction in your wallet extension.
                   </p>
                   <div className="flex items-center gap-2 text-sm">
-                    <span className={cn(poppins_400, "text-ink-muted")}>
+                    <span className={cn(poppins_400.className, "text-ink-muted")}>
                       Donating:
                     </span>
-                    <span className={cn(poppins_600, "text-ink")}>
+                    <span className={cn(poppins_600.className, "text-ink")}>
                       ${formatAmount(donationData.amount)} USDC
                     </span>
                   </div>
@@ -516,7 +513,7 @@ export default function SadaqahPage() {
                   <div className="rounded-xl border border-accent/10 bg-surface p-4">
                     <p
                       className={cn(
-                        poppins_500,
+                        poppins_500.className,
                         "mb-3 text-center text-sm text-ink"
                       )}
                     >
@@ -527,10 +524,17 @@ export default function SadaqahPage() {
                 )}
 
                 <div className="flex gap-3">
-                  <Button round outlined onClick={handleBack} className="flex-1">
+                  <Button
+                    variant="outline"
+                    className="flex-1 rounded-full"
+                    onClick={handleBack}
+                  >
                     Back
                   </Button>
-                  <Button round onClick={handleConfirm} className="flex-1">
+                  <Button
+                    className="flex-1 rounded-full bg-accent text-white hover:bg-accent/90"
+                    onClick={handleConfirm}
+                  >
                     <Wallet className="mr-2 h-4 w-4" />
                     Sign &amp; Donate
                   </Button>
@@ -541,12 +545,12 @@ export default function SadaqahPage() {
             {step === "processing" && (
               <div className="flex flex-col items-center py-10">
                 <Loader2 className="h-12 w-12 animate-spin text-secondary" />
-                <p className={cn(poppins_500, "mt-4 text-ink")}>
+                <p className={cn(poppins_500.className, "mt-4 text-ink")}>
                   {isProcessing
                     ? "Processing donation…"
                     : "Preparing transaction…"}
                 </p>
-                <p className={cn(poppins_400, "mt-2 text-xs text-ink-muted")}>
+                <p className={cn(poppins_400.className, "mt-2 text-xs text-ink-muted")}>
                   Please check your wallet for the signing request
                 </p>
               </div>
@@ -557,10 +561,10 @@ export default function SadaqahPage() {
                 <div className="mx-auto flex size-16 items-center justify-center rounded-full bg-secondary/10">
                   <CheckCircle className="h-9 w-9 text-secondary" />
                 </div>
-                <h3 className={cn(poppins_600, "mt-4 text-xl text-ink")}>
+                <h3 className={cn(poppins_600.className, "mt-4 text-xl text-ink")}>
                   JazakAllahu Khairan!
                 </h3>
-                <p className={cn(poppins_400, "mt-2 text-ink-muted")}>
+                <p className={cn(poppins_400.className, "mt-2 text-ink-muted")}>
                   Your donation was recorded on the Stellar network.
                 </p>
                 {result?.explorerUrl && (
@@ -569,14 +573,17 @@ export default function SadaqahPage() {
                     target="_blank"
                     rel="noopener noreferrer"
                     className={cn(
-                      poppins_500,
+                      poppins_500.className,
                       "mt-4 inline-flex items-center gap-1 text-sm text-secondary hover:text-highlight"
                     )}
                   >
                     View on Stellar Explorer <ExternalLink className="h-3 w-3" />
                   </a>
                 )}
-                <Button round wide onClick={handleReset} className="mt-6">
+                <Button
+                  className="mt-6 w-full rounded-full bg-accent text-white hover:bg-accent/90"
+                  onClick={handleReset}
+                >
                   Donate Again
                 </Button>
               </div>
@@ -587,11 +594,14 @@ export default function SadaqahPage() {
                 <div className="mx-auto flex size-16 items-center justify-center rounded-full bg-red-50">
                   <AlertCircle className="h-9 w-9 text-red-600" />
                 </div>
-                <h3 className={cn(poppins_600, "mt-4 text-xl text-ink")}>
+                <h3 className={cn(poppins_600.className, "mt-4 text-xl text-ink")}>
                   Donation Failed
                 </h3>
-                <p className={cn(poppins_400, "mt-2 text-ink-muted")}>{error}</p>
-                <Button round wide onClick={handleReset} className="mt-6">
+                <p className={cn(poppins_400.className, "mt-2 text-ink-muted")}>{error}</p>
+                <Button
+                  className="mt-6 w-full rounded-full bg-accent text-white hover:bg-accent/90"
+                  onClick={handleReset}
+                >
                   Try Again
                 </Button>
               </div>
@@ -614,7 +624,7 @@ export default function SadaqahPage() {
               </div>
             ) : statsUnconfigured || statsError ? (
               <div className="rounded-xl border border-dashed border-accent/15 py-8 text-center">
-                <p className={cn(poppins_400, "text-sm text-ink-muted")}>
+                <p className={cn(poppins_400.className, "text-sm text-ink-muted")}>
                   Donation activity is unavailable right now
                 </p>
               </div>
@@ -623,8 +633,8 @@ export default function SadaqahPage() {
                 <div className="mx-auto mb-3 flex size-11 items-center justify-center rounded-xl bg-gradient-to-br from-secondary/15 to-highlight/10">
                   <HeartHandshake className="h-5 w-5 text-accent" />
                 </div>
-                <p className={cn(poppins_500, "text-ink")}>No donations yet</p>
-                <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
+                <p className={cn(poppins_500.className, "text-ink")}>No donations yet</p>
+                <p className={cn(poppins_400.className, "mt-1 text-sm text-ink-muted")}>
                   Be the first to give Sadaqah Jariyah
                 </p>
               </div>
@@ -640,15 +650,15 @@ export default function SadaqahPage() {
                         <HeartHandshake className="h-4 w-4 text-accent" />
                       </div>
                       <div>
-                        <p className={cn(poppins_600, "text-ink")}>
+                        <p className={cn(poppins_600.className, "text-ink")}>
                           ${formatAmount(donation.amount)}{" "}
                           <span
-                            className={cn(poppins_400, "text-xs text-ink-muted")}
+                            className={cn(poppins_400.className, "text-xs text-ink-muted")}
                           >
                             USDC
                           </span>
                         </p>
-                        <p className={cn(poppins_400, "text-xs text-ink-muted")}>
+                        <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
                           {formatDate(donation.createdAt)}
                         </p>
                       </div>
@@ -679,7 +689,7 @@ export default function SadaqahPage() {
                     <s.icon className="h-4 w-4 text-accent" />
                   </div>
                   <div className="pt-1">
-                    <p className={cn(poppins_500, "text-sm text-ink")}>
+                    <p className={cn(poppins_500.className, "text-sm text-ink")}>
                       <span className="text-ink-muted">{i + 1}.</span> {s.text}
                     </p>
                   </div>
@@ -688,7 +698,7 @@ export default function SadaqahPage() {
             </ol>
             <p
               className={cn(
-                poppins_400,
+                poppins_400.className,
                 "mt-5 border-t border-accent/10 pt-4 text-xs leading-relaxed text-ink-muted"
               )}
             >
@@ -698,6 +708,6 @@ export default function SadaqahPage() {
           </Panel>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/dashboard/saved/page.jsx
+++ b/app/dashboard/saved/page.jsx
@@ -6,27 +6,15 @@ import CourseCard from "@/components/molecules/dashboard/cards/courseCard";
 import LibraryBookCard from "@/components/molecules/dashboard/cards/libraryCard";
 import CourseCardSkeleton from "@/components/atoms/skeletons/CourseCardSkeleton";
 import LibraryBookSkeleton from "@/components/atoms/skeletons/LibraryBookSkeleton";
-import Button from "@/components/atoms/form/Button";
+import { Button } from "@/components/ui/button";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { CardGrid } from "@/components/ui/card-grid";
+import { EmptyState } from "@/components/ui/empty-state";
 import { getBookmarkedCourses } from "@/lib/actions/courses/bookmark-course";
 import { getBookmarkedBooks } from "@/lib/actions/library/bookmark-book";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
 import { cn } from "@/lib/utils";
-import {
-  poppins_400,
-  poppins_500,
-  poppins_600,
-} from "@/lib/config/font.config";
-
-const Panel = ({ className, children }) => (
-  <div
-    className={cn(
-      "rounded-2xl border border-accent/10 bg-surface-raised shadow-sm",
-      className
-    )}
-  >
-    {children}
-  </div>
-);
 
 export default function SavedPage() {
   const [activeTab, setActiveTab] = useState("courses");
@@ -107,41 +95,32 @@ export default function SavedPage() {
   }
 
   return (
-    <div className="space-y-6 bg-surface p-4 sm:p-6">
-      <div className="flex items-center gap-3">
-        <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-          <Bookmark className="h-5 w-5 fill-accent text-accent" />
-        </div>
-        <div>
-          <h1
-            className={cn(
-              poppins_600,
-              "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
-            )}
-          >
-            My Saved Hub
-          </h1>
-          <p className={cn(poppins_400, "text-sm text-ink-muted")}>
-            Access all your bookmarked courses and books in one place
-          </p>
-        </div>
-      </div>
+    <PageShell>
+      <PageHeader
+        icon={Bookmark}
+        title="My Saved Hub"
+        subtitle="Access all your bookmarked courses and books in one place"
+      />
 
       {/* Tab Toggle */}
       <div className="flex gap-2">
         <Button
-          round
-          outlined={activeTab !== "courses"}
-          className={activeTab === "courses" ? "bg-accent text-white" : ""}
+          variant={activeTab === "courses" ? "default" : "outline"}
+          className={cn(
+            "rounded-full",
+            activeTab === "courses" && "bg-accent text-white hover:bg-accent/90"
+          )}
           onClick={() => setActiveTab("courses")}
         >
           <LaptopMinimal className="h-4 w-4 mr-1" />
           Courses ({courses.length})
         </Button>
         <Button
-          round
-          outlined={activeTab !== "books"}
-          className={activeTab === "books" ? "bg-accent text-white" : ""}
+          variant={activeTab === "books" ? "default" : "outline"}
+          className={cn(
+            "rounded-full",
+            activeTab === "books" && "bg-accent text-white hover:bg-accent/90"
+          )}
           onClick={() => setActiveTab("books")}
         >
           <Book className="h-4 w-4 mr-1" />
@@ -151,7 +130,7 @@ export default function SavedPage() {
 
       {/* Content */}
       {loading ? (
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        <CardGrid>
           {[...Array(6)].map((_, idx) =>
             activeTab === "courses" ? (
               <CourseCardSkeleton key={`skeleton-course-${idx}`} />
@@ -159,27 +138,25 @@ export default function SavedPage() {
               <LibraryBookSkeleton key={`skeleton-book-${idx}`} />
             )
           )}
-        </div>
+        </CardGrid>
       ) : activeTab === "courses" ? (
         courses.length === 0 ? (
-          <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
-            <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
-              <LaptopMinimal className="h-7 w-7 text-accent" />
-            </div>
-            <div>
-              <h3 className={cn(poppins_600, "text-lg text-ink")}>
-                No Saved Courses
-              </h3>
-              <p className={cn(poppins_400, "mt-1 max-w-md text-sm text-ink-muted")}>
-                Explore our catalog and bookmark courses you are interested in.
-              </p>
-            </div>
-            <Button round outlined onClick={() => window.location.href = "/dashboard/courses"}>
-              Browse Courses
-            </Button>
-          </Panel>
+          <EmptyState
+            icon={LaptopMinimal}
+            title="No Saved Courses"
+            description="Explore our catalog and bookmark courses you are interested in."
+            action={
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={() => (window.location.href = "/dashboard/courses")}
+              >
+                Browse Courses
+              </Button>
+            }
+          />
         ) : (
-          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          <CardGrid>
             {courses.map((course) => (
               <CourseCard
                 key={course._id}
@@ -190,27 +167,25 @@ export default function SavedPage() {
                 }
               />
             ))}
-          </div>
+          </CardGrid>
         )
       ) : books.length === 0 ? (
-        <Panel className="flex flex-col items-center justify-center gap-4 py-16 text-center">
-          <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
-            <Book className="h-7 w-7 text-accent" />
-          </div>
-          <div>
-            <h3 className={cn(poppins_600, "text-lg text-ink")}>
-              No Saved Books
-            </h3>
-            <p className={cn(poppins_400, "mt-1 max-w-md text-sm text-ink-muted")}>
-              Browse our Islamic library and save books to build your personal reading list.
-            </p>
-          </div>
-          <Button round outlined onClick={() => window.location.href = "/dashboard/library"}>
-            Browse Library
-          </Button>
-        </Panel>
+        <EmptyState
+          icon={Book}
+          title="No Saved Books"
+          description="Browse our Islamic library and save books to build your personal reading list."
+          action={
+            <Button
+              variant="outline"
+              className="rounded-full"
+              onClick={() => (window.location.href = "/dashboard/library")}
+            >
+              Browse Library
+            </Button>
+          }
+        />
       ) : (
-        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+        <CardGrid>
           {books.map((book) => (
             <LibraryBookCard
               key={book._id}
@@ -221,8 +196,8 @@ export default function SavedPage() {
               }
             />
           ))}
-        </div>
+        </CardGrid>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/app/dashboard/spaces/page.jsx
+++ b/app/dashboard/spaces/page.jsx
@@ -3,18 +3,17 @@ import React, { useState, useEffect } from "react";
 import { Globe, Plus } from "lucide-react";
 import SpaceCard from "@/components/molecules/dashboard/cards/spaceCard";
 import CourseCardSkeleton from "@/components/atoms/skeletons/CourseCardSkeleton";
-import Button from "@/components/atoms/form/Button";
+import { Button } from "@/components/ui/button";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { CardGrid } from "@/components/ui/card-grid";
+import { EmptyState } from "@/components/ui/empty-state";
 import SpaceCreateForm from "@/components/organisms/create/space-create-form";
 import Modal from "@/components/molecules/Modal";
 import { getSpaces } from "@/lib/actions/spaces/get-spaces";
 import useAuth from "@/hooks/useAuth";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
 import { cn } from "@/lib/utils";
-import {
-  poppins_400,
-  poppins_500,
-  poppins_600,
-} from "@/lib/config/font.config";
 
 const tabnames = [
   { value: "all", label: "All" },
@@ -68,40 +67,33 @@ const Page = () => {
   );
 
   return (
-    <div className="space-y-6 bg-surface p-4 sm:p-6">
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-            <Globe className="h-5 w-5 text-accent" />
-          </div>
-          <div>
-            <h1
-              className={cn(
-                poppins_600,
-                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
-              )}
-            >
-              Islamic Spaces
-            </h1>
-            <p className={cn(poppins_400, "mt-1 text-sm text-ink-muted")}>
-              Join live sessions, discussions, and community events
-            </p>
-          </div>
-        </div>
-        <Button round outlined onClick={() => setmodalOpen(true)}>
-          <Plus className="mr-1 h-4 w-4" />
-          Create
-        </Button>
-      </div>
+    <PageShell>
+      <PageHeader
+        icon={Globe}
+        title="Islamic Spaces"
+        subtitle="Join live sessions, discussions, and community events"
+        actions={
+          <Button
+            variant="outline"
+            className="rounded-full"
+            onClick={() => setmodalOpen(true)}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            Create
+          </Button>
+        }
+      />
 
       {/* Tab Filters */}
       <div className="flex gap-2">
         {tabnames.map((tab) => (
           <Button
             key={tab.value}
-            round
-            outlined={selectedTab !== tab.value}
-            className={selectedTab === tab.value ? "bg-accent text-white" : ""}
+            variant={selectedTab === tab.value ? "default" : "outline"}
+            className={cn(
+              "rounded-full",
+              selectedTab === tab.value && "bg-accent text-white hover:bg-accent/90"
+            )}
             onClick={() => setSelectedTab(tab.value)}
           >
             {tab.label}
@@ -110,38 +102,36 @@ const Page = () => {
       </div>
 
       {loading ? (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <CardGrid>
           {[...Array(6)].map((_, idx) => (
             <CourseCardSkeleton key={idx} />
           ))}
-        </div>
+        </CardGrid>
       ) : filteredSpaces.length === 0 ? (
-        <div className="rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
-          <div className="flex flex-col items-center justify-center space-y-4 py-16 text-center">
-            <div className="flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10">
-              <Globe className="h-7 w-7 text-accent" />
-            </div>
-            <div>
-              <h3 className={cn(poppins_600, "text-lg text-ink")}>
-                No Spaces Found
-              </h3>
-              <p className={cn(poppins_400, "mt-1 max-w-md text-sm text-ink-muted")}>
-                {selectedTab === "all"
-                  ? "No spaces available at the moment."
-                  : `No ${selectedTab} spaces at the moment.`}
-              </p>
-            </div>
-            <Button round outlined onClick={() => setmodalOpen(true)}>
+        <EmptyState
+          icon={Globe}
+          title="No Spaces Found"
+          description={
+            selectedTab === "all"
+              ? "No spaces available at the moment."
+              : `No ${selectedTab} spaces at the moment.`
+          }
+          action={
+            <Button
+              variant="outline"
+              className="rounded-full"
+              onClick={() => setmodalOpen(true)}
+            >
               Create Space
             </Button>
-          </div>
-        </div>
+          }
+        />
       ) : (
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <CardGrid>
           {filteredSpaces.map((space, index) => (
             <SpaceCard key={space._id || index} space={space} />
           ))}
-        </div>
+        </CardGrid>
       )}
 
       <Modal
@@ -151,7 +141,7 @@ const Page = () => {
       >
         <SpaceCreateForm onSpaceCreated={handleSpaceCreated} />
       </Modal>
-    </div>
+    </PageShell>
   );
 };
 

--- a/components/atoms/form/Button.jsx
+++ b/components/atoms/form/Button.jsx
@@ -1,129 +1,105 @@
-'use client';
+"use client";
 
-import React from 'react';
-import { Loader2Icon } from 'lucide-react';
-import Ripples from 'react-ripples';
-import { cn } from '@/lib/utils';
-import Link from 'next/link';
-import { poppins_500 } from '@/lib/config/font.config';
+import * as React from "react";
+import Link from "next/link";
+import { Loader2 } from "lucide-react";
+import { Button as UiButton, buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
-const Button = ({
+const Button = React.forwardRef(function Button(
+  {
     children,
-    loaderSize = 25,
     className,
+    variant,
+    size,
     to,
     download,
-    type,
     wide,
     outlined,
     loading,
     round,
-    onClick,
     disabled,
+    loaderSize = 16,
     loaderColor,
-    id,
     childrenClassName,
+    asChild = false,
     ...props
-}) => {
-    const commonClasses = cn(
-        wide && 'flex-grow w-full bg-accent hover:bg-highlight transitions-all',
-        outlined && 'border border-accent bg-background text-foreground hover:bg-accent hover:text-white animate-in-out transition-all delay-100',
-        round ? 'rounded-full' : 'rounded-lg',
-        'inline-block text-sm py-2 px-4 font-medium flex items-center justify-center cursor-pointer flex-shrink-0 font-nunito font-normal focus:outline-none focus:ring-0',
-        poppins_500.className,
-        className
-    );
+  },
+  ref
+) {
+  const resolvedVariant =
+    variant || (outlined ? "outline" : undefined);
 
-    const commonProps = {
-        className: commonClasses,
-        disabled: disabled || loading,
-        id,
-    };
+  const resolvedClassName = cn(
+    wide && "w-full",
+    round && "rounded-full",
+    className
+  );
 
-    if (to) {
-        if (disabled) {
-            return (
-                <span {...props} {...commonProps}>
-                    {children}
-                </span>
-            );
-        } else {
-            return (
-                <Link download={download} href={to} className="overflow-hidden">
-                    <button
-                        type={type}
-                        {...props}
-                        disabled={commonProps.disabled}
-                        id={commonProps.id}
-                        className={cn(wide && 'w-full flex-grow')}
-                    >
-                        <div
-                            id={commonProps.id}
-                            className={cn(
-                                'hover:!shadow-none !shadow-none inline-block',
-                                commonProps.className
-                            )}
-                            onClick={onClick}
-                            itemScope
-                        >
-                            <p
-                                className={cn(
-                                    'text-clash-grotesk font-medium flex items-center justify-center space-x-2',
-                                    childrenClassName
-                                )}
-                            >
-                                {loading ? (
-                                    <FaSpinner
-                                        className="animate-spin"
-                                        color={loaderColor}
-                                        size={loaderSize}
-                                    />
-                                ) : (
-                                    children
-                                )}
-                            </p>
-                        </div>
-                    </button>
-                </Link>
-            );
-        }
+  const content = (
+    <>
+      {loading && (
+        <Loader2
+          className="animate-spin shrink-0 mr-1"
+          size={loaderSize}
+          color={loaderColor}
+        />
+      )}
+      {childrenClassName ? (
+        <span className={childrenClassName}>{children}</span>
+      ) : (
+        children
+      )}
+    </>
+  );
+
+  if (to) {
+    if (disabled) {
+      return (
+        <UiButton
+          ref={ref}
+          variant={resolvedVariant}
+          size={size}
+          disabled
+          className={resolvedClassName}
+          {...props}
+        >
+          {content}
+        </UiButton>
+      );
     }
     return (
-        <button
-            type={type}
-            {...props}
-            disabled={commonProps.disabled}
-            id={commonProps.id}
-            className={cn(wide && 'w-full flex-grow h-auto focus:outline-none', wide && !outlined && 'text-white')}
-        >
-            <Ripples
-                id={commonProps.id}
-                className={cn(
-                    'hover:!shadow-none !shadow-none inline-block',
-                    commonProps.className
-                )}
-                onClick={onClick}
-                itemScope
-            >
-                <div
-                    className={cn(
-                        'text-clash-grotesk font-medium flex items-center justify-center space-x-2',
-                        childrenClassName
-                    )}
-                >
-                    {loading ? (
-                        <Loader2Icon
-                            className="animate-spin"
-                            color={loaderColor}
-                            size={loaderSize}
-                        />
-                    ) : (
-                        children
-                    )}
-                </div>
-            </Ripples>
-        </button>
+      <UiButton
+        ref={ref}
+        asChild
+        variant={resolvedVariant}
+        size={size}
+        className={resolvedClassName}
+        {...props}
+      >
+        <Link href={to} download={download}>
+          {content}
+        </Link>
+      </UiButton>
     );
-};
+  }
+
+  return (
+    <UiButton
+      ref={ref}
+      asChild={asChild}
+      variant={resolvedVariant}
+      size={size}
+      disabled={disabled || loading}
+      className={resolvedClassName}
+      {...props}
+    >
+      {content}
+    </UiButton>
+  );
+});
+
+Button.displayName = "Button";
 
 export default Button;
+export { Button, buttonVariants };

--- a/components/molecules/dashboard/LibraryToolbar.jsx
+++ b/components/molecules/dashboard/LibraryToolbar.jsx
@@ -1,7 +1,7 @@
 "use client";
 import { Search } from "lucide-react";
 import { Input } from "@/components/ui/input";
-import Button from "@/components/atoms/form/Button";
+import { Button } from "@/components/ui/button";
 import {
   Select,
   SelectContent,
@@ -104,7 +104,7 @@ const LibraryToolbar = ({
           {resultCount} {resultCount === 1 ? "book" : "books"}
         </p>
         {isFiltered && (
-          <Button round outlined onClick={onClear}>
+          <Button variant="outline" className="rounded-full" onClick={onClear}>
             Clear filters
           </Button>
         )}

--- a/components/ui/card-grid.jsx
+++ b/components/ui/card-grid.jsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function CardGrid({
+  as: Comp = "div",
+  className,
+  children,
+  ...props
+}) {
+  return (
+    <Comp
+      data-slot="card-grid"
+      className={cn(
+        "grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3",
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+}
+
+export { CardGrid };

--- a/components/ui/empty-state.jsx
+++ b/components/ui/empty-state.jsx
@@ -1,0 +1,96 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_600 } from "@/lib/config/font.config";
+import { Card, CardContent } from "@/components/ui/card";
+
+function EmptyState({
+  icon: Icon,
+  title,
+  heading,
+  description,
+  action,
+  children,
+  className,
+  contentClassName,
+  iconContainerClassName,
+  titleClassName,
+  descriptionClassName,
+  ...props
+}) {
+  const displayTitle = title || heading;
+
+  const renderIcon = () => {
+    if (!Icon) return null;
+    if (React.isValidElement(Icon)) {
+      return Icon;
+    }
+    if (typeof Icon === "function" || typeof Icon === "object") {
+      return <Icon className="h-7 w-7 text-accent" />;
+    }
+    return null;
+  };
+
+  const actionContent = action || children;
+
+  return (
+    <Card
+      data-slot="empty-state"
+      className={cn(
+        "rounded-2xl border border-accent/10 bg-surface-raised pb-0 shadow-sm",
+        className
+      )}
+      {...props}
+    >
+      <CardContent
+        className={cn(
+          "flex flex-col items-center justify-center space-y-4 py-16 text-center",
+          contentClassName
+        )}
+      >
+        {Icon && (
+          <div
+            className={cn(
+              "flex size-14 items-center justify-center rounded-2xl bg-gradient-to-br from-secondary/15 to-highlight/10",
+              iconContainerClassName
+            )}
+          >
+            {renderIcon()}
+          </div>
+        )}
+        {(displayTitle || description) && (
+          <div>
+            {displayTitle && (
+              <h3
+                className={cn(
+                  poppins_600.className,
+                  "text-lg text-ink",
+                  titleClassName
+                )}
+              >
+                {displayTitle}
+              </h3>
+            )}
+            {description && (
+              <p
+                className={cn(
+                  poppins_400.className,
+                  "mt-1 max-w-md text-sm text-ink-muted",
+                  descriptionClassName
+                )}
+              >
+                {description}
+              </p>
+            )}
+          </div>
+        )}
+        {actionContent && (
+          <div className="flex flex-wrap items-center justify-center gap-3">
+            {actionContent}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export { EmptyState };

--- a/components/ui/page-header.jsx
+++ b/components/ui/page-header.jsx
@@ -1,0 +1,76 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_600 } from "@/lib/config/font.config";
+
+function PageHeader({
+  icon: Icon,
+  title,
+  subtitle,
+  actions,
+  children,
+  className,
+  titleClassName,
+  subtitleClassName,
+  ...props
+}) {
+  const renderIcon = () => {
+    if (!Icon) return null;
+    if (React.isValidElement(Icon)) {
+      return Icon;
+    }
+    if (typeof Icon === "function" || typeof Icon === "object") {
+      return <Icon className="h-5 w-5 text-accent" />;
+    }
+    return null;
+  };
+
+  const actionContent = actions || children;
+
+  return (
+    <div
+      data-slot="page-header"
+      className={cn(
+        "flex flex-wrap items-center justify-between gap-4",
+        className
+      )}
+      {...props}
+    >
+      <div className="flex items-center gap-3">
+        {Icon && (
+          <div className="flex size-11 shrink-0 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
+            {renderIcon()}
+          </div>
+        )}
+        <div>
+          {title && (
+            <h1
+              className={cn(
+                poppins_600.className,
+                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent",
+                titleClassName
+              )}
+            >
+              {title}
+            </h1>
+          )}
+          {subtitle && (
+            <p
+              className={cn(
+                poppins_400.className,
+                "mt-1 text-sm text-ink-muted",
+                subtitleClassName
+              )}
+            >
+              {subtitle}
+            </p>
+          )}
+        </div>
+      </div>
+      {actionContent && (
+        <div className="flex items-center gap-2 flex-wrap">{actionContent}</div>
+      )}
+    </div>
+  );
+}
+
+export { PageHeader };

--- a/components/ui/page-shell.jsx
+++ b/components/ui/page-shell.jsx
@@ -1,0 +1,21 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+function PageShell({
+  as: Comp = "div",
+  className,
+  children,
+  ...props
+}) {
+  return (
+    <Comp
+      data-slot="page-shell"
+      className={cn("p-4 sm:p-6 space-y-6", className)}
+      {...props}
+    >
+      {children}
+    </Comp>
+  );
+}
+
+export { PageShell };


### PR DESCRIPTION
### Summary
Closes #176

Extract the repeated page/section/card/header markup across the dashboard pages into a set of shared, token-driven layout primitives (`PageShell`, `PageHeader`, `CardGrid`, `EmptyState`) under `@/components/ui/`, standardize the Button component app-wide on `@/components/ui/button`, and refactor all off-spec dashboard pages onto these primitives.

### Key Changes
- `components/ui/page-shell.jsx` — Shared outer container (`p-4 sm:p-6 space-y-6`)
- `components/ui/page-header.jsx` — Standardized header with Lucide icon badge, gradient title, subtitle, and action cluster
- `components/ui/card-grid.jsx` — Responsive card grid (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-3`)
- `components/ui/empty-state.jsx` — Token-driven empty-state backed by `Card` & `CardContent`
- `components/atoms/form/Button.jsx` — Backward-compatible adapter unified on `@/components/ui/button`
- Refactored: `dashboard/page.jsx`, `courses`, `library`, `spaces`, `saved`, `purchases`, `sadaqah`, `earnings`, `LibraryToolbar`

### Verification
- [x] Rebased cleanly on latest `upstream/dev`
- [x] `npm run lint` — 0 errors
- [x] `npm run build` — 39/39 pages compiled successfully
- [x] HTTP 200 verified on all 8 dashboard routes
