### PR TITLE
fix: only auto-retry idempotent requests on 5xx

### DIFF
--- a/__tests__/config/axiosRetry.test.js
+++ b/__tests__/config/axiosRetry.test.js
@@ -1,0 +1,267 @@
+/**
+ * Axios retry-policy tests (issue #75)
+ * ------------------------------------
+ * The response interceptor used to replay ANY request that failed with a 5xx,
+ * regardless of method. A 500 does not mean the server declined the request —
+ * it may have processed it and then died. Replaying a mutation therefore risks
+ * resubmitting an already-accepted Stellar payment (double charge) or creating
+ * duplicate purchases, enrollments and reviews.
+ *
+ * These tests drive the REAL axiosInstance and its REAL interceptor; only the
+ * network adapter is swapped so requests can be counted. Counting requests at
+ * the adapter is the same place a mock server would see them, which is what the
+ * issue asks to observe.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import axiosInstance from "@/lib/config/axios.config";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+// ── Adapter that always fails with a given status and counts calls ─────────
+
+let sent = [];
+
+function makeAxiosError(config, status) {
+  const error = new Error(`Request failed with status code ${status}`);
+  error.isAxiosError = true;
+  error.config = config;
+  error.response = {
+    data: { message: "Internal Server Error" },
+    status,
+    statusText: "Internal Server Error",
+    headers: {},
+    config,
+  };
+  return error;
+}
+
+/** Fails every call with `status`. */
+function alwaysFailing(status) {
+  return (config) => {
+    sent.push(config);
+    return Promise.reject(makeAxiosError(config, status));
+  };
+}
+
+/** Fails the first call with `status`, then succeeds. */
+function failThenSucceed(status) {
+  return (config) => {
+    sent.push(config);
+    if (sent.length === 1) {
+      return Promise.reject(makeAxiosError(config, status));
+    }
+    return Promise.resolve({
+      data: { recovered: true },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config,
+    });
+  };
+}
+
+let originalAdapter;
+
+beforeEach(() => {
+  sent = [];
+  originalAdapter = axiosInstance.defaults.adapter;
+});
+
+afterEach(() => {
+  axiosInstance.defaults.adapter = originalAdapter;
+  document.cookie =
+    "authToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+
+describe("issue #75 — mutations are never auto-retried on 5xx", () => {
+  it("does not retry POST /api/stellar/payment/submit", async () => {
+    axiosInstance.defaults.adapter = alwaysFailing(500);
+
+    await expect(
+      axiosInstance.post("/api/stellar/payment/submit", {
+        transactionId: "tx_1",
+        signedXdr: "AAAAA...signed",
+      })
+    ).rejects.toMatchObject({ response: { status: 500 } });
+
+    // Exactly one request reached the wire — the signed XDR was submitted once.
+    expect(sent).toHaveLength(1);
+  });
+
+  it("does not retry POST /api/stellar/payment/initialize", async () => {
+    axiosInstance.defaults.adapter = alwaysFailing(500);
+
+    await expect(
+      axiosInstance.post("/api/stellar/payment/initialize", { itemId: "c1" })
+    ).rejects.toBeTruthy();
+
+    expect(sent).toHaveLength(1);
+  });
+
+  it.each([
+    ["post", "/api/purchase/book"],
+    ["put", "/api/users/update/u1"],
+    ["patch", "/api/courses/c1/reviews/r1"],
+    ["delete", "/api/spaces/s1"],
+  ])("does not retry %s %s", async (method, url) => {
+    axiosInstance.defaults.adapter = alwaysFailing(500);
+
+    await expect(axiosInstance({ method, url })).rejects.toBeTruthy();
+
+    expect(sent).toHaveLength(1);
+  });
+
+  it("surfaces the original server error to the caller on the first failure", async () => {
+    axiosInstance.defaults.adapter = alwaysFailing(503);
+
+    const error = await axiosInstance
+      .post("/api/stellar/payment/submit", {})
+      .catch((e) => e);
+
+    expect(error.response.status).toBe(503);
+    expect(error.response.data.message).toBe("Internal Server Error");
+    expect(sent).toHaveLength(1);
+  });
+});
+
+describe("issue #75 — idempotent requests still retry once", () => {
+  it("retries a GET exactly once, after roughly a second", async () => {
+    axiosInstance.defaults.adapter = alwaysFailing(500);
+
+    const startedAt = Date.now();
+    await expect(axiosInstance.get("/api/courses")).rejects.toBeTruthy();
+    const elapsed = Date.now() - startedAt;
+
+    // Original + one retry, and no more.
+    expect(sent).toHaveLength(2);
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+  });
+
+  it("recovers when the retried GET succeeds", async () => {
+    axiosInstance.defaults.adapter = failThenSucceed(500);
+
+    const res = await axiosInstance.get("/api/courses");
+
+    expect(res.data).toEqual({ recovered: true });
+    expect(sent).toHaveLength(2);
+  });
+
+  it("retries HEAD and OPTIONS too", async () => {
+    axiosInstance.defaults.adapter = alwaysFailing(500);
+    await expect(axiosInstance.head("/api/courses")).rejects.toBeTruthy();
+    expect(sent).toHaveLength(2);
+
+    sent = [];
+    await expect(
+      axiosInstance({ method: "options", url: "/api/courses" })
+    ).rejects.toBeTruthy();
+    expect(sent).toHaveLength(2);
+  });
+
+  it("does not retry a GET that fails with 4xx", async () => {
+    axiosInstance.defaults.adapter = alwaysFailing(404);
+
+    await expect(axiosInstance.get("/api/courses/missing")).rejects.toBeTruthy();
+
+    expect(sent).toHaveLength(1);
+  });
+});
+
+describe("issue #75 — explicit per-request opt-in", () => {
+  it("retries a POST that sets retryOnServerError: true", async () => {
+    axiosInstance.defaults.adapter = alwaysFailing(500);
+
+    await expect(
+      axiosInstance.post(
+        "/api/idempotent-thing",
+        { idempotencyKey: "key_1" },
+        { retryOnServerError: true }
+      )
+    ).rejects.toBeTruthy();
+
+    expect(sent).toHaveLength(2);
+  });
+
+  it("replays the identical idempotency key rather than a fresh request", async () => {
+    axiosInstance.defaults.adapter = alwaysFailing(500);
+
+    await axiosInstance
+      .post(
+        "/api/idempotent-thing",
+        { idempotencyKey: "key_1" },
+        { retryOnServerError: true }
+      )
+      .catch(() => {});
+
+    expect(sent).toHaveLength(2);
+    expect(JSON.parse(sent[0].data)).toEqual({ idempotencyKey: "key_1" });
+    expect(JSON.parse(sent[1].data)).toEqual({ idempotencyKey: "key_1" });
+  });
+
+  it("lets a GET opt OUT with retryOnServerError: false", async () => {
+    axiosInstance.defaults.adapter = alwaysFailing(500);
+
+    await expect(
+      axiosInstance.get("/api/courses", { retryOnServerError: false })
+    ).rejects.toBeTruthy();
+
+    expect(sent).toHaveLength(1);
+  });
+});
+
+describe("issue #75 — console noise", () => {
+  /** Capture everything written to the console while `fn` runs. */
+  async function captureConsole(fn) {
+    const spies = ["log", "info", "warn", "error", "debug"].map((level) =>
+      vi.spyOn(console, level).mockImplementation(() => {})
+    );
+    try {
+      await fn();
+      return spies
+        .flatMap((spy) => spy.mock.calls)
+        .flat()
+        .map((arg) => (typeof arg === "string" ? arg : String(arg)))
+        .join(" ");
+    } finally {
+      spies.forEach((spy) => spy.mockRestore());
+    }
+  }
+
+  it("writes nothing to the console at import time in a production build", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.resetModules();
+
+    const output = await captureConsole(async () => {
+      await import("@/lib/config/axios.config");
+    });
+
+    // The only import-time output in this graph is the missing-env warning in
+    // lib/config/env.js, which is already gated on NODE_ENV. In a production
+    // build the module graph must be silent.
+    expect(output).toBe("");
+
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it("no source file logs the API base URL", () => {
+    // The base-URL banner the issue describes must not come back.
+    const sources = [
+      "lib/config/axios.config.js",
+      "lib/config/env.js",
+    ].map((relative) => readFileSync(resolve(REPO_ROOT, relative), "utf8"));
+
+    for (const source of sources) {
+      expect(source).not.toContain("API Base URL");
+      expect(source).not.toMatch(/console\.log\([^)]*baseURL/);
+      expect(source).not.toMatch(/console\.log\([^)]*apiUrl/);
+    }
+  });
+});

--- a/__tests__/config/axiosRetry.test.js
+++ b/__tests__/config/axiosRetry.test.js
@@ -76,6 +76,8 @@ afterEach(() => {
   document.cookie =
     "authToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT";
   vi.restoreAllMocks();
+  // Covers any future test that stubs the environment and doesn't clean up.
+  vi.unstubAllEnvs();
 });
 
 // ---------------------------------------------------------------------------
@@ -238,17 +240,21 @@ describe("issue #75 — console noise", () => {
     vi.stubEnv("NODE_ENV", "production");
     vi.resetModules();
 
-    const output = await captureConsole(async () => {
-      await import("@/lib/config/axios.config");
-    });
+    try {
+      const output = await captureConsole(async () => {
+        await import("@/lib/config/axios.config");
+      });
 
-    // The only import-time output in this graph is the missing-env warning in
-    // lib/config/env.js, which is already gated on NODE_ENV. In a production
-    // build the module graph must be silent.
-    expect(output).toBe("");
-
-    vi.unstubAllEnvs();
-    vi.resetModules();
+      // The only import-time output in this graph is the missing-env warning
+      // in lib/config/env.js, which is already gated on NODE_ENV. In a
+      // production build the module graph must be silent.
+      expect(output).toBe("");
+    } finally {
+      // In a finally block so a failed assertion cannot leave NODE_ENV stubbed
+      // as "production" for the tests that follow.
+      vi.unstubAllEnvs();
+      vi.resetModules();
+    }
   });
 
   it("no source file logs the API base URL", () => {

--- a/lib/config/axios.config.js
+++ b/lib/config/axios.config.js
@@ -44,6 +44,28 @@ axiosInstance.interceptors.request.use(
   }
 );
 
+// ---------------------------------------------------------------------------
+// Retry policy
+// ---------------------------------------------------------------------------
+// A 5xx does NOT mean the server failed to process the request — it may have
+// succeeded and then died formatting the response. Replaying a mutation is
+// therefore unsafe: a retried POST /api/stellar/payment/submit can resubmit an
+// already-accepted signed XDR (double charge), and a retried purchase/enroll
+// can create duplicate records.
+//
+// Only methods that are idempotent by definition are replayed automatically.
+// A mutation can opt in explicitly with `retryOnServerError: true` on the
+// request config, which callers should set only when the endpoint de-duplicates
+// server-side (e.g. via an idempotency key).
+const IDEMPOTENT_METHODS = new Set(["get", "head", "options"]);
+
+const isRetryableRequest = (request) => {
+  if (!request) return false;
+  if (request.retryOnServerError === true) return true;
+  if (request.retryOnServerError === false) return false;
+  return IDEMPOTENT_METHODS.has(String(request.method ?? "get").toLowerCase());
+};
+
 // Add response interceptor to handle errors
 axiosInstance.interceptors.response.use(
   (response) => response,
@@ -130,8 +152,15 @@ axiosInstance.interceptors.response.use(
       }
     }
 
-    // Auto-retry once on 5xx errors after 1 second
-    if (!originalRequest._retry && error.response?.status >= 500) {
+    // Auto-retry once on 5xx errors after 1 second — idempotent requests only.
+    // Mutations surface immediately so the caller (e.g. the payment modal's
+    // error step) can tell the user what happened instead of silently
+    // resubmitting.
+    if (
+      !originalRequest._retry &&
+      error.response?.status >= 500 &&
+      isRetryableRequest(originalRequest)
+    ) {
       originalRequest._retry = true;
       try {
         await new Promise((resolve) => setTimeout(resolve, 1000));


### PR DESCRIPTION
Closes #75

## What this changes

The 5xx auto-retry in `lib/config/axios.config.js` is now restricted to methods that are idempotent by definition:

```js
const IDEMPOTENT_METHODS = new Set(["get", "head", "options"]);

const isRetryableRequest = (request) => {
  if (!request) return false;
  if (request.retryOnServerError === true) return true;
  if (request.retryOnServerError === false) return false;
  return IDEMPOTENT_METHODS.has(String(request.method ?? "get").toLowerCase());
};
```

A mutation can opt in explicitly with `retryOnServerError: true`, for endpoints the backend de-duplicates server-side via an idempotency key. Nothing sets it today — the flag exists so that when the backend idempotency work lands, payment resilience is a one-line change at the call site rather than a reopening of this policy. A GET can also opt *out* with `false`.

The existing `_retry` guard is kept, so a retried GET is still replayed only once. `ERR_NETWORK` and `ECONNABORTED` handling above the retry block is untouched, as the issue asked.

## Acceptance criteria

| Criterion | Where |
|---|---|
| A POST that receives 500 is not retried — exactly one request | `axiosRetry.test.js`, counted at the adapter (the same place a mock server would see it) |
| A GET that receives 500 is retried at most once, after ~1s | `axiosRetry.test.js` — asserts 2 requests and elapsed ≥ 900ms |
| Payment submit/initialize errors surface on the first failure | `axiosRetry.test.js` — asserts the original 503 and its body reach the caller |
| No unconditional `console.log` of the API base URL in production | see below |
| `npm run lint` and `npm run build` pass | both green |

## On the base-URL log

The `🌐 API Base URL: ...` line the issue describes is **not present on `dev`** — it has already been removed from `axios.config.js`. The only import-time output left in that module graph is the missing-env warning in `lib/config/env.js`, which is already gated on `NODE_ENV !== "production"`.

Rather than call the criterion vacuously met, I pinned it: one test stubs `NODE_ENV=production`, re-imports the graph, and asserts the console is completely silent; a second asserts no source file reintroduces an `API Base URL` / `baseURL` / `apiUrl` log.

## Tests

`__tests__/config/axiosRetry.test.js` — 16 tests driving the **real** `axiosInstance` and its **real** interceptor, with only the adapter swapped so requests can be counted.

```
 ✓ __tests__/config/axiosRetry.test.js (16 tests) 6090ms
   Test Files  1 passed (1)
        Tests  16 passed (16)
```

Restoring the old interceptor fails 8 of them — including the exact double-submit the issue is about:

```
 × does not retry POST /api/stellar/payment/submit
 × does not retry POST /api/stellar/payment/initialize
 × does not retry post /api/purchase/book
 × does not retry put /api/users/update/u1
 × does not retry patch /api/courses/c1/reviews/r1
 × does not retry delete /api/spaces/s1
 × surfaces the original server error to the caller on the first failure
 × lets a GET opt OUT with retryOnServerError: false
   Tests  8 failed | 8 passed (16)
```

Coverage includes: payment submit and initialize, purchase/update/review/delete across POST/PUT/PATCH/DELETE, GET retry timing, GET recovery when the retry succeeds, HEAD and OPTIONS, 4xx not retried, and both directions of the opt-in flag (including that a replayed request carries the *identical* idempotency key rather than a fresh one).

## Full suite, lint, build

```
Tests  135 passed (135)     # 119 on dev + 16 new
next lint                   # clean (2 pre-existing warnings, untouched)
next build                  # exit 0
```

**Pre-existing failures, not from this PR:** three test *files* fail to collect on `dev` already (`bookProgress`, `VerificationBanner`, `VerificationPage`) — they import paths the `[locale]` route move relocated. Verified identical on a clean `dev` checkout.

## Notes for review

- The retry delay is still a hardcoded 1s. Making it configurable would have meant new API surface beyond what this issue asks for, so the tests wait it out; the file adds ~6s to the suite.
- Not changed here: `hooks/useStellarPayment.js` has an unrelated pre-existing bug — `executePayment` references an undefined `isCancelled` in its catch block. It is a separate issue and deliberately left out of this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry handling for server errors on safe request methods: GET, HEAD, and OPTIONS.
  * Added per-request controls to enable or disable server-error retries.

* **Bug Fixes**
  * Prevented unintended retries for mutating requests and client errors.
  * Preserved request payloads and original server errors across retry attempts.
  * Removed unexpected console output and API base-URL logging in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->