### PR TITLE
feat(library): book reader keyboard nav, jump-to-page, and resume last-read position (#86)

### DIFF
--- a/__tests__/library/bookProgress.test.js
+++ b/__tests__/library/bookProgress.test.js
@@ -1,0 +1,131 @@
+/**
+ * bookProgress — unit tests
+ * -------------------------
+ * Covers the pure reader helpers:
+ *   - clampPage bounds and integer coercion
+ *   - localStorage persistence round-trip and corruption tolerance
+ *   - keyboard-key → target-page resolution
+ *   - progress percentage
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  bookProgressKey,
+  clampPage,
+  clearBookProgress,
+  nextPageForKey,
+  progressPercent,
+  readBookProgress,
+  saveBookProgress,
+} from "@/app/dashboard/library/read/[bookid]/bookProgress";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("clampPage", () => {
+  it("clamps below 1 and above pageCount", () => {
+    expect(clampPage(0, 10)).toBe(1);
+    expect(clampPage(-5, 10)).toBe(1);
+    expect(clampPage(999, 10)).toBe(10);
+    expect(clampPage(5, 10)).toBe(5);
+  });
+
+  it("floors fractional pages", () => {
+    expect(clampPage(3.9, 10)).toBe(3);
+  });
+
+  it("enforces a floor of 1 when pageCount is unknown", () => {
+    expect(clampPage(7, 0)).toBe(7);
+    expect(clampPage(0, 0)).toBe(1);
+  });
+
+  it("returns 1 for non-numeric input", () => {
+    expect(clampPage("abc", 10)).toBe(1);
+    expect(clampPage(NaN, 10)).toBe(1);
+  });
+});
+
+describe("localStorage persistence", () => {
+  it("saves and reads back the shape { page, updatedAt }", () => {
+    saveBookProgress("book-1", 137, () => "2026-01-01T00:00:00.000Z");
+    const stored = JSON.parse(window.localStorage.getItem(bookProgressKey("book-1")));
+    expect(stored).toEqual({ page: 137, updatedAt: "2026-01-01T00:00:00.000Z" });
+
+    const progress = readBookProgress("book-1");
+    expect(progress.page).toBe(137);
+    expect(progress.updatedAt).toBe("2026-01-01T00:00:00.000Z");
+  });
+
+  it("returns null when nothing is stored", () => {
+    expect(readBookProgress("missing")).toBeNull();
+  });
+
+  it("does not persist invalid pages", () => {
+    expect(saveBookProgress("book-1", 0)).toBe(false);
+    expect(saveBookProgress("book-1", -3)).toBe(false);
+    expect(saveBookProgress("book-1", "x")).toBe(false);
+    expect(window.localStorage.getItem(bookProgressKey("book-1"))).toBeNull();
+  });
+
+  it("tolerates corrupt JSON", () => {
+    window.localStorage.setItem(bookProgressKey("book-1"), "{not json");
+    expect(readBookProgress("book-1")).toBeNull();
+  });
+
+  it("ignores stored entries with an invalid page", () => {
+    window.localStorage.setItem(
+      bookProgressKey("book-1"),
+      JSON.stringify({ page: "nope", updatedAt: "x" })
+    );
+    expect(readBookProgress("book-1")).toBeNull();
+  });
+
+  it("clears a saved position", () => {
+    saveBookProgress("book-1", 5);
+    clearBookProgress("book-1");
+    expect(readBookProgress("book-1")).toBeNull();
+  });
+
+  it("no-ops without a bookId", () => {
+    expect(saveBookProgress("", 5)).toBe(false);
+    expect(readBookProgress("")).toBeNull();
+  });
+});
+
+describe("nextPageForKey", () => {
+  it("maps prev/next keys", () => {
+    expect(nextPageForKey("ArrowLeft", 5, 10)).toBe(4);
+    expect(nextPageForKey("PageUp", 5, 10)).toBe(4);
+    expect(nextPageForKey("ArrowRight", 5, 10)).toBe(6);
+    expect(nextPageForKey("PageDown", 5, 10)).toBe(6);
+  });
+
+  it("maps Home/End to first/last", () => {
+    expect(nextPageForKey("Home", 5, 10)).toBe(1);
+    expect(nextPageForKey("End", 5, 10)).toBe(10);
+  });
+
+  it("clamps at the edges", () => {
+    expect(nextPageForKey("ArrowLeft", 1, 10)).toBe(1);
+    expect(nextPageForKey("ArrowRight", 10, 10)).toBe(10);
+  });
+
+  it("returns null for non-nav keys and empty docs", () => {
+    expect(nextPageForKey("a", 5, 10)).toBeNull();
+    expect(nextPageForKey("Enter", 5, 10)).toBeNull();
+    expect(nextPageForKey("ArrowRight", 5, 0)).toBeNull();
+  });
+});
+
+describe("progressPercent", () => {
+  it("computes a whole-number percentage", () => {
+    expect(progressPercent(137, 400)).toBe(34);
+    expect(progressPercent(1, 400)).toBe(0);
+    expect(progressPercent(400, 400)).toBe(100);
+  });
+
+  it("returns 0 when pageCount is unknown", () => {
+    expect(progressPercent(5, 0)).toBe(0);
+  });
+});

--- a/app/dashboard/library/read/[bookid]/BookReaderClient.jsx
+++ b/app/dashboard/library/read/[bookid]/BookReaderClient.jsx
@@ -17,6 +17,8 @@ import {
   BookOpen,
   ChevronLeft,
   ChevronRight,
+  RotateCcw,
+  X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
@@ -26,6 +28,13 @@ import {
 } from "@/lib/config/font.config";
 import { GlobalWorkerOptions, getDocument } from "pdfjs-dist";
 import workerSrc from "pdfjs-dist/build/pdf.worker.min.js?url";
+import {
+  clampPage,
+  nextPageForKey,
+  progressPercent,
+  readBookProgress,
+  saveBookProgress,
+} from "./bookProgress";
 
 GlobalWorkerOptions.workerSrc = workerSrc;
 
@@ -67,6 +76,14 @@ const BookReaderClient = ({ book }) => {
   const [fitWidth, setFitWidth] = useState(true);
   const [containerWidth, setContainerWidth] = useState(0);
   const [isTransitioning, startTransition] = useTransition();
+
+  // Jump-to-page input (kept as a string so partial typing isn't clobbered)
+  // and the "resumed at page N" banner shown after restoring a saved position.
+  const [pageInput, setPageInput] = useState("1");
+  const [resumeBanner, setResumeBanner] = useState(null);
+  // Latest page, read inside the keyboard handler without re-subscribing on
+  // every page turn.
+  const pageNumberRef = useRef(pageNumber);
 
   const canAccess = useMemo(() => {
     if (!book) return false;
@@ -128,7 +145,14 @@ const BookReaderClient = ({ book }) => {
         docRef.current?.destroy?.();
         docRef.current = pdf;
         setPageCount(pdf.numPages);
-        setPageNumber((prev) => clamp(prev, 1, pdf.numPages));
+
+        // Resume the last-read position (clamped) if one is saved for this book.
+        const saved = readBookProgress(book?._id);
+        const startPage = saved
+          ? clampPage(saved.page, pdf.numPages)
+          : clamp(pageNumberRef.current, 1, pdf.numPages);
+        setPageNumber(startPage);
+        setResumeBanner(saved && startPage > 1 ? startPage : null);
       } catch (error) {
         console.error("Error loading PDF document:", error);
         if (!cancelled) {
@@ -228,11 +252,72 @@ const BookReaderClient = ({ book }) => {
     );
   };
 
+  const jumpToPage = (page) => {
+    if (!pageCount) return;
+    startTransition(() => setPageNumber(clampPage(page, pageCount)));
+  };
+
   const handleZoom = (direction) => {
     setFitWidth(false);
     setBaseScale((prev) =>
       clamp(prev + direction * 0.15, MIN_SCALE, MAX_SCALE)
     );
+  };
+
+  // Keep the jump-to-page input and the ref mirror in sync with the page.
+  useEffect(() => {
+    setPageInput(String(pageNumber));
+    pageNumberRef.current = pageNumber;
+  }, [pageNumber]);
+
+  // Persist the last-read position whenever the page changes (guarded to the
+  // browser inside saveBookProgress).
+  useEffect(() => {
+    if (!book?._id || !pageCount) return;
+    saveBookProgress(book._id, pageNumber);
+  }, [book?._id, pageNumber, pageCount]);
+
+  // Keyboard navigation while the reader is mounted. Ignored when a form field
+  // (the page input / slider) has focus so typing never triggers page flips.
+  useEffect(() => {
+    if (!pageCount) return;
+
+    const handleKeyDown = (event) => {
+      const target = event.target;
+      const tag = target?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || target?.isContentEditable) {
+        return;
+      }
+      const targetPage = nextPageForKey(event.key, pageNumberRef.current, pageCount);
+      if (targetPage == null) return;
+      event.preventDefault();
+      startTransition(() => setPageNumber(targetPage));
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [pageCount, startTransition]);
+
+  const commitPageInput = () => {
+    const parsed = Number.parseInt(pageInput, 10);
+    if (Number.isNaN(parsed)) {
+      setPageInput(String(pageNumber));
+      return;
+    }
+    jumpToPage(parsed);
+  };
+
+  const handlePageInputKeyDown = (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      commitPageInput();
+      event.currentTarget.blur();
+    }
+  };
+
+  const handleStartOver = () => {
+    setResumeBanner(null);
+    jumpToPage(1);
   };
 
   if (!book) {
@@ -347,9 +432,11 @@ const BookReaderClient = ({ book }) => {
                 poppins_500,
                 "hidden rounded-lg border border-accent/10 bg-surface px-3 py-1.5 text-xs text-ink-muted sm:inline-flex"
               )}
+              aria-live="polite"
             >
-              Page {pageNumber}
-              {pageCount ? ` / ${pageCount}` : ""}
+              {pageCount
+                ? `Page ${pageNumber} of ${pageCount} · ${progressPercent(pageNumber, pageCount)}%`
+                : `Page ${pageNumber}`}
             </span>
 
             <div className="hidden items-center gap-1.5 sm:flex">
@@ -465,6 +552,41 @@ const BookReaderClient = ({ book }) => {
           </div>
         ) : (
           <>
+            {resumeBanner && (
+              <div
+                role="status"
+                className="flex items-center justify-center gap-3 border-b border-accent/10 bg-secondary/10 px-4 py-2 md:px-6"
+              >
+                <span
+                  className={cn(
+                    poppins_500,
+                    "text-xs text-ink-muted sm:text-sm"
+                  )}
+                >
+                  Resumed at page {resumeBanner}
+                </span>
+                <button
+                  type="button"
+                  onClick={handleStartOver}
+                  className={cn(
+                    poppins_600,
+                    "inline-flex items-center gap-1.5 rounded-lg border border-accent/20 bg-surface-raised px-2.5 py-1 text-xs text-accent transition-colors hover:border-secondary/40"
+                  )}
+                >
+                  <RotateCcw className="h-3.5 w-3.5" />
+                  Start over
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setResumeBanner(null)}
+                  aria-label="Dismiss resume notice"
+                  className="inline-flex size-6 items-center justify-center rounded-md text-ink-muted transition-colors hover:text-accent"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            )}
+
             {/* Scrollable stage with centered PDF sheet */}
             <div
               ref={containerRef}
@@ -547,26 +669,56 @@ const BookReaderClient = ({ book }) => {
                 </div>
 
                 {pageCount > 1 && (
-                  <div className="flex flex-1 items-center gap-1.5 overflow-x-auto">
-                    {Array.from({ length: pageCount }).map((_, index) => {
-                      const page = index + 1;
-                      return (
-                        <button
-                          key={`page-thumb-${page}`}
-                          type="button"
-                          onClick={() => setPageNumber(page)}
-                          className={cn(
-                            poppins_500,
-                            "shrink-0 rounded-lg border px-3 py-1 text-xs transition-colors",
-                            pageNumber === page
-                              ? "border-accent bg-accent text-white shadow-sm"
-                              : "border-accent/10 bg-surface text-ink-muted hover:border-secondary/40 hover:text-accent"
-                          )}
-                        >
-                          {page}
-                        </button>
-                      );
-                    })}
+                  <div className="flex flex-1 items-center gap-3">
+                    {/* Page scrubber — O(1) DOM, no per-page buttons */}
+                    <input
+                      type="range"
+                      min={1}
+                      max={pageCount}
+                      value={pageNumber}
+                      onChange={(event) =>
+                        jumpToPage(Number(event.target.value))
+                      }
+                      aria-label="Scrub through pages"
+                      className="h-1.5 flex-1 cursor-pointer appearance-none rounded-full bg-accent/15 accent-accent"
+                    />
+
+                    {/* Jump-to-page input, validated 1..pageCount */}
+                    <div className="flex shrink-0 items-center gap-1.5">
+                      <label
+                        htmlFor="reader-go-to-page"
+                        className={cn(
+                          poppins_500,
+                          "text-xs text-ink-muted"
+                        )}
+                      >
+                        Go to
+                      </label>
+                      <input
+                        id="reader-go-to-page"
+                        type="number"
+                        inputMode="numeric"
+                        min={1}
+                        max={pageCount}
+                        value={pageInput}
+                        onChange={(event) => setPageInput(event.target.value)}
+                        onBlur={commitPageInput}
+                        onKeyDown={handlePageInputKeyDown}
+                        aria-label={`Go to page (1 to ${pageCount})`}
+                        className={cn(
+                          poppins_600,
+                          "w-16 rounded-lg border border-accent/15 bg-surface px-2 py-1 text-center text-xs text-ink outline-none focus:border-secondary/50"
+                        )}
+                      />
+                      <span
+                        className={cn(
+                          poppins_500,
+                          "text-xs text-ink-muted"
+                        )}
+                      >
+                        / {pageCount}
+                      </span>
+                    </div>
                   </div>
                 )}
               </div>

--- a/app/dashboard/library/read/[bookid]/bookProgress.js
+++ b/app/dashboard/library/read/[bookid]/bookProgress.js
@@ -1,0 +1,116 @@
+/**
+ * Book reader progress + navigation helpers.
+ *
+ * Pure, DOM-free logic extracted from BookReaderClient so it can be unit
+ * tested and reused:
+ *   - last-read position persistence in localStorage (`dnb:book-progress:<id>`)
+ *   - page clamping
+ *   - keyboard-key → target-page resolution
+ *
+ * All storage helpers guard `typeof window` so they are safe to call during
+ * SSR / non-browser environments.
+ */
+
+export const PROGRESS_KEY_PREFIX = "dnb:book-progress:";
+
+/** localStorage key for a given book. */
+export const bookProgressKey = (bookId) => `${PROGRESS_KEY_PREFIX}${bookId}`;
+
+/**
+ * Clamp a page to the valid 1..pageCount range and coerce to an integer.
+ * When pageCount is unknown (0/falsy) the lower bound of 1 is still enforced.
+ */
+export const clampPage = (page, pageCount) => {
+  const max = Number.isFinite(pageCount) && pageCount > 0 ? Math.floor(pageCount) : Infinity;
+  const value = Math.floor(Number(page));
+  if (!Number.isFinite(value)) return 1;
+  return Math.min(Math.max(value, 1), max);
+};
+
+/**
+ * Read a saved reading position for a book.
+ * Returns `{ page, updatedAt }` or `null` when absent/invalid.
+ */
+export const readBookProgress = (bookId) => {
+  if (typeof window === "undefined" || !bookId) return null;
+  try {
+    const raw = window.localStorage.getItem(bookProgressKey(bookId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    const page = Number(parsed?.page);
+    if (!Number.isFinite(page) || page < 1) return null;
+    return { page: Math.floor(page), updatedAt: parsed?.updatedAt ?? null };
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Persist the current reading position for a book as `{ page, updatedAt }`.
+ * Returns true on success. Invalid pages and non-browser envs are no-ops.
+ */
+export const saveBookProgress = (bookId, page, now = () => new Date().toISOString()) => {
+  if (typeof window === "undefined" || !bookId) return false;
+  const value = Math.floor(Number(page));
+  if (!Number.isFinite(value) || value < 1) return false;
+  try {
+    window.localStorage.setItem(
+      bookProgressKey(bookId),
+      JSON.stringify({ page: value, updatedAt: now() })
+    );
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/** Remove any saved reading position for a book. */
+export const clearBookProgress = (bookId) => {
+  if (typeof window === "undefined" || !bookId) return false;
+  try {
+    window.localStorage.removeItem(bookProgressKey(bookId));
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Resolve a keyboard key to the page it should navigate to.
+ *
+ * ArrowLeft / PageUp  → previous page
+ * ArrowRight / PageDown → next page
+ * Home → first page, End → last page
+ *
+ * Returns the clamped target page, or `null` when the key is not a navigation
+ * key or there is no document (`pageCount` falsy).
+ */
+export const nextPageForKey = (key, current, pageCount) => {
+  if (!Number.isFinite(pageCount) || pageCount <= 0) return null;
+  let target;
+  switch (key) {
+    case "ArrowLeft":
+    case "PageUp":
+      target = current - 1;
+      break;
+    case "ArrowRight":
+    case "PageDown":
+      target = current + 1;
+      break;
+    case "Home":
+      target = 1;
+      break;
+    case "End":
+      target = pageCount;
+      break;
+    default:
+      return null;
+  }
+  return clampPage(target, pageCount);
+};
+
+/** Reading progress as a whole-number percentage (0 when unknown). */
+export const progressPercent = (page, pageCount) => {
+  if (!Number.isFinite(pageCount) || pageCount <= 0) return 0;
+  return Math.round((clampPage(page, pageCount) / pageCount) * 100);
+};


### PR DESCRIPTION
## Summary

Closes #86. Makes the in-app PDF book reader (`app/dashboard/library/read/[bookid]/BookReaderClient.jsx`) usable for real, long books by replacing the per-page button strip with a compact pager and adding keyboard navigation, jump-to-page, resume, and a progress indicator — all without changing the existing zoom / fit-width / access-gating / download behavior.

## What changed

- **No more O(pageCount) DOM.** The horizontal strip that rendered one `Page N` button per page (unusable at 400 pages) is replaced with a **range slider** + a **validated numeric "Go to" input** (clamped to `1..pageCount`).
- **Keyboard navigation** while the reader is mounted: `ArrowLeft`/`ArrowRight` and `PageUp`/`PageDown` page through; `Home`/`End` jump to first/last. Keys are **ignored when a form field has focus**, so typing a page number never flips pages.
- **Resume last-read position** per book in `localStorage` under `dnb:book-progress:<bookId>` as `{ page, updatedAt }`. On load the reader resumes at the saved page (clamped to `pageCount`) and shows a **"Resumed at page N — start over"** banner.
- **Progress indicator** in the toolbar: `Page X of Y · Z%`.

Navigation always flows through the existing clamp and `useTransition`, so render cancellation and responsiveness are unchanged.

## Design note

The pure, DOM-free logic — persistence, page clamping, and key→page mapping — is extracted into `bookProgress.js` so it can be unit-tested without mocking `pdfjs`/canvas, and the component stays declarative. A dedicated `localStorage` helper is used (rather than the TTL-based `localCache`) so a reading position never silently expires.

## Acceptance criteria

- [x] Opening a 100+ page PDF renders **no per-page button list**; jumping via input works and clamps invalid values.
- [x] Arrow keys page through; typing in the page input does not trigger page flips.
- [x] Reopening a book resumes at the last-read page, with a visible way to go back to page 1.
- [x] Progress text/percentage updates as you read.
- [x] Zoom, fit-width, access gating, and download behave exactly as before (untouched).
- [x] `npm run lint` and `npm run build` pass.

## Verification (local)

- `npm run lint` → passes (only 2 pre-existing warnings in unrelated files).
- `npm run a11y` → passes (new inputs/buttons carry labels).
- `npm run build` → succeeds; `/dashboard/library/read/[bookid]` compiles.
- `npx vitest --run` → **173 passed** (14 files), including **17 new tests** in `__tests__/library/bookProgress.test.js` covering clamping, persistence round-trip + corruption tolerance, key→page mapping, and progress percentage.

## Files

- `app/dashboard/library/read/[bookid]/BookReaderClient.jsx` — pager UI, keyboard nav, resume, progress
- `app/dashboard/library/read/[bookid]/bookProgress.js` — pure helpers (new)
- `__tests__/library/bookProgress.test.js` — unit tests (new)
