### PR TITLE
feat(auth): frontend RBAC — capability gating, route guards, and verified-educator gating (#174)

### DIFF
--- a/__tests__/auth/RoleGuard.test.jsx
+++ b/__tests__/auth/RoleGuard.test.jsx
@@ -1,0 +1,101 @@
+/**
+ * RoleGuard — route-level authorization outcomes.
+ * -----------------------------------------------
+ *   - loading            → loader only, no children flash, no redirect
+ *   - student            → redirect to /dashboard/unauthorized + Unauthorized screen
+ *   - unverified educator→ VerificationRequired (recoverable), NO redirect
+ *   - verified educator  → children
+ *   - admin              → children
+ *
+ * Child screens are mocked to markers so we assert branch selection, not their
+ * internals.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CAPABILITIES } from "@/lib/auth/roles";
+
+// Controlled auth + router
+let _auth = { user: null, isAuthenticated: false, loading: true };
+const replace = vi.fn();
+const push = vi.fn();
+
+vi.mock("@/hooks/useAuth", () => ({ useAuth: () => _auth }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace, push }),
+}));
+// ProtectedRoute is authentication (tested separately). Compose over a
+// pass-through so this suite isolates the capability/verification logic; the
+// fail-closed-while-loading behaviour is asserted on the guard itself below.
+vi.mock("@/hooks/protected-route", () => ({
+  default: ({ children }) => children,
+}));
+
+vi.mock("@/components/molecules/loaders/rootLoader", () => ({
+  default: () => <div data-testid="loader" />,
+}));
+vi.mock("@/components/molecules/errors/Unauthorized", () => ({
+  default: () => <div data-testid="unauthorized" />,
+}));
+vi.mock("@/components/auth/VerificationRequired", () => ({
+  default: () => <div data-testid="verify" />,
+}));
+
+import { RoleGuard } from "@/components/auth/RoleGuard";
+
+function renderGuard() {
+  return render(
+    <RoleGuard capability={CAPABILITIES.COURSE_CREATE}>
+      <div data-testid="content">secret create flow</div>
+    </RoleGuard>
+  );
+}
+
+beforeEach(() => {
+  replace.mockClear();
+  push.mockClear();
+  _auth = { user: null, isAuthenticated: false, loading: true };
+});
+
+describe("RoleGuard", () => {
+  it("shows only the loader while auth resolves — no children flash, no redirect", () => {
+    _auth = { user: null, isAuthenticated: false, loading: true };
+    renderGuard();
+    expect(screen.getByTestId("loader")).toBeInTheDocument();
+    expect(screen.queryByTestId("content")).not.toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("redirects a student to the unauthorized screen", () => {
+    _auth = { user: { role: "student" }, isAuthenticated: true, loading: false };
+    renderGuard();
+    expect(screen.queryByTestId("content")).not.toBeInTheDocument();
+    expect(screen.getByTestId("unauthorized")).toBeInTheDocument();
+    expect(replace).toHaveBeenCalledWith("/dashboard/unauthorized");
+  });
+
+  it("shows the verification prompt to an unverified educator — no redirect", () => {
+    _auth = { user: { role: "educator" }, isAuthenticated: true, loading: false };
+    renderGuard();
+    expect(screen.queryByTestId("content")).not.toBeInTheDocument();
+    expect(screen.getByTestId("verify")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("renders children for a verified educator", () => {
+    _auth = {
+      user: { role: "educator", isVerified: true },
+      isAuthenticated: true,
+      loading: false,
+    };
+    renderGuard();
+    expect(screen.getByTestId("content")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("renders children for an admin", () => {
+    _auth = { user: { role: "admin" }, isAuthenticated: true, loading: false };
+    renderGuard();
+    expect(screen.getByTestId("content")).toBeInTheDocument();
+    expect(replace).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/auth/VerifiedBadge.test.jsx
+++ b/__tests__/auth/VerifiedBadge.test.jsx
@@ -1,0 +1,47 @@
+/**
+ * VerifiedBadge — renders only when the subject is verified.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { VerifiedBadge } from "@/components/atoms/VerifiedBadge";
+
+describe("VerifiedBadge", () => {
+  it("renders for a verified user (via user object)", () => {
+    render(<VerifiedBadge user={{ role: "educator", isVerified: true }} />);
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+  });
+
+  it("renders for verificationStatus === 'verified'", () => {
+    render(<VerifiedBadge user={{ verificationStatus: "verified" }} />);
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+  });
+
+  it("renders nothing for an unverified user", () => {
+    const { container } = render(
+      <VerifiedBadge user={{ role: "educator" }} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for a null subject", () => {
+    const { container } = render(<VerifiedBadge user={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("honours an explicit `verified` boolean over the user object", () => {
+    const { container, rerender } = render(
+      <VerifiedBadge verified={false} user={{ isVerified: true }} />
+    );
+    expect(container).toBeEmptyDOMElement();
+
+    rerender(<VerifiedBadge verified={true} user={null} />);
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+  });
+
+  it("can hide its label (icon-only) while still rendering", () => {
+    render(<VerifiedBadge user={{ isVerified: true }} showLabel={false} />);
+    expect(screen.queryByText("Verified")).not.toBeInTheDocument();
+    // The badge element itself is still present (icon-only)
+    expect(document.querySelector('[data-slot="badge"]')).toBeInTheDocument();
+  });
+});

--- a/__tests__/auth/can.test.js
+++ b/__tests__/auth/can.test.js
@@ -1,0 +1,130 @@
+/**
+ * lib/auth/roles — `can()` capability matrix.
+ * -------------------------------------------
+ * Exhaustive per-role matrix: student, educator (unverified), verified
+ * educator, admin — across every capability. Also covers fail-closed behaviour
+ * for missing/unknown input and the tolerant `isVerified` / `normalizeRole`
+ * rules.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  can,
+  isVerified,
+  normalizeRole,
+  roleAllows,
+  requiresVerification,
+  ROLES,
+  CAPABILITIES,
+} from "@/lib/auth/roles";
+
+const ALL_CAPS = Object.values(CAPABILITIES);
+
+const student = { role: "student" };
+const educator = { role: "educator" }; // unverified
+const verifiedEducator = { role: "educator", isVerified: true };
+const admin = { role: "admin" };
+
+describe("can() — student", () => {
+  it("denies every mutating capability", () => {
+    for (const cap of ALL_CAPS) {
+      expect(can(cap, student)).toBe(false);
+    }
+  });
+});
+
+describe("can() — unverified educator", () => {
+  it("is denied all creation/edit capabilities until verified", () => {
+    for (const cap of ALL_CAPS) {
+      expect(can(cap, educator)).toBe(false);
+    }
+  });
+});
+
+describe("can() — verified educator", () => {
+  it("is granted every creation/edit capability", () => {
+    for (const cap of ALL_CAPS) {
+      expect(can(cap, verifiedEducator)).toBe(true);
+    }
+  });
+});
+
+describe("can() — admin", () => {
+  it("is granted everything, no verification needed", () => {
+    for (const cap of ALL_CAPS) {
+      expect(can(cap, admin)).toBe(true);
+    }
+  });
+});
+
+describe("can() — fail closed", () => {
+  it("denies for null/undefined user", () => {
+    expect(can(CAPABILITIES.COURSE_CREATE, null)).toBe(false);
+    expect(can(CAPABILITIES.COURSE_CREATE, undefined)).toBe(false);
+  });
+
+  it("denies for a user with no/unknown role", () => {
+    expect(can(CAPABILITIES.COURSE_CREATE, {})).toBe(false);
+    expect(can(CAPABILITIES.COURSE_CREATE, { role: "wizard" })).toBe(false);
+  });
+
+  it("denies for a missing/unknown action", () => {
+    expect(can(undefined, verifiedEducator)).toBe(false);
+    expect(can("course:teleport", verifiedEducator)).toBe(false);
+  });
+});
+
+describe("isVerified() — tolerant field reading", () => {
+  it("accepts several boolean flag names", () => {
+    expect(isVerified({ isVerified: true })).toBe(true);
+    expect(isVerified({ educatorVerified: true })).toBe(true);
+    expect(isVerified({ isEducatorVerified: true })).toBe(true);
+  });
+
+  it("accepts a string status of 'verified' (case/space-insensitive)", () => {
+    expect(isVerified({ verificationStatus: "verified" })).toBe(true);
+    expect(isVerified({ verificationStatus: "  Verified " })).toBe(true);
+  });
+
+  it("returns false for non-verified statuses and empty input", () => {
+    expect(isVerified({ verificationStatus: "pending" })).toBe(false);
+    expect(isVerified({ isVerified: false })).toBe(false);
+    expect(isVerified(null)).toBe(false);
+    expect(isVerified({})).toBe(false);
+  });
+});
+
+describe("normalizeRole() — synonyms and casing", () => {
+  it("maps instructor/mentor/teacher to educator", () => {
+    expect(normalizeRole("instructor")).toBe(ROLES.EDUCATOR);
+    expect(normalizeRole("Mentor")).toBe(ROLES.EDUCATOR);
+    expect(normalizeRole("TEACHER")).toBe(ROLES.EDUCATOR);
+  });
+
+  it("maps learner to student and trims/lowercases", () => {
+    expect(normalizeRole("learner")).toBe(ROLES.STUDENT);
+    expect(normalizeRole("  Admin ")).toBe(ROLES.ADMIN);
+  });
+
+  it("returns null for unknown/invalid roles", () => {
+    expect(normalizeRole("wizard")).toBe(null);
+    expect(normalizeRole(undefined)).toBe(null);
+    expect(normalizeRole(42)).toBe(null);
+  });
+});
+
+describe("roleAllows() vs can() — the verification gap", () => {
+  it("an unverified educator's role permits create, but can() still denies it", () => {
+    expect(roleAllows(educator, CAPABILITIES.COURSE_CREATE)).toBe(true);
+    expect(can(CAPABILITIES.COURSE_CREATE, educator)).toBe(false);
+  });
+
+  it("a student's role does not permit create at all", () => {
+    expect(roleAllows(student, CAPABILITIES.COURSE_CREATE)).toBe(false);
+  });
+
+  it("every mutating capability requires verification", () => {
+    for (const cap of ALL_CAPS) {
+      expect(requiresVerification(cap)).toBe(true);
+    }
+  });
+});

--- a/__tests__/auth/useCan.test.jsx
+++ b/__tests__/auth/useCan.test.jsx
@@ -1,0 +1,50 @@
+/**
+ * useCan — fail-closed-while-loading + delegation to can().
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { CAPABILITIES } from "@/lib/auth/roles";
+
+let _auth = { user: null, loading: true };
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => _auth,
+}));
+
+import { useCan } from "@/hooks/useCan";
+
+beforeEach(() => {
+  _auth = { user: null, loading: true };
+});
+
+describe("useCan", () => {
+  it("denies everything while auth is loading, even for a verified educator", () => {
+    _auth = { user: { role: "educator", isVerified: true }, loading: true };
+    const { result } = renderHook(() => useCan());
+    expect(result.current.can(CAPABILITIES.COURSE_CREATE)).toBe(false);
+    expect(result.current.loading).toBe(true);
+    expect(result.current.role).toBe(null);
+    expect(result.current.isVerified).toBe(false);
+  });
+
+  it("delegates to can() once resolved — verified educator allowed", () => {
+    _auth = { user: { role: "educator", isVerified: true }, loading: false };
+    const { result } = renderHook(() => useCan());
+    expect(result.current.can(CAPABILITIES.COURSE_CREATE)).toBe(true);
+    expect(result.current.role).toBe("educator");
+    expect(result.current.isVerified).toBe(true);
+  });
+
+  it("denies a resolved student", () => {
+    _auth = { user: { role: "student" }, loading: false };
+    const { result } = renderHook(() => useCan());
+    expect(result.current.can(CAPABILITIES.COURSE_CREATE)).toBe(false);
+    expect(result.current.role).toBe("student");
+  });
+
+  it("denies a resolved unverified educator", () => {
+    _auth = { user: { role: "educator" }, loading: false };
+    const { result } = renderHook(() => useCan());
+    expect(result.current.can(CAPABILITIES.BOOK_CREATE)).toBe(false);
+    expect(result.current.isVerified).toBe(false);
+  });
+});

--- a/app/account/settings/page.jsx
+++ b/app/account/settings/page.jsx
@@ -14,6 +14,7 @@ import { Switch } from "@/components/ui/switch";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
+import { VerifiedBadge } from "@/components/atoms/VerifiedBadge";
 import {
   User,
   Mail,
@@ -432,9 +433,12 @@ const SettingsPage = () => {
                     <p className={cn(poppins_400, "text-ink-muted")}>
                       @{profile.username || user?.username}
                     </p>
-                    <Badge className="mt-2 bg-accent text-white">
-                      {user?.role || "Member"}
-                    </Badge>
+                    <div className="mt-2 flex items-center justify-center gap-2 sm:justify-start">
+                      <Badge className="bg-accent text-white">
+                        {user?.role || "Member"}
+                      </Badge>
+                      <VerifiedBadge user={user} />
+                    </div>
                   </div>
                 </div>
                 <Separator className="bg-accent/10" />

--- a/app/dashboard/courses/create/page.jsx
+++ b/app/dashboard/courses/create/page.jsx
@@ -1,5 +1,11 @@
 import CourseWizard from "@/components/organisms/create/course-wizard";
+import { RoleGuard } from "@/components/auth/RoleGuard";
+import { CAPABILITIES } from "@/lib/auth/roles";
 
 export default function CreateCoursePage() {
-  return <CourseWizard />;
+  return (
+    <RoleGuard capability={CAPABILITIES.COURSE_CREATE}>
+      <CourseWizard />
+    </RoleGuard>
+  );
 }

--- a/app/dashboard/courses/edit/[courseId]/page.jsx
+++ b/app/dashboard/courses/edit/[courseId]/page.jsx
@@ -1,7 +1,13 @@
 import CourseWizard from "@/components/organisms/create/course-wizard";
+import { RoleGuard } from "@/components/auth/RoleGuard";
+import { CAPABILITIES } from "@/lib/auth/roles";
 
 export default async function EditCoursePage({ params }) {
   const { courseId } = await params;
 
-  return <CourseWizard courseId={courseId} />;
+  return (
+    <RoleGuard capability={CAPABILITIES.COURSE_EDIT}>
+      <CourseWizard courseId={courseId} />
+    </RoleGuard>
+  );
 }

--- a/app/dashboard/courses/page.jsx
+++ b/app/dashboard/courses/page.jsx
@@ -11,12 +11,16 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { fetchCourses } from "@/lib/actions/courses/fetch-courses";
 import { getBookmarkedCourses } from "@/lib/actions/courses/bookmark-course";
 import useAuth from "@/hooks/useAuth";
+import { useCan } from "@/hooks/useCan";
+import { CAPABILITIES } from "@/lib/auth/roles";
 import { useAllCourseProgress } from "@/hooks/useCourseProgress";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
 import { cn } from "@/lib/utils";
 
 export default function CoursesPage() {
   const { user } = useAuth();
+  const { can } = useCan();
+  const canCreateCourse = can(CAPABILITIES.COURSE_CREATE);
   const { progressMap } = useAllCourseProgress();
   const [courses, setCourses] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -66,14 +70,16 @@ export default function CoursesPage() {
         }
         actions={
           <>
-            <Button
-              variant="outline"
-              className="rounded-full"
-              onClick={() => (window.location.href = "/dashboard/courses/create")}
-            >
-              <Plus className="h-4 w-4 mr-1" />
-              Create
-            </Button>
+            {canCreateCourse && (
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={() => (window.location.href = "/dashboard/courses/create")}
+              >
+                <Plus className="h-4 w-4 mr-1" />
+                Create
+              </Button>
+            )}
             <Button
               variant={showBookmarks ? "default" : "outline"}
               className={cn("rounded-full", showBookmarks && "bg-accent text-white hover:bg-accent/90")}
@@ -102,7 +108,7 @@ export default function CoursesPage() {
               : "No courses available at the moment."
           }
           action={
-            !showBookmarks && (
+            !showBookmarks && canCreateCourse && (
               <Button
                 variant="outline"
                 className="rounded-full"

--- a/app/dashboard/library/page.jsx
+++ b/app/dashboard/library/page.jsx
@@ -20,6 +20,8 @@ import { fetchBooks } from "@/lib/actions/library/fetch-books";
 import { getBookmarkedBooks } from "@/lib/actions/library/bookmark-book";
 import LibraryBookSkeleton from "@/components/atoms/skeletons/LibraryBookSkeleton";
 import useAuth from "@/hooks/useAuth";
+import { useCan } from "@/hooks/useCan";
+import { CAPABILITIES } from "@/lib/auth/roles";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
 import { getAverageRating } from "@/hooks/getAverageRating";
 import useDebouncedValue from "@/hooks/useDebouncedValue";
@@ -63,6 +65,8 @@ const BookGridSkeleton = () => (
 
 const LibraryPageContent = () => {
   const { user } = useAuth();
+  const { can } = useCan();
+  const canCreateBook = can(CAPABILITIES.BOOK_CREATE);
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -254,14 +258,16 @@ const LibraryPageContent = () => {
         }
         actions={
           <>
-            <Button
-              variant="outline"
-              className="rounded-full"
-              onClick={() => setModalOpen(true)}
-            >
-              <Plus className="h-4 w-4 mr-1" />
-              Create
-            </Button>
+            {canCreateBook && (
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={() => setModalOpen(true)}
+              >
+                <Plus className="h-4 w-4 mr-1" />
+                Create
+              </Button>
+            )}
             <Button
               variant={showBookmarks ? "default" : "outline"}
               className={cn("rounded-full", showBookmarks && "bg-accent text-white hover:bg-accent/90")}
@@ -320,7 +326,7 @@ const LibraryPageContent = () => {
                 Clear filters
               </Button>
             ) : (
-              !showBookmarks && (
+              !showBookmarks && canCreateBook && (
                 <Button
                   variant="outline"
                   className="rounded-full"

--- a/app/dashboard/spaces/page.jsx
+++ b/app/dashboard/spaces/page.jsx
@@ -12,6 +12,8 @@ import SpaceCreateForm from "@/components/organisms/create/space-create-form";
 import Modal from "@/components/molecules/Modal";
 import { getSpaces } from "@/lib/actions/spaces/get-spaces";
 import useAuth from "@/hooks/useAuth";
+import { useCan } from "@/hooks/useCan";
+import { CAPABILITIES } from "@/lib/auth/roles";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
 import { cn } from "@/lib/utils";
 
@@ -29,6 +31,8 @@ const Page = () => {
   const [modalOpen, setmodalOpen] = useState(false);
   const [selectedTab, setSelectedTab] = useState("all");
   const { user } = useAuth();
+  const { can } = useCan();
+  const canCreateSpace = can(CAPABILITIES.SPACE_CREATE);
 
   const fetchSpaces = async () => {
     setLoading(true);
@@ -73,14 +77,16 @@ const Page = () => {
         title="Islamic Spaces"
         subtitle="Join live sessions, discussions, and community events"
         actions={
-          <Button
-            variant="outline"
-            className="rounded-full"
-            onClick={() => setmodalOpen(true)}
-          >
-            <Plus className="mr-1 h-4 w-4" />
-            Create
-          </Button>
+          canCreateSpace && (
+            <Button
+              variant="outline"
+              className="rounded-full"
+              onClick={() => setmodalOpen(true)}
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              Create
+            </Button>
+          )
         }
       />
 
@@ -117,13 +123,15 @@ const Page = () => {
               : `No ${selectedTab} spaces at the moment.`
           }
           action={
-            <Button
-              variant="outline"
-              className="rounded-full"
-              onClick={() => setmodalOpen(true)}
-            >
-              Create Space
-            </Button>
+            canCreateSpace && (
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={() => setmodalOpen(true)}
+              >
+                Create Space
+              </Button>
+            )
           }
         />
       ) : (

--- a/app/dashboard/unauthorized/page.jsx
+++ b/app/dashboard/unauthorized/page.jsx
@@ -1,0 +1,10 @@
+import { PageShell } from "@/components/ui/page-shell";
+import Unauthorized from "@/components/molecules/errors/Unauthorized";
+
+export default function UnauthorizedPage() {
+  return (
+    <PageShell>
+      <Unauthorized />
+    </PageShell>
+  );
+}

--- a/components/atoms/VerifiedBadge.jsx
+++ b/components/atoms/VerifiedBadge.jsx
@@ -1,0 +1,38 @@
+/**
+ * VerifiedBadge — trust badge for verified educators.
+ * ---------------------------------------------------
+ * Renders ONLY when the subject is a verified educator; otherwise renders
+ * nothing. Built on the shared `Badge` primitive.
+ *
+ * Pass either a `user`/subject object (verification is read from it via the
+ * shared `isVerified` rule) or an explicit `verified` boolean when the caller
+ * already knows the status.
+ *
+ *   <VerifiedBadge user={course.createdBy} />
+ *   <VerifiedBadge verified={isVerified} />
+ */
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { BadgeCheck } from "lucide-react";
+import { isVerified as isVerifiedRule } from "@/lib/auth/roles";
+
+export function VerifiedBadge({ user, verified, className, showLabel = true }) {
+  const show = verified === true || (verified === undefined && isVerifiedRule(user));
+  if (!show) return null;
+
+  return (
+    <Badge
+      variant="secondary"
+      className={cn(
+        "gap-1 border-transparent bg-emerald-100 text-emerald-800 dark:bg-emerald-900/40 dark:text-emerald-300",
+        className
+      )}
+      title="Verified educator"
+    >
+      <BadgeCheck className="size-3" aria-hidden="true" />
+      {showLabel && <span>Verified</span>}
+    </Badge>
+  );
+}
+
+export default VerifiedBadge;

--- a/components/auth/RoleGuard.jsx
+++ b/components/auth/RoleGuard.jsx
@@ -1,0 +1,95 @@
+"use client";
+/**
+ * RoleGuard — route-level authorization, composed over ProtectedRoute.
+ * --------------------------------------------------------------------
+ * Wrap a gated page/segment:
+ *
+ *   <RoleGuard capability={CAPABILITIES.COURSE_CREATE}>
+ *     <CourseWizard />
+ *   </RoleGuard>
+ *
+ * Layering:
+ *   1. `ProtectedRoute` handles authentication (redirect to /login, loader
+ *      while auth resolves) — we reuse it rather than re-implement it.
+ *   2. Inside it, `CapabilityGate` runs the role/verification check. It only
+ *      ever renders once the user is known (ProtectedRoute has resolved), so
+ *      it fails closed with no affordance flash.
+ *
+ * Outcomes for a gated capability:
+ *   - allowed                       → render children
+ *   - right role, not yet verified  → <VerificationRequired /> (recoverable)
+ *   - wrong role (e.g. student)     → redirect to the Unauthorized screen
+ *
+ * `capability` gates on a {@link CAPABILITIES} action. Alternatively pass
+ * `roles` (array of {@link ROLES}) for a plain role gate with no verification
+ * requirement.
+ */
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import ProtectedRoute from "@/hooks/protected-route";
+import { useAuth } from "@/hooks/useAuth";
+import Loader from "@/components/molecules/loaders/rootLoader";
+import Unauthorized from "@/components/molecules/errors/Unauthorized";
+import VerificationRequired from "@/components/auth/VerificationRequired";
+import {
+  can,
+  roleAllows,
+  requiresVerification,
+  isVerified,
+  normalizeRole,
+} from "@/lib/auth/roles";
+
+const UNAUTHORIZED_PATH = "/dashboard/unauthorized";
+
+function CapabilityGate({ capability, roles, redirectTo, children }) {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  // Decide the outcome. `loading` is already handled by ProtectedRoute (this
+  // component isn't rendered until auth resolves), but we guard defensively.
+  let allowed;
+  let recoverableViaVerification = false;
+
+  if (capability) {
+    allowed = can(capability, user);
+    recoverableViaVerification =
+      !allowed &&
+      requiresVerification(capability) &&
+      roleAllows(user, capability) &&
+      !isVerified(user);
+  } else if (Array.isArray(roles) && roles.length > 0) {
+    const role = user ? normalizeRole(user.role) : null;
+    allowed = role !== null && roles.includes(role);
+  } else {
+    // No capability/roles specified → treat as authenticated-only pass-through.
+    allowed = !!user;
+  }
+
+  const shouldRedirect = !loading && !allowed && !recoverableViaVerification;
+
+  useEffect(() => {
+    if (shouldRedirect) {
+      router.replace(redirectTo || UNAUTHORIZED_PATH);
+    }
+  }, [shouldRedirect, redirectTo, router]);
+
+  if (loading) return <Loader />;
+  if (allowed) return <>{children}</>;
+  if (recoverableViaVerification) return <VerificationRequired />;
+
+  // Wrong role: render the unauthorized screen inline while the redirect above
+  // takes effect, so there's never a blank frame.
+  return <Unauthorized />;
+}
+
+export function RoleGuard({ capability, roles, redirectTo, children }) {
+  return (
+    <ProtectedRoute>
+      <CapabilityGate capability={capability} roles={roles} redirectTo={redirectTo}>
+        {children}
+      </CapabilityGate>
+    </ProtectedRoute>
+  );
+}
+
+export default RoleGuard;

--- a/components/auth/VerificationRequired.jsx
+++ b/components/auth/VerificationRequired.jsx
@@ -1,0 +1,59 @@
+"use client";
+/**
+ * VerificationRequired — shown to an educator who has the right role for a
+ * content-creation flow but has NOT completed verification yet. Unlike the
+ * Unauthorized screen (wrong role), this is a recoverable state: it explains
+ * what's needed and links straight to the verification flow.
+ */
+import { Inter_800, Inter_400 } from "@/lib/config/font.config";
+import { cn } from "@/lib/utils";
+import Button from "@/components/atoms/form/Button";
+import { BadgeCheck } from "lucide-react";
+import React from "react";
+
+const VerificationRequired = ({ className, message }) => {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "w-full flex flex-col items-center justify-center py-16",
+        "max-w-xl mx-auto text-center",
+        className
+      )}
+    >
+      <div className="mb-8 flex h-24 w-24 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/40">
+        <BadgeCheck
+          className="h-12 w-12 text-amber-600 dark:text-amber-400"
+          aria-hidden="true"
+        />
+      </div>
+      <h1
+        className={cn(
+          "text-3xl lg:text-4xl text-foreground font-bold mb-4",
+          Inter_800.className
+        )}
+      >
+        Verification required
+      </h1>
+      <p
+        className={cn(
+          "text-lg lg:text-xl text-muted-foreground mb-8",
+          Inter_400.className
+        )}
+      >
+        {message ||
+          "Only verified educators can create content. Complete your verification to unlock course, book, and space creation."}
+      </p>
+      <Button
+        type="button"
+        round
+        to="/account/verification"
+        className="py-3 px-8 text-base lg:text-lg bg-accent text-white font-bold hover:bg-accent/90 transition"
+      >
+        Complete verification
+      </Button>
+    </div>
+  );
+};
+
+export default VerificationRequired;

--- a/components/molecules/dashboard/cards/userCard.jsx
+++ b/components/molecules/dashboard/cards/userCard.jsx
@@ -5,6 +5,7 @@ import Button from "@/components/atoms/form/Button";
 import Link from "next/link";
 import { useAuth } from "@/hooks/useAuth";
 import { followUser, unfollowUser, checkIfFollowing } from "@/hooks/useFollow";
+import { VerifiedBadge } from "@/components/atoms/VerifiedBadge";
 import { cn } from "@/lib/utils";
 
 const UserCard = ({ user, showFollowButton = true }) => {
@@ -75,7 +76,10 @@ const UserCard = ({ user, showFollowButton = true }) => {
           </AvatarFallback>
         </Avatar>
         <div className="flex-1">
-          <h3 className="font-semibold text-lg">{user.name}</h3>
+          <div className="flex items-center gap-2">
+            <h3 className="font-semibold text-lg">{user.name}</h3>
+            <VerifiedBadge user={user} showLabel={false} />
+          </div>
           <p className="text-sm ">{user.role || "Member"}</p>
         </div>
       </Link>

--- a/components/molecules/errors/Unauthorized.jsx
+++ b/components/molecules/errors/Unauthorized.jsx
@@ -1,0 +1,69 @@
+"use client";
+/**
+ * Unauthorized — graceful 403 screen.
+ * -----------------------------------
+ * Shown when an authenticated user reaches a surface their role can't access
+ * (e.g. a student navigating directly to a create route). Never a blank page
+ * or a broken render — a clear message and a way back. This is a UX affordance
+ * layered on top of server-side authorization, not the enforcement point.
+ */
+import { Inter_800, Inter_400 } from "@/lib/config/font.config";
+import { cn } from "@/lib/utils";
+import Button from "@/components/atoms/form/Button";
+import { useRouter } from "next/navigation";
+import { ShieldAlert } from "lucide-react";
+import React from "react";
+
+const Unauthorized = ({ className, message }) => {
+  const router = useRouter();
+
+  const handleGoBack = () => {
+    if (typeof window !== "undefined" && window.history.length > 2) {
+      router.back();
+    } else {
+      router.push("/dashboard");
+    }
+  };
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "w-full flex flex-col items-center justify-center py-16",
+        "max-w-xl mx-auto text-center",
+        className
+      )}
+    >
+      <div className="mb-8 flex h-24 w-24 items-center justify-center rounded-full bg-destructive/10">
+        <ShieldAlert className="h-12 w-12 text-destructive" aria-hidden="true" />
+      </div>
+      <h1
+        className={cn(
+          "text-3xl lg:text-4xl text-foreground font-bold mb-4",
+          Inter_800.className
+        )}
+      >
+        Access restricted
+      </h1>
+      <p
+        className={cn(
+          "text-lg lg:text-xl text-muted-foreground mb-8",
+          Inter_400.className
+        )}
+      >
+        {message ||
+          "You don't have permission to view this page. If you think this is a mistake, contact a maintainer."}
+      </p>
+      <Button
+        type="button"
+        round
+        onClick={handleGoBack}
+        className="py-3 px-8 text-base lg:text-lg bg-accent text-white font-bold hover:bg-accent/90 transition"
+      >
+        Back to dashboard
+      </Button>
+    </div>
+  );
+};
+
+export default Unauthorized;

--- a/components/organisms/dashboard/CommandPalette.jsx
+++ b/components/organisms/dashboard/CommandPalette.jsx
@@ -12,6 +12,8 @@ import {
   CommandSeparator,
 } from "@/components/ui/command";
 import { searchQuery } from "@/hooks/useSearch";
+import { useCan } from "@/hooks/useCan";
+import { CAPABILITIES } from "@/lib/auth/roles";
 import { cn } from "@/lib/utils";
 import {
   poppins_400,
@@ -90,12 +92,23 @@ const primaryDestinations = [
 ];
 
 const quickActions = [
-  { name: "Create Course", href: "/dashboard/courses/create", icon: PlusCircle },
+  {
+    name: "Create Course",
+    href: "/dashboard/courses/create",
+    icon: PlusCircle,
+    capability: CAPABILITIES.COURSE_CREATE,
+  },
   { name: "Open Wallet", href: "/dashboard/earnings", icon: Wallet },
 ];
 
 export function CommandPalette() {
   const router = useRouter();
+  const { can } = useCan();
+  // Hide capability-gated quick actions the current user can't perform
+  // (defense-in-depth; the server remains the source of truth).
+  const visibleQuickActions = quickActions.filter(
+    (action) => !action.capability || can(action.capability)
+  );
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const [results, setResults] = useState([]);
@@ -566,7 +579,7 @@ export function CommandPalette() {
 
             {/* Quick Actions */}
             <CommandGroup heading="Quick Actions">
-              {quickActions.map((action) => (
+              {visibleQuickActions.map((action) => (
                 <CommandItem
                   key={action.name}
                   value={`action-${action.name}`}

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -1,0 +1,105 @@
+# Frontend RBAC (capability gating)
+
+This document describes the client-side role-based access control (RBAC) layer:
+a `can(action)` capability helper, route guards, and verified-educator gating.
+
+> **Defense-in-depth only.** The real authorization boundary is the backend
+> (role/ownership enforcement in `dnb-backend#88`, educator verification in
+> `dnb-backend#92`). Nothing on the client is a security control on its own —
+> its job is to stop the UI from *offering* actions the server will reject, so a
+> logged-in student never sees, or can navigate into, instructor-only surfaces.
+
+## Pieces
+
+| Concern | Where |
+| --- | --- |
+| Roles, capabilities, `can()`, `isVerified()` | [`lib/auth/roles.js`](../lib/auth/roles.js) |
+| Capability hook bound to the user (`useCan`) | [`hooks/useCan.js`](../hooks/useCan.js) |
+| Route guard (composes over `ProtectedRoute`) | [`components/auth/RoleGuard.jsx`](../components/auth/RoleGuard.jsx) |
+| Unauthorized screen | [`components/molecules/errors/Unauthorized.jsx`](../components/molecules/errors/Unauthorized.jsx) + [`app/dashboard/unauthorized/`](../app/dashboard/unauthorized/) |
+| Verify-required prompt | [`components/auth/VerificationRequired.jsx`](../components/auth/VerificationRequired.jsx) |
+| Trust badge | [`components/atoms/VerifiedBadge.jsx`](../components/atoms/VerifiedBadge.jsx) |
+
+## Roles and capabilities
+
+Roles: `student`, `educator`, `admin` (`lib/auth/roles.js` also normalises the
+synonyms `instructor`/`mentor`/`teacher` → educator, `learner` → student).
+
+Capabilities are `resource:action` strings:
+
+- `course:create`, `course:edit`
+- `book:create`
+- `space:create`
+
+Decision rules (`can(action, user)`):
+
+- **Admin** is a superuser — allowed everything, no verification needed.
+- **Educator** may hold the content-creation capabilities, but every one of them
+  is **verification-gated**: an educator who has not completed verification is
+  denied until they do.
+- **Student** holds no mutating capability.
+- **Fail closed**: unknown user, unknown role, or unknown action → denied.
+
+`can()` is pure and synchronous — it reads only the passed `user` object, so it
+is trivially unit-testable per role. The verification signal is read from the
+user object (`isVerified` / `educatorVerified` / `isEducatorVerified`, or
+`verificationStatus === "verified"`) since `dnb-backend#92` owns the canonical
+field shape.
+
+## Usage
+
+Gate an affordance (hides it for students and unverified educators):
+
+```jsx
+import { useCan } from "@/hooks/useCan";
+import { CAPABILITIES } from "@/lib/auth/roles";
+
+const { can } = useCan();
+{can(CAPABILITIES.COURSE_CREATE) && <CreateCourseButton />}
+```
+
+`useCan` **fails closed while auth is loading** — every check returns `false`
+until the user is known, so no instructor affordance flashes before auth
+resolves.
+
+Gate a route/segment:
+
+```jsx
+import { RoleGuard } from "@/components/auth/RoleGuard";
+import { CAPABILITIES } from "@/lib/auth/roles";
+
+export default function CreateCoursePage() {
+  return (
+    <RoleGuard capability={CAPABILITIES.COURSE_CREATE}>
+      <CourseWizard />
+    </RoleGuard>
+  );
+}
+```
+
+Outcomes for a gated capability:
+
+- allowed → renders children
+- right role, not yet verified → `VerificationRequired` prompt (recoverable;
+  links to `/account/verification`)
+- wrong role (e.g. student) → redirect to `/dashboard/unauthorized`
+
+`RoleGuard` composes over `ProtectedRoute`, so authentication (redirect to
+`/login`, loader while auth resolves) is handled first, then the
+role/verification check runs.
+
+## Gated surfaces
+
+Route guards: `app/dashboard/courses/create`, `app/dashboard/courses/edit/[courseId]`.
+
+Affordances hidden via `useCan`: the Create buttons on the courses, library, and
+spaces pages, and the "Create Course" quick action in the command palette.
+
+Trust badge (`VerifiedBadge`) renders only when the subject is a verified
+educator — shown on the account profile and on user cards.
+
+## Tests
+
+`__tests__/auth/` — `can()` per-role matrix, `useCan` fail-closed, `RoleGuard`
+outcomes (redirect / verify-prompt / children / no-flash-while-loading), and
+`VerifiedBadge` visibility. Run with `npm test`.

--- a/hooks/useCan.js
+++ b/hooks/useCan.js
@@ -1,0 +1,46 @@
+"use client";
+/**
+ * useCan — capability helper bound to the authenticated user.
+ * -----------------------------------------------------------
+ * Thin, memoised wrapper over `can(action, user)` from `lib/auth/roles`, reading
+ * the user (and the auth `loading` flag) from AuthProvider.
+ *
+ * **Fails closed while auth is resolving.** During the `loading` window every
+ * check returns `false`, so no instructor affordance can flash before we know
+ * who the user is. Once resolved it delegates to the pure `can()`.
+ *
+ * Usage:
+ *   const { can } = useCan();
+ *   if (can(CAPABILITIES.COURSE_CREATE)) { ...render Create button... }
+ */
+import { useCallback, useMemo } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  can as canFn,
+  isVerified as isVerifiedFn,
+  normalizeRole,
+} from "@/lib/auth/roles";
+
+export function useCan() {
+  const { user, loading } = useAuth();
+
+  const can = useCallback(
+    (action) => {
+      if (loading) return false; // fail closed until auth resolves
+      return canFn(action, user);
+    },
+    [user, loading]
+  );
+
+  return useMemo(
+    () => ({
+      can,
+      loading,
+      role: !loading && user ? normalizeRole(user.role) : null,
+      isVerified: !loading && isVerifiedFn(user),
+    }),
+    [can, loading, user]
+  );
+}
+
+export default useCan;

--- a/lib/auth/roles.js
+++ b/lib/auth/roles.js
@@ -1,0 +1,157 @@
+/**
+ * Client-side RBAC — roles, capabilities, and the `can()` decision function.
+ * ---------------------------------------------------------------------------
+ * This is **defense-in-depth only**. The real authorization boundary is the
+ * backend (dnb-backend#88 role/ownership enforcement, dnb-backend#92 educator
+ * verification). Nothing here is a security control on its own — its job is to
+ * stop the UI from *offering* actions the server will reject, so a logged-in
+ * student never sees (or can navigate into) instructor-only surfaces.
+ *
+ * Design rules
+ * ------------
+ *   - **Fail closed.** Unknown user / unknown role / unknown action → denied.
+ *     Callers that don't yet know the user (auth still loading) must also treat
+ *     the answer as `false` (see `useCan`).
+ *   - **Pure & synchronous.** `can(action, user)` reads only the passed `user`
+ *     object so it is trivially unit-testable per role. It never fetches.
+ *   - **Verified-educator gating.** Content-creation capabilities require an
+ *     educator whose verification has completed. The verification signal is
+ *     read from the user object (set by the backend on the user record); the
+ *     field name is tolerant (see `isVerified`) because dnb-backend#92 owns the
+ *     canonical shape.
+ */
+
+/** Canonical role identifiers used across the client. */
+export const ROLES = Object.freeze({
+  STUDENT: "student",
+  EDUCATOR: "educator",
+  ADMIN: "admin",
+});
+
+/** Capability (action) identifiers. `resource:action`. */
+export const CAPABILITIES = Object.freeze({
+  COURSE_CREATE: "course:create",
+  COURSE_EDIT: "course:edit",
+  BOOK_CREATE: "book:create",
+  SPACE_CREATE: "space:create",
+});
+
+/**
+ * Capabilities each role *could* exercise, ignoring verification. Admin is a
+ * superuser handled separately in `can`. Students have no mutating capability.
+ * Educator capabilities are further gated by verification (see below).
+ */
+const ROLE_CAPABILITIES = Object.freeze({
+  [ROLES.STUDENT]: Object.freeze([]),
+  [ROLES.EDUCATOR]: Object.freeze([
+    CAPABILITIES.COURSE_CREATE,
+    CAPABILITIES.COURSE_EDIT,
+    CAPABILITIES.BOOK_CREATE,
+    CAPABILITIES.SPACE_CREATE,
+  ]),
+  [ROLES.ADMIN]: Object.freeze(Object.values(CAPABILITIES)),
+});
+
+/**
+ * Capabilities that additionally require a *verified* educator. An educator who
+ * has not completed verification is denied these (but an admin is not).
+ */
+const VERIFICATION_REQUIRED = Object.freeze(
+  new Set([
+    CAPABILITIES.COURSE_CREATE,
+    CAPABILITIES.COURSE_EDIT,
+    CAPABILITIES.BOOK_CREATE,
+    CAPABILITIES.SPACE_CREATE,
+  ])
+);
+
+/**
+ * Normalise a raw role string to a canonical {@link ROLES} value.
+ * Tolerates casing/whitespace and common synonyms ("instructor"/"mentor" →
+ * educator) so a backend label drift doesn't silently grant/deny wrongly.
+ *
+ * @param {unknown} role
+ * @returns {string|null} canonical role, or null if unrecognised
+ */
+export function normalizeRole(role) {
+  if (typeof role !== "string") return null;
+  const r = role.trim().toLowerCase();
+  if (r === ROLES.STUDENT || r === "learner") return ROLES.STUDENT;
+  if (r === ROLES.EDUCATOR || r === "instructor" || r === "mentor" || r === "teacher") {
+    return ROLES.EDUCATOR;
+  }
+  if (r === ROLES.ADMIN) return ROLES.ADMIN;
+  return null;
+}
+
+/**
+ * Whether the given user is a verified educator, read from the user object.
+ * Tolerant of the exact field name owned by dnb-backend#92: accepts a boolean
+ * flag (`isVerified` / `educatorVerified` / `isEducatorVerified`) or a string
+ * status (`verificationStatus === "verified"`).
+ *
+ * @param {object|null|undefined} user
+ * @returns {boolean}
+ */
+export function isVerified(user) {
+  if (!user || typeof user !== "object") return false;
+  if (user.isVerified === true) return true;
+  if (user.educatorVerified === true) return true;
+  if (user.isEducatorVerified === true) return true;
+  if (
+    typeof user.verificationStatus === "string" &&
+    user.verificationStatus.trim().toLowerCase() === "verified"
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Whether an action requires educator verification. */
+export function requiresVerification(action) {
+  return VERIFICATION_REQUIRED.has(action);
+}
+
+/**
+ * Whether the user's role is, in principle, allowed the action — *before*
+ * applying the verification gate. Used by the route guard to tell "wrong role"
+ * (→ unauthorized) apart from "right role, not yet verified" (→ verify prompt).
+ *
+ * @param {object|null|undefined} user
+ * @param {string} action
+ * @returns {boolean}
+ */
+export function roleAllows(user, action) {
+  if (!user) return false;
+  const role = normalizeRole(user.role);
+  if (!role) return false;
+  if (role === ROLES.ADMIN) return true;
+  return (ROLE_CAPABILITIES[role] || []).includes(action);
+}
+
+/**
+ * Core capability check. Returns true only if the user's role permits the
+ * action AND (for verification-gated actions) the educator is verified.
+ * Admins bypass the verification gate. Fails closed on any missing/unknown
+ * input.
+ *
+ * @param {string} action  a {@link CAPABILITIES} value
+ * @param {object|null|undefined} user  the authenticated user (or null)
+ * @returns {boolean}
+ */
+export function can(action, user) {
+  if (!action || !user || typeof user !== "object") return false;
+
+  const role = normalizeRole(user.role);
+  if (!role) return false;
+
+  // Admin is a superuser and is not subject to the verification gate.
+  if (role === ROLES.ADMIN) return true;
+
+  const allowed = ROLE_CAPABILITIES[role] || [];
+  if (!allowed.includes(action)) return false;
+
+  if (requiresVerification(action) && !isVerified(user)) return false;
+
+  return true;
+}


### PR DESCRIPTION
## Summary

Introduces a single client-side **RBAC layer** for the dashboard, closing the gap where the frontend authenticated but never *authorized* — a logged-in student could render every instructor affordance and navigate directly to `dashboard/courses/create`. This is **defense-in-depth**: the server remains the source of truth (`dnb-backend#88` role/ownership, `dnb-backend#92` educator verification); the client's job is to stop *offering* actions the server will reject.

Closes #174. Merges backlog items #8, #9, #10.

## What's in it

**Capability layer** — [`lib/auth/roles.js`](lib/auth/roles.js)
- `ROLES` + `CAPABILITIES` constants and a **pure, synchronous** `can(action, user)`.
- Admin is a superuser; educator create/edit capabilities are **verification-gated**; students hold none.
- **Fails closed** on unknown user / role / action. Tolerant `isVerified()` and `normalizeRole()` (accepts the field-name variants `dnb-backend#92` may settle on, and the `instructor`/`mentor` role synonyms).

**Capability hook** — [`hooks/useCan.js`](hooks/useCan.js)
- Binds `can()` to `AuthProvider` and **fails closed while auth is loading**, so no instructor affordance flashes before auth resolves.

**Route guards** — [`components/auth/RoleGuard.jsx`](components/auth/RoleGuard.jsx)
- Composes over the existing `ProtectedRoute` (auth first, then role/verification).
- Outcomes: allowed → children · right role but unverified → recoverable **`VerificationRequired`** prompt (links to `/account/verification`) · wrong role → redirect to the **`Unauthorized`** screen.
- New graceful screens under [`app/dashboard/unauthorized/`](app/dashboard/unauthorized/) — never a blank page or broken render.

**Verified-educator trust badge** — [`components/atoms/VerifiedBadge.jsx`](components/atoms/VerifiedBadge.jsx)
- Built on the existing `Badge` primitive; renders **only** when the subject is a verified educator. Shown on the account profile and user cards.

**Wiring**
- Route guards on `courses/create` and `courses/edit/[courseId]`.
- Create affordances hidden via `useCan` on the **courses**, **library**, and **spaces** pages, and the command-palette **"Create Course"** quick action.

## Acceptance criteria

- [x] `can()` unit-tested per role (student, educator, verified-educator, admin); students never see instructor actions.
- [x] Direct navigation to a gated route as a student is blocked → redirected to the unauthorized screen (asserted via `RoleGuard` tests).
- [x] Capability layer **fails closed during the loading window** — no affordance flash before auth resolves (tested).
- [x] An unverified educator cannot open create flows; the verified badge renders only when verified (tested).
- [x] CI stays green (lint + build).

> **Note on the E2E tool:** the acceptance list mentions Playwright for the direct-nav check, but this repo's test stack is **Vitest + Testing Library** (no Playwright configured). Rather than bolt on a second framework, the redirect/guard matrix is covered with Vitest component tests that assert the exact `router.replace("/dashboard/unauthorized")` and the rendered outcome per role. Happy to add a Playwright pass in a follow-up if the team wants to standardise E2E.

## Testing

```
npm test        # 156 passed (31 new in __tests__/auth/ + 125 existing, no regressions)
npm run lint    # clean (only 2 pre-existing warnings in untouched files)
npm run build   # ✓ Compiled successfully — /dashboard/unauthorized prerendered
```

New tests in [`__tests__/auth/`](__tests__/auth/): the `can()` per-role matrix, `useCan` fail-closed, `RoleGuard` outcomes (redirect / verify-prompt / children / no-flash-while-loading), and `VerifiedBadge` visibility.

## Reviewer notes

- **Nothing here is a security boundary.** It's UI gating; enforcement stays on the backend. The verification signal is read from the user object because `dnb-backend#92` owns the canonical field — `isVerified()` accepts several shapes so a label choice there won't silently break this.
- `RoleGuard` deliberately distinguishes *wrong role* (→ Unauthorized) from *right role, not yet verified* (→ recoverable verify prompt) so educators aren't dead-ended.
- Affordance gating hides Create buttons rather than disabling them, keeping students' UI clean; the route guard is the actual stop for direct navigation.
- Docs: [`docs/rbac.md`](docs/rbac.md).
