### PR TITLE
feat: secure document upload for educator KYC (government ID, certificate)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,12 @@ NEXT_PUBLIC_DONATION_WALLET=
 
 # ─── Cloudinary ────────────────────────────────────
 NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
-# Cloudinary cloud name for unsigned uploads (required)
+# Cloudinary cloud name for unsigned uploads (required).
+# Unsigned uploads return a PUBLIC secure_url, so this path is for course
+# media only — thumbnails, previews, lesson video.
+# Verification documents (government ID, certificates) must NEVER go through
+# it. They upload to a private, short-lived signed URL issued by the backend;
+# see lib/actions/educators/uploadDocument.js.
 
 # ─── Jitsi ─────────────────────────────────────────
 NEXT_PUBLIC_JITSI_DOMAIN=https://meet.jit.si

--- a/__tests__/documents/DocumentUpload.test.jsx
+++ b/__tests__/documents/DocumentUpload.test.jsx
@@ -1,0 +1,504 @@
+/**
+ * DocumentUpload — real-path integration tests (issue #172)
+ * ---------------------------------------------------------
+ * These drive the actual component → useDocumentUpload → uploadDocument
+ * action chain. Only the two HTTP clients are mocked:
+ *
+ *   @/lib/config/axios.config — our API (signed-target, complete, status, delete)
+ *   axios                      — the raw client used for the signed PUT
+ *
+ * Everything between the drop event and those calls is the real code path.
+ *
+ * Covers the acceptance criteria:
+ *   • invalid type/size/magic-byte rejected before upload, with a visible reason
+ *   • no public asset URL is produced or stored
+ *   • replace and remove update the referenced object
+ *   • drag/drop and camera capture both produce a valid upload
+ *   • progress renders; "scan pending" resolves to accepted / rejected
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+// ── HTTP mocks ─────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/config/axios.config", () => ({
+  default: {
+    post: vi.fn(),
+    get: vi.fn(),
+    delete: vi.fn(),
+    put: vi.fn(),
+  },
+}));
+
+vi.mock("axios", () => ({
+  default: {
+    request: vi.fn(),
+    isCancel: () => false,
+  },
+}));
+
+import axiosInstance from "@/lib/config/axios.config";
+import axios from "axios";
+import DocumentUpload from "@/components/organisms/educator-onboarding/DocumentUpload";
+import { DOCUMENT_TYPES } from "@/lib/verification/documents/policy";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const PDF_MAGIC = [0x25, 0x50, 0x44, 0x46, 0x2d];
+const JPEG_MAGIC = [0xff, 0xd8, 0xff, 0xe0];
+const EXE_MAGIC = [0x4d, 0x5a, 0x90, 0x00];
+
+function makeFile(magic, { name, type, size = 1024 }) {
+  const bytes = new Uint8Array(size);
+  bytes.set(magic, 0);
+  return new File([bytes], name, { type });
+}
+
+const ID = DOCUMENT_TYPES.GOVERNMENT_ID;
+
+const SIGNED_TARGET = {
+  documentId: "doc_abc123",
+  uploadUrl:
+    "https://private-storage.example.com/kyc/doc_abc123?X-Amz-Signature=deadbeef&X-Amz-Expires=300",
+  method: "PUT",
+  headers: { "Content-Type": "application/pdf" },
+  expiresAt: "2026-08-20T18:00:00.000Z",
+};
+
+/** Wire the happy-path API responses. `finalStatus` drives the scan result. */
+function mockHappyPath({ finalStatus = "scan_pending", pollStatus } = {}) {
+  axiosInstance.post.mockImplementation((url) => {
+    if (url.endsWith("/upload-url")) {
+      return Promise.resolve({ data: SIGNED_TARGET });
+    }
+    if (url.endsWith("/complete")) {
+      return Promise.resolve({
+        data: {
+          documentId: SIGNED_TARGET.documentId,
+          documentType: ID,
+          status: finalStatus,
+          filename: "passport.pdf",
+          uploadedAt: "2026-08-20T17:00:00.000Z",
+        },
+      });
+    }
+    return Promise.resolve({ data: {} });
+  });
+
+  axiosInstance.get.mockResolvedValue({
+    data: {
+      documentId: SIGNED_TARGET.documentId,
+      status: pollStatus ?? "accepted",
+      scanMessage: null,
+    },
+  });
+
+  axiosInstance.delete.mockResolvedValue({ data: { success: true } });
+
+  axios.request.mockImplementation(async (config) => {
+    // Emit progress the way a real upload would.
+    config.onUploadProgress?.({ loaded: 512, total: 1024 });
+    config.onUploadProgress?.({ loaded: 1024, total: 1024 });
+    return { data: {}, status: 200 };
+  });
+}
+
+/** Only the government-ID slot, to keep assertions unambiguous. */
+const SINGLE_SLOT = [
+  {
+    type: DOCUMENT_TYPES.GOVERNMENT_ID,
+    label: "Government ID",
+    description: "Passport or national ID.",
+    required: true,
+    allowCamera: true,
+  },
+];
+
+function renderUpload(props = {}) {
+  return render(
+    <DocumentUpload
+      slots={SINGLE_SLOT}
+      uploadOptions={{ pollIntervalMs: 5, maxPollAttempts: 5 }}
+      {...props}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // jsdom has no object-URL implementation.
+  global.URL.createObjectURL = vi.fn(() => "blob:mock-preview");
+  global.URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+
+describe("rejection before any network call", () => {
+  it("rejects a renamed .exe declaring itself a PDF, and uploads nothing", async () => {
+    mockHappyPath();
+    renderUpload();
+
+    const disguised = makeFile(EXE_MAGIC, {
+      name: "passport.pdf",
+      type: "application/pdf",
+    });
+
+    fireEvent.drop(screen.getByTestId(`dropzone-${ID}`), {
+      dataTransfer: { files: [disguised] },
+    });
+
+    // Visible, specific reason.
+    const error = await screen.findByTestId(`error-${ID}`);
+    expect(error).toHaveTextContent(/Windows executable/i);
+
+    // Nothing left the browser: no signed target requested, no bytes sent.
+    expect(axiosInstance.post).not.toHaveBeenCalled();
+    expect(axios.request).not.toHaveBeenCalled();
+  });
+
+  it("rejects an oversized PDF without requesting an upload target", async () => {
+    mockHappyPath();
+    renderUpload();
+
+    const huge = makeFile(PDF_MAGIC, {
+      name: "scan.pdf",
+      type: "application/pdf",
+      size: 11 * 1024 * 1024,
+    });
+
+    fireEvent.drop(screen.getByTestId(`dropzone-${ID}`), {
+      dataTransfer: { files: [huge] },
+    });
+
+    expect(await screen.findByTestId(`error-${ID}`)).toHaveTextContent(
+      /limit is 10 MB/i
+    );
+    expect(axiosInstance.post).not.toHaveBeenCalled();
+    expect(axios.request).not.toHaveBeenCalled();
+  });
+
+  it("rejects a disallowed type without requesting an upload target", async () => {
+    mockHappyPath();
+    renderUpload();
+
+    fireEvent.drop(screen.getByTestId(`dropzone-${ID}`), {
+      dataTransfer: {
+        files: [makeFile(PDF_MAGIC, { name: "notes.txt", type: "text/plain" })],
+      },
+    });
+
+    expect(await screen.findByTestId(`error-${ID}`)).toBeInTheDocument();
+    expect(axiosInstance.post).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("drag/drop upload", () => {
+  it("uploads a valid PDF through the signed URL and reaches scan pending", async () => {
+    mockHappyPath({ finalStatus: "scan_pending", pollStatus: "scan_pending" });
+    renderUpload();
+
+    fireEvent.drop(screen.getByTestId(`dropzone-${ID}`), {
+      dataTransfer: {
+        files: [
+          makeFile(PDF_MAGIC, { name: "passport.pdf", type: "application/pdf" }),
+        ],
+      },
+    });
+
+    await screen.findByTestId(`scan-pending-${ID}`);
+
+    // 1. Signed target requested with the VERIFIED content type.
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      "/api/educators/applications/documents/upload-url",
+      expect.objectContaining({
+        documentType: ID,
+        filename: "passport.pdf",
+        contentType: "application/pdf",
+      })
+    );
+
+    // 2. Bytes went to the signed URL, not to our API.
+    const uploadCall = axios.request.mock.calls[0][0];
+    expect(uploadCall.url).toBe(SIGNED_TARGET.uploadUrl);
+    expect(uploadCall.method).toBe("PUT");
+    expect(uploadCall.withCredentials).toBe(false);
+    expect(uploadCall.headers.Authorization).toBeUndefined();
+
+    // 3. Finalised, which starts server-side scanning.
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      `/api/educators/applications/documents/${SIGNED_TARGET.documentId}/complete`,
+      expect.objectContaining({ documentType: ID })
+    );
+  });
+
+  it("renders upload progress while the bytes are in flight", async () => {
+    let releaseUpload;
+    mockHappyPath();
+    axios.request.mockImplementation(
+      (config) =>
+        new Promise((resolve) => {
+          config.onUploadProgress?.({ loaded: 300, total: 1000 });
+          releaseUpload = () => resolve({ data: {}, status: 200 });
+        })
+    );
+
+    renderUpload();
+
+    fireEvent.drop(screen.getByTestId(`dropzone-${ID}`), {
+      dataTransfer: {
+        files: [
+          makeFile(PDF_MAGIC, { name: "passport.pdf", type: "application/pdf" }),
+        ],
+      },
+    });
+
+    const bar = await screen.findByTestId(`progress-${ID}`);
+    await waitFor(() => expect(bar).toHaveAttribute("aria-valuenow", "30"));
+
+    await act(async () => {
+      releaseUpload();
+    });
+  });
+});
+
+describe("camera capture", () => {
+  it("exposes a capture-enabled input and uploads the photo it produces", async () => {
+    mockHappyPath({ finalStatus: "accepted" });
+    renderUpload();
+
+    const cameraInput = screen.getByTestId(`camera-input-${ID}`);
+    expect(cameraInput).toHaveAttribute("capture", "environment");
+    expect(cameraInput).toHaveAttribute("accept", "image/*");
+
+    const photo = makeFile(JPEG_MAGIC, {
+      name: "id-photo.jpg",
+      type: "image/jpeg",
+    });
+
+    fireEvent.change(cameraInput, { target: { files: [photo] } });
+
+    await waitFor(() =>
+      expect(screen.getByTestId("slot-status")).toHaveAttribute(
+        "data-state",
+        "accepted"
+      )
+    );
+
+    expect(axiosInstance.post).toHaveBeenCalledWith(
+      "/api/educators/applications/documents/upload-url",
+      expect.objectContaining({ contentType: "image/jpeg" })
+    );
+    expect(axios.request).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("scan pending resolves", () => {
+  it("moves from scan pending to accepted when the scan clears", async () => {
+    mockHappyPath({ finalStatus: "scan_pending", pollStatus: "accepted" });
+    renderUpload();
+
+    fireEvent.drop(screen.getByTestId(`dropzone-${ID}`), {
+      dataTransfer: {
+        files: [
+          makeFile(PDF_MAGIC, { name: "passport.pdf", type: "application/pdf" }),
+        ],
+      },
+    });
+
+    await screen.findByTestId(`scan-pending-${ID}`);
+
+    await waitFor(
+      () =>
+        expect(screen.getByTestId("slot-status")).toHaveAttribute(
+          "data-state",
+          "accepted"
+        ),
+      { timeout: 3000 }
+    );
+
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      `/api/educators/applications/documents/${SIGNED_TARGET.documentId}`
+    );
+  });
+
+  it("moves from scan pending to rejected when the scan finds something", async () => {
+    mockHappyPath({ finalStatus: "scan_pending" });
+    axiosInstance.get.mockResolvedValue({
+      data: {
+        documentId: SIGNED_TARGET.documentId,
+        status: "infected",
+        scanMessage: "Malware detected in this file.",
+      },
+    });
+
+    renderUpload();
+
+    fireEvent.drop(screen.getByTestId(`dropzone-${ID}`), {
+      dataTransfer: {
+        files: [
+          makeFile(PDF_MAGIC, { name: "passport.pdf", type: "application/pdf" }),
+        ],
+      },
+    });
+
+    await waitFor(
+      () =>
+        expect(screen.getByTestId("slot-status")).toHaveAttribute(
+          "data-state",
+          "rejected"
+        ),
+      { timeout: 3000 }
+    );
+
+    expect(await screen.findByTestId(`error-${ID}`)).toHaveTextContent(
+      "Malware detected in this file."
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("replace and remove", () => {
+  it("replace deletes the old document and reports the new reference", async () => {
+    mockHappyPath({ finalStatus: "accepted" });
+    const onChange = vi.fn();
+    renderUpload({ onChange });
+
+    // First upload
+    fireEvent.drop(screen.getByTestId(`dropzone-${ID}`), {
+      dataTransfer: {
+        files: [
+          makeFile(PDF_MAGIC, { name: "first.pdf", type: "application/pdf" }),
+        ],
+      },
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("slot-status")).toHaveAttribute(
+        "data-state",
+        "accepted"
+      )
+    );
+
+    // Replace with a second file, via the slot's file input
+    axiosInstance.post.mockImplementation((url) => {
+      if (url.endsWith("/upload-url")) {
+        return Promise.resolve({
+          data: { ...SIGNED_TARGET, documentId: "doc_second" },
+        });
+      }
+      if (url.endsWith("/complete")) {
+        return Promise.resolve({
+          data: {
+            documentId: "doc_second",
+            documentType: ID,
+            status: "accepted",
+            filename: "second.pdf",
+          },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+
+    fireEvent.change(screen.getByTestId(`input-${ID}`), {
+      target: {
+        files: [
+          makeFile(PDF_MAGIC, { name: "second.pdf", type: "application/pdf" }),
+        ],
+      },
+    });
+
+    await waitFor(() => expect(screen.getByText("second.pdf")).toBeInTheDocument());
+
+    // The superseded document was deleted.
+    expect(axiosInstance.delete).toHaveBeenCalledWith(
+      `/api/educators/applications/documents/${SIGNED_TARGET.documentId}`
+    );
+
+    // The referenced object now points at the new document.
+    const latest = onChange.mock.calls.at(-1)[0];
+    expect(latest[ID].documentId).toBe("doc_second");
+  });
+
+  it("remove deletes the document and clears the slot", async () => {
+    mockHappyPath({ finalStatus: "accepted" });
+    const onChange = vi.fn();
+    renderUpload({ onChange });
+
+    fireEvent.drop(screen.getByTestId(`dropzone-${ID}`), {
+      dataTransfer: {
+        files: [
+          makeFile(PDF_MAGIC, { name: "passport.pdf", type: "application/pdf" }),
+        ],
+      },
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("slot-status")).toHaveAttribute(
+        "data-state",
+        "accepted"
+      )
+    );
+
+    fireEvent.click(screen.getByTestId(`remove-${ID}`));
+
+    await waitFor(() =>
+      expect(screen.getByTestId(`dropzone-${ID}`)).toBeInTheDocument()
+    );
+
+    expect(axiosInstance.delete).toHaveBeenCalledWith(
+      `/api/educators/applications/documents/${SIGNED_TARGET.documentId}`
+    );
+    expect(onChange.mock.calls.at(-1)[0]).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("no public asset URL is ever produced or stored", () => {
+  it("never surfaces a cloudinary or other public URL, and stores only an id", async () => {
+    mockHappyPath({ finalStatus: "accepted" });
+    const onChange = vi.fn();
+    renderUpload({ onChange });
+
+    fireEvent.drop(screen.getByTestId(`dropzone-${ID}`), {
+      dataTransfer: {
+        files: [
+          makeFile(PDF_MAGIC, { name: "passport.pdf", type: "application/pdf" }),
+        ],
+      },
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("slot-status")).toHaveAttribute(
+        "data-state",
+        "accepted"
+      )
+    );
+
+    // The stored reference carries an opaque id and a status — no URL field.
+    const reference = onChange.mock.calls.at(-1)[0][ID];
+    expect(reference).toEqual(
+      expect.objectContaining({
+        documentId: "doc_abc123",
+        status: "accepted",
+      })
+    );
+    expect(JSON.stringify(reference)).not.toMatch(/https?:\/\//);
+    expect(reference.secure_url).toBeUndefined();
+    expect(reference.url).toBeUndefined();
+
+    // Nothing in the rendered DOM links to a remote asset. The only URL is the
+    // local object URL used for the preview thumbnail.
+    const html = document.body.innerHTML;
+    expect(html).not.toContain("cloudinary");
+    expect(html).not.toContain(SIGNED_TARGET.uploadUrl);
+    expect(html).not.toMatch(/src="https?:\/\//);
+  });
+});

--- a/__tests__/documents/DocumentUpload.test.jsx
+++ b/__tests__/documents/DocumentUpload.test.jsx
@@ -423,9 +423,12 @@ describe("replace and remove", () => {
       `/api/educators/applications/documents/${SIGNED_TARGET.documentId}`
     );
 
-    // The referenced object now points at the new document.
-    const latest = onChange.mock.calls.at(-1)[0];
-    expect(latest[ID].documentId).toBe("doc_second");
+    // The referenced object now points at the new document. Waited for rather
+    // than read once: the filename renders as soon as validation starts, which
+    // is before the replacement upload has finalised.
+    await waitFor(() =>
+      expect(onChange.mock.calls.at(-1)[0][ID].documentId).toBe("doc_second")
+    );
   });
 
   it("remove deletes the document and clears the slot", async () => {
@@ -462,6 +465,109 @@ describe("replace and remove", () => {
 
 // ---------------------------------------------------------------------------
 
+describe("onChange reports the full reference map", () => {
+  const CERT = DOCUMENT_TYPES.TEACHING_CERTIFICATE;
+
+  const TWO_SLOTS = [
+    { ...SINGLE_SLOT[0] },
+    {
+      type: CERT,
+      label: "Teaching certificate",
+      description: "Ijazah or teaching licence.",
+      required: true,
+      allowCamera: false,
+    },
+  ];
+
+  /** Give each slot its own documentId so the map can be told apart. */
+  function mockPerSlot() {
+    axiosInstance.post.mockImplementation((url, body) => {
+      if (url.endsWith("/upload-url")) {
+        return Promise.resolve({
+          data: { ...SIGNED_TARGET, documentId: `doc_${body.documentType}` },
+        });
+      }
+      if (url.endsWith("/complete")) {
+        const documentId = url.split("/documents/")[1].split("/complete")[0];
+        return Promise.resolve({
+          data: {
+            documentId,
+            documentType: body.documentType,
+            status: "accepted",
+          },
+        });
+      }
+      return Promise.resolve({ data: {} });
+    });
+    axios.request.mockResolvedValue({ data: {}, status: 200 });
+  }
+
+  function dropInto(type, name) {
+    fireEvent.drop(screen.getByTestId(`dropzone-${type}`), {
+      dataTransfer: {
+        files: [makeFile(PDF_MAGIC, { name, type: "application/pdf" })],
+      },
+    });
+  }
+
+  it("keeps earlier slots when a later slot finishes", async () => {
+    mockPerSlot();
+    const onChange = vi.fn();
+
+    render(
+      <DocumentUpload
+        slots={TWO_SLOTS}
+        uploadOptions={{ pollIntervalMs: 5, maxPollAttempts: 5 }}
+        onChange={onChange}
+      />
+    );
+
+    dropInto(ID, "passport.pdf");
+    await waitFor(() =>
+      expect(screen.getByTestId(`document-slot-${ID}`)).toHaveAttribute(
+        "data-state",
+        "accepted"
+      )
+    );
+
+    dropInto(CERT, "ijazah.pdf");
+    await waitFor(() =>
+      expect(screen.getByTestId(`document-slot-${CERT}`)).toHaveAttribute(
+        "data-state",
+        "accepted"
+      )
+    );
+
+    // The second slot completing must not drop the first slot's reference.
+    const latest = onChange.mock.calls.at(-1)[0];
+    expect(Object.keys(latest).sort()).toEqual([CERT, ID].sort());
+    expect(latest[ID].documentId).toBe(`doc_${ID}`);
+    expect(latest[CERT].documentId).toBe(`doc_${CERT}`);
+  });
+
+  it("reports the status change when a pending scan resolves", async () => {
+    mockHappyPath({ finalStatus: "scan_pending", pollStatus: "accepted" });
+    const onChange = vi.fn();
+    renderUpload({ onChange });
+
+    dropInto(ID, "passport.pdf");
+
+    await waitFor(
+      () =>
+        expect(screen.getByTestId("slot-status")).toHaveAttribute(
+          "data-state",
+          "accepted"
+        ),
+      { timeout: 3000 }
+    );
+
+    // The parent must see the resolved status, not the stale scan_pending one.
+    expect(onChange.mock.calls.at(-1)[0][ID].status).toBe("accepted");
+  });
+});
+
+// ---------------------------------------------------------------------------
+
 describe("no public asset URL is ever produced or stored", () => {
   it("never surfaces a cloudinary or other public URL, and stores only an id", async () => {
     mockHappyPath({ finalStatus: "accepted" });
@@ -483,13 +589,17 @@ describe("no public asset URL is ever produced or stored", () => {
     );
 
     // The stored reference carries an opaque id and a status — no URL field.
-    const reference = onChange.mock.calls.at(-1)[0][ID];
-    expect(reference).toEqual(
-      expect.objectContaining({
-        documentId: "doc_abc123",
-        status: "accepted",
-      })
+    // Waited for: the reference map is reported from an effect, which flushes
+    // a tick after the slot's DOM state settles.
+    await waitFor(() =>
+      expect(onChange.mock.calls.at(-1)?.[0]?.[ID]).toEqual(
+        expect.objectContaining({
+          documentId: "doc_abc123",
+          status: "accepted",
+        })
+      )
     );
+    const reference = onChange.mock.calls.at(-1)[0][ID];
     expect(JSON.stringify(reference)).not.toMatch(/https?:\/\//);
     expect(reference.secure_url).toBeUndefined();
     expect(reference.url).toBeUndefined();

--- a/__tests__/documents/magicBytes.test.js
+++ b/__tests__/documents/magicBytes.test.js
@@ -1,0 +1,205 @@
+/**
+ * Magic-byte pre-validation (issue #172)
+ * --------------------------------------
+ * `File.type` is derived from the file extension and is therefore
+ * attacker-controlled. These tests pin the property that matters: a file whose
+ * declared extension/MIME says PDF but whose leading bytes say otherwise is
+ * rejected — the exact adversarial case a type- or size-only check cannot
+ * catch.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  identifyHostileSignature,
+  identifySignature,
+  inspectFileSignature,
+  readMagicBytes,
+} from "@/lib/verification/documents/fileSignature";
+import {
+  MAX_DOCUMENT_BYTES,
+  REJECTION,
+  formatBytes,
+  validateDocumentFile,
+} from "@/lib/verification/documents/policy";
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+
+const PDF_MAGIC = [0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34];
+const JPEG_MAGIC = [0xff, 0xd8, 0xff, 0xe0];
+const PNG_MAGIC = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a];
+const WINDOWS_EXE_MAGIC = [0x4d, 0x5a, 0x90, 0x00]; // "MZ"
+const ELF_MAGIC = [0x7f, 0x45, 0x4c, 0x46];
+const ZIP_MAGIC = [0x50, 0x4b, 0x03, 0x04];
+
+/** Build a File with the given leading bytes, padded to `size`. */
+function makeFile(magic, { name, type, size = 2048 }) {
+  const bytes = new Uint8Array(size);
+  bytes.set(magic, 0);
+  return new File([bytes], name, { type });
+}
+
+// ---------------------------------------------------------------------------
+
+describe("readMagicBytes", () => {
+  it("reads only the leading bytes, not the whole file", async () => {
+    const file = makeFile(PDF_MAGIC, {
+      name: "id.pdf",
+      type: "application/pdf",
+      size: 5 * 1024 * 1024,
+    });
+
+    const bytes = await readMagicBytes(file, 5);
+
+    expect(bytes).toHaveLength(5);
+    expect(Array.from(bytes)).toEqual([0x25, 0x50, 0x44, 0x46, 0x2d]);
+  });
+});
+
+describe("identifySignature", () => {
+  it.each([
+    ["PDF", PDF_MAGIC, "application/pdf"],
+    ["JPEG", JPEG_MAGIC, "image/jpeg"],
+    ["PNG", PNG_MAGIC, "image/png"],
+  ])("recognises %s", (_label, magic, expected) => {
+    expect(identifySignature(new Uint8Array(magic))?.mime).toBe(expected);
+  });
+
+  it("returns null for content it does not recognise", () => {
+    expect(identifySignature(new Uint8Array(WINDOWS_EXE_MAGIC))).toBeNull();
+    expect(identifySignature(new Uint8Array([0x00, 0x01, 0x02]))).toBeNull();
+  });
+});
+
+describe("identifyHostileSignature", () => {
+  it.each([
+    ["Windows executable", WINDOWS_EXE_MAGIC],
+    ["Linux executable", ELF_MAGIC],
+    ["ZIP or Office archive", ZIP_MAGIC],
+  ])("names a %s", (label, magic) => {
+    expect(identifyHostileSignature(new Uint8Array(magic))).toBe(label);
+  });
+});
+
+describe("inspectFileSignature", () => {
+  it("reports the real type of a renamed executable", async () => {
+    const disguised = makeFile(WINDOWS_EXE_MAGIC, {
+      name: "passport.pdf",
+      type: "application/pdf",
+    });
+
+    const result = await inspectFileSignature(disguised);
+
+    expect(result.detectedMime).toBeNull();
+    expect(result.hostileLabel).toBe("Windows executable");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The acceptance criterion, stated directly.
+// ---------------------------------------------------------------------------
+
+describe("validateDocumentFile — the adversarial case", () => {
+  it("rejects a renamed .exe that declares itself a PDF", async () => {
+    const disguised = makeFile(WINDOWS_EXE_MAGIC, {
+      name: "passport.pdf",
+      type: "application/pdf",
+    });
+
+    // Type check passes. Size check passes. Only the bytes give it away.
+    expect(disguised.type).toBe("application/pdf");
+    expect(disguised.size).toBeLessThan(MAX_DOCUMENT_BYTES);
+
+    const result = await validateDocumentFile(disguised);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(REJECTION.SIGNATURE_UNRECOGNISED);
+    expect(result.error).toContain("Windows executable");
+  });
+
+  it("rejects a PNG renamed to .pdf (declared/actual mismatch)", async () => {
+    const mislabelled = makeFile(PNG_MAGIC, {
+      name: "certificate.pdf",
+      type: "application/pdf",
+    });
+
+    const result = await validateDocumentFile(mislabelled);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(REJECTION.SIGNATURE_MISMATCH);
+    expect(result.error).toMatch(/contents are a PNG/i);
+  });
+
+  it("rejects a ZIP renamed to .png", async () => {
+    const result = await validateDocumentFile(
+      makeFile(ZIP_MAGIC, { name: "diploma.png", type: "image/png" })
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain("ZIP or Office archive");
+  });
+});
+
+describe("validateDocumentFile — type and size gates", () => {
+  it("rejects a disallowed declared type outright", async () => {
+    const result = await validateDocumentFile(
+      makeFile(ZIP_MAGIC, {
+        name: "notes.docx",
+        type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      })
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(REJECTION.TYPE_NOT_ALLOWED);
+  });
+
+  it("rejects a file over the size limit", async () => {
+    const oversized = makeFile(PDF_MAGIC, {
+      name: "scan.pdf",
+      type: "application/pdf",
+      size: MAX_DOCUMENT_BYTES + 1,
+    });
+
+    const result = await validateDocumentFile(oversized);
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(REJECTION.TOO_LARGE);
+    expect(result.error).toContain(formatBytes(MAX_DOCUMENT_BYTES));
+  });
+
+  it("rejects an empty file", async () => {
+    const result = await validateDocumentFile(
+      new File([], "blank.pdf", { type: "application/pdf" })
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(REJECTION.EMPTY);
+  });
+
+  it("rejects a missing file", async () => {
+    const result = await validateDocumentFile(null);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe(REJECTION.EMPTY);
+  });
+});
+
+describe("validateDocumentFile — genuine documents pass", () => {
+  it.each([
+    ["a real PDF", PDF_MAGIC, "id.pdf", "application/pdf", "application/pdf"],
+    ["a real JPEG", JPEG_MAGIC, "id.jpg", "image/jpeg", "image/jpeg"],
+    ["a real PNG", PNG_MAGIC, "id.png", "image/png", "image/png"],
+  ])("accepts %s", async (_label, magic, name, type, expectedMime) => {
+    const result = await validateDocumentFile(makeFile(magic, { name, type }));
+
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeNull();
+    expect(result.detectedMime).toBe(expectedMime);
+  });
+
+  it("accepts image/jpg as an alias for image/jpeg", async () => {
+    const result = await validateDocumentFile(
+      makeFile(JPEG_MAGIC, { name: "id.jpg", type: "image/jpg" })
+    );
+
+    expect(result.valid).toBe(true);
+  });
+});

--- a/__tests__/documents/noPublicUpload.test.js
+++ b/__tests__/documents/noPublicUpload.test.js
@@ -1,0 +1,106 @@
+/**
+ * Static guard: verification documents never use the unsigned Cloudinary path
+ * ---------------------------------------------------------------------------
+ * lib/utils/cloudinaryUpload.js posts to an UNSIGNED upload preset and returns
+ * `result.secure_url` — a permanently public asset URL. It is the right tool
+ * for a course thumbnail and the wrong tool for a passport scan.
+ *
+ * A runtime test can only prove that the paths it happens to exercise behave.
+ * This file is the lint-style assertion the issue asks for: it reads the
+ * verification-document source files and fails if any of them reaches for the
+ * unsigned uploader, or grows a public-URL field.
+ *
+ * If a future change genuinely needs to touch these files, this test is the
+ * place that change has to argue with.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/** Every source file that participates in the document-upload path. */
+const DOCUMENT_UPLOAD_SOURCES = [
+  "lib/actions/educators/uploadDocument.js",
+  "lib/verification/documents/policy.js",
+  "lib/verification/documents/fileSignature.js",
+  "hooks/useDocumentUpload.js",
+  "components/organisms/educator-onboarding/DocumentUpload.jsx",
+];
+
+function read(relativePath) {
+  const full = resolve(REPO_ROOT, relativePath);
+  expect(existsSync(full), `${relativePath} should exist`).toBe(true);
+  return readFileSync(full, "utf8");
+}
+
+describe("verification documents never use the unsigned Cloudinary preset", () => {
+  it.each(DOCUMENT_UPLOAD_SOURCES)(
+    "%s does not import the Cloudinary uploader",
+    (relativePath) => {
+      const source = read(relativePath);
+
+      expect(source).not.toMatch(
+        /(?:from\s*|require\(\s*)["'][^"']*cloudinaryUpload["']/
+      );
+      expect(source).not.toMatch(
+        /(?:from\s*|require\(\s*)["'][^"']*useCloudinaryUpload["']/
+      );
+    }
+  );
+
+  it.each(DOCUMENT_UPLOAD_SOURCES)(
+    "%s never references an upload preset or api.cloudinary.com",
+    (relativePath) => {
+      const source = read(relativePath);
+
+      expect(source).not.toContain("upload_preset");
+      expect(source).not.toContain("api.cloudinary.com");
+      expect(source).not.toContain("dnb_courses_thumbnails");
+    }
+  );
+
+  it("the upload action never reads or returns a public URL field", () => {
+    const source = read("lib/actions/educators/uploadDocument.js");
+
+    // `secure_url` is Cloudinary's public asset URL. It must not appear
+    // outside the explanatory comment that says why it is absent.
+    const codeOnly = source
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "");
+
+    expect(codeOnly).not.toContain("secure_url");
+    expect(codeOnly).not.toContain("publicUrl");
+  });
+
+  it("the upload action sends bytes with a bare axios client, not axiosInstance", () => {
+    const source = read("lib/actions/educators/uploadDocument.js");
+
+    // The signed URL points at a third-party storage origin; routing it
+    // through axiosInstance would attach the user's bearer token to it.
+    expect(source).toMatch(/axios\.request\(/);
+    expect(source).toMatch(/withCredentials:\s*false/);
+  });
+});
+
+describe("the existing Cloudinary path is untouched and still thumbnail-only", () => {
+  it("course wizards still use the unsigned preset, which is fine for thumbnails", () => {
+    const wizard = read("components/organisms/create/course-wizard.jsx");
+
+    expect(wizard).toContain("useCloudinaryUpload");
+  });
+
+  it("no verification surface imports the Cloudinary hook", () => {
+    const verificationSurfaces = [
+      "components/organisms/educator-onboarding/DocumentUpload.jsx",
+      "components/organisms/educator-onboarding/LivenessCapture.jsx",
+      "components/organisms/educator-onboarding/LivenessConsent.jsx",
+    ].filter((path) => existsSync(resolve(REPO_ROOT, path)));
+
+    for (const path of verificationSurfaces) {
+      expect(read(path)).not.toContain("Cloudinary");
+    }
+  });
+});

--- a/app/[locale]/educator-onboarding/documents/page.jsx
+++ b/app/[locale]/educator-onboarding/documents/page.jsx
@@ -1,0 +1,59 @@
+"use client";
+/**
+ * Educator Onboarding — Document upload step
+ * ------------------------------------------
+ * The step after the liveness check: the educator uploads their government ID
+ * and teaching/school certificate.
+ *
+ * The wizard's liveness capture routes here on success, and this page hands
+ * off to /profile-setup once the required documents are in. It is a distinct
+ * route (rather than another slide in the wizard's state machine) so the step
+ * is resumable and deep-linkable — the verification status center's
+ * "Complete verification" CTA can point straight at it.
+ *
+ * Only opaque document references live in this page's state. No URL to a
+ * stored document is ever produced; viewing one requires a fresh signed URL
+ * minted on demand.
+ */
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ShieldCheck } from "lucide-react";
+
+import DocumentUpload from "@/components/organisms/educator-onboarding/DocumentUpload";
+
+export default function EducatorDocumentsPage() {
+  const router = useRouter();
+  const [documentRefs, setDocumentRefs] = useState({});
+
+  const handleComplete = useCallback(() => {
+    router.push("/profile-setup");
+  }, [router]);
+
+  const handleCancel = useCallback(() => {
+    router.push("/educator-onboarding");
+  }, [router]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col items-center gap-2 text-center">
+        <div className="flex h-12 w-12 items-center justify-center rounded-full bg-accent/10">
+          <ShieldCheck className="h-6 w-6 text-accent" aria-hidden="true" />
+        </div>
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Step 4 of 4
+        </p>
+      </div>
+
+      <DocumentUpload
+        onChange={setDocumentRefs}
+        onComplete={handleComplete}
+        onCancel={handleCancel}
+      />
+
+      <p className="sr-only" data-testid="document-reference-count">
+        {Object.keys(documentRefs).length} documents uploaded
+      </p>
+    </div>
+  );
+}

--- a/app/[locale]/educator-onboarding/page.jsx
+++ b/app/[locale]/educator-onboarding/page.jsx
@@ -7,16 +7,18 @@
  *   Step 1 — Branch selector ("verify now" vs "later")
  *   Step 2 — Consent screen (liveness disclosure + explicit opt-in)
  *   Step 3 — Capture + state machine (liveness check)
+ *   Step 4 — Document upload, at /educator-onboarding/documents
  *
- * Document upload (#3) and the admin review console (#38) are out of scope
- * here; this wizard hands off after the liveness token is acknowledged.
+ * Step 4 lives on its own route rather than in this state machine so it stays
+ * resumable and deep-linkable. The admin review console (#38) remains out of
+ * scope here.
  *
  * Navigation contract
  * -------------------
  *   • "Start verification"  → step 2 (consent)
  *   • Consent given         → step 3 (capture)
  *   • Cancel at any point   → step 1 (branch selector)
- *   • Capture success       → /profile-setup (existing profile wizard)
+ *   • Capture success       → /educator-onboarding/documents (step 4)
  *   • "Do this later"       → /dashboard
  */
 
@@ -159,9 +161,9 @@ function WizardInner() {
     [recordConsent, goToStep]
   );
 
-  // Capture success → profile setup
+  // Capture success → document upload (step 4)
   const handleCaptureSuccess = useCallback(() => {
-    router.push("/profile-setup");
+    router.push("/educator-onboarding/documents");
   }, [router]);
 
   // "Later" → dashboard

--- a/components/organisms/educator-onboarding/DocumentUpload.jsx
+++ b/components/organisms/educator-onboarding/DocumentUpload.jsx
@@ -1,0 +1,469 @@
+"use client";
+/**
+ * DocumentUpload
+ * --------------
+ * The secure upload surface for educator KYC documents.
+ *
+ * Per slot it supports drag/drop, click-to-browse, mobile camera capture,
+ * per-file progress, an inline preview, replace, remove, and a "scan pending"
+ * state that resolves to accepted or rejected.
+ *
+ * Security notes
+ * --------------
+ * - Every file passes validateDocumentFile() (type + size + magic bytes)
+ *   BEFORE a signed upload target is requested. A rejected file produces an
+ *   inline reason and never touches the network.
+ * - The preview is a local object URL built from the File the user picked. It
+ *   is not a remote link, and it is revoked when the slot is cleared.
+ * - No component in this tree ever receives or renders a public asset URL.
+ */
+
+import { useCallback, useId, useRef, useState } from "react";
+import {
+  AlertCircle,
+  Camera,
+  CheckCircle2,
+  FileText,
+  Loader2,
+  RefreshCw,
+  ShieldAlert,
+  Trash2,
+  Upload,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import {
+  ACCEPT_ATTRIBUTE,
+  DOCUMENT_SLOTS,
+  MAX_DOCUMENT_BYTES,
+  formatBytes,
+} from "@/lib/verification/documents/policy";
+import useDocumentUpload, { SLOT_STATE } from "@/hooks/useDocumentUpload";
+
+// ── Per-state presentation ─────────────────────────────────────────────────
+
+const BUSY_STATES = new Set([
+  SLOT_STATE.VALIDATING,
+  SLOT_STATE.REQUESTING,
+  SLOT_STATE.UPLOADING,
+]);
+
+const STATUS_COPY = {
+  [SLOT_STATE.VALIDATING]: "Checking file…",
+  [SLOT_STATE.REQUESTING]: "Preparing secure upload…",
+  [SLOT_STATE.UPLOADING]: "Uploading…",
+  [SLOT_STATE.SCANNING]: "Scan pending — checking this file for malware",
+  [SLOT_STATE.ACCEPTED]: "Accepted",
+  [SLOT_STATE.REJECTED]: "Rejected",
+};
+
+function StatusPill({ state }) {
+  if (state === SLOT_STATE.EMPTY) return null;
+
+  const tone =
+    state === SLOT_STATE.ACCEPTED
+      ? "bg-emerald-500/10 text-emerald-600 dark:text-emerald-400"
+      : state === SLOT_STATE.REJECTED || state === SLOT_STATE.ERROR
+      ? "bg-destructive/10 text-destructive"
+      : state === SLOT_STATE.SCANNING
+      ? "bg-amber-500/10 text-amber-600 dark:text-amber-400"
+      : "bg-muted text-muted-foreground";
+
+  const Icon =
+    state === SLOT_STATE.ACCEPTED
+      ? CheckCircle2
+      : state === SLOT_STATE.REJECTED
+      ? ShieldAlert
+      : state === SLOT_STATE.ERROR
+      ? AlertCircle
+      : Loader2;
+
+  return (
+    <span
+      data-testid="slot-status"
+      data-state={state}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium",
+        tone
+      )}
+    >
+      <Icon
+        className={cn("h-3.5 w-3.5", BUSY_STATES.has(state) && "animate-spin")}
+        aria-hidden="true"
+      />
+      {STATUS_COPY[state] ?? "Not uploaded"}
+    </span>
+  );
+}
+
+// ── One document slot ──────────────────────────────────────────────────────
+
+function DocumentSlot({ slot, definition, onSelectFile, onRemove }) {
+  const inputId = useId();
+  const cameraInputId = `${inputId}-camera`;
+  const fileInputRef = useRef(null);
+  const cameraInputRef = useRef(null);
+  const [isDragging, setIsDragging] = useState(false);
+
+  const isBusy = BUSY_STATES.has(slot.state);
+  const hasFile = slot.state !== SLOT_STATE.EMPTY;
+  const canReplace =
+    hasFile && !isBusy && slot.state !== SLOT_STATE.VALIDATING;
+
+  const handleFiles = useCallback(
+    (fileList) => {
+      const file = fileList?.[0];
+      if (file) onSelectFile(definition.type, file);
+    },
+    [definition.type, onSelectFile]
+  );
+
+  const handleDrop = useCallback(
+    (event) => {
+      event.preventDefault();
+      setIsDragging(false);
+      if (isBusy) return;
+      handleFiles(event.dataTransfer?.files);
+    },
+    [handleFiles, isBusy]
+  );
+
+  const handleDragOver = useCallback((event) => {
+    event.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  const handleDragLeave = useCallback(() => setIsDragging(false), []);
+
+  const openBrowser = useCallback(() => fileInputRef.current?.click(), []);
+  const openCamera = useCallback(() => cameraInputRef.current?.click(), []);
+
+  return (
+    <section
+      data-testid={`document-slot-${definition.type}`}
+      data-state={slot.state}
+      className="rounded-xl border border-border bg-card p-4"
+    >
+      <header className="flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-sm font-semibold text-foreground">
+            {definition.label}
+            {definition.required && (
+              <span className="ml-1 text-destructive" aria-hidden="true">
+                *
+              </span>
+            )}
+            {!definition.required && (
+              <span className="ml-2 text-xs font-normal text-muted-foreground">
+                Optional
+              </span>
+            )}
+          </h3>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {definition.description}
+          </p>
+        </div>
+        <StatusPill state={slot.state} />
+      </header>
+
+      {/* ── Drop zone ─────────────────────────────────────────────────────── */}
+      {!hasFile && (
+        <div
+          data-testid={`dropzone-${definition.type}`}
+          onDrop={handleDrop}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          className={cn(
+            "mt-3 flex flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-6 text-center transition-colors",
+            isDragging
+              ? "border-accent bg-accent/5"
+              : "border-border bg-background"
+          )}
+        >
+          <Upload className="h-6 w-6 text-muted-foreground" aria-hidden="true" />
+          <p className="text-xs text-muted-foreground">
+            Drag a file here, or
+          </p>
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <button
+              type="button"
+              onClick={openBrowser}
+              data-testid={`browse-${definition.type}`}
+              className="rounded-full border border-accent px-3 py-1.5 text-xs font-medium text-accent transition-colors hover:bg-accent/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Choose file
+            </button>
+            {definition.allowCamera && (
+              <button
+                type="button"
+                onClick={openCamera}
+                data-testid={`camera-${definition.type}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <Camera className="h-3.5 w-3.5" aria-hidden="true" />
+                Take a photo
+              </button>
+            )}
+          </div>
+          <p className="mt-1 text-[11px] text-muted-foreground">
+            PDF, JPEG, or PNG · up to {formatBytes(MAX_DOCUMENT_BYTES)}
+          </p>
+        </div>
+      )}
+
+      {/* ── Selected file ─────────────────────────────────────────────────── */}
+      {hasFile && (
+        <div className="mt-3 flex items-start gap-3 rounded-lg border border-border bg-background p-3">
+          <div className="flex h-14 w-14 shrink-0 items-center justify-center overflow-hidden rounded-md bg-muted">
+            {slot.previewUrl ? (
+              // Local object URL for the file the user just picked — never a
+              // remote asset, so next/image would add nothing here.
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={slot.previewUrl}
+                alt={`Preview of ${slot.filename}`}
+                data-testid={`preview-${definition.type}`}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <FileText
+                className="h-6 w-6 text-muted-foreground"
+                aria-hidden="true"
+              />
+            )}
+          </div>
+
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-medium text-foreground">
+              {slot.filename}
+            </p>
+            {slot.size != null && (
+              <p className="text-xs text-muted-foreground">
+                {formatBytes(slot.size)}
+              </p>
+            )}
+
+            {/* Progress */}
+            {isBusy && (
+              <div className="mt-2">
+                <div
+                  role="progressbar"
+                  aria-valuenow={slot.progress}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label={`${definition.label} upload progress`}
+                  data-testid={`progress-${definition.type}`}
+                  className="h-1.5 w-full overflow-hidden rounded-full bg-muted"
+                >
+                  <div
+                    className="h-full rounded-full bg-accent transition-all"
+                    style={{ width: `${slot.progress}%` }}
+                  />
+                </div>
+                <p className="mt-1 text-[11px] text-muted-foreground">
+                  {slot.progress}%
+                </p>
+              </div>
+            )}
+
+            {/* Scan pending */}
+            {slot.state === SLOT_STATE.SCANNING && (
+              <p
+                data-testid={`scan-pending-${definition.type}`}
+                className="mt-2 text-xs text-amber-600 dark:text-amber-400"
+              >
+                Scan pending — you can continue; we&apos;ll tell you if
+                anything is wrong.
+              </p>
+            )}
+
+            {/* Errors / rejection */}
+            {slot.error && (
+              <p
+                role="alert"
+                data-testid={`error-${definition.type}`}
+                className="mt-2 text-xs text-destructive"
+              >
+                {slot.error}
+              </p>
+            )}
+
+            {/* Actions */}
+            {canReplace && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                <button
+                  type="button"
+                  onClick={openBrowser}
+                  data-testid={`replace-${definition.type}`}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-border px-2.5 py-1 text-[11px] font-medium text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <RefreshCw className="h-3 w-3" aria-hidden="true" />
+                  Replace
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onRemove(definition.type)}
+                  data-testid={`remove-${definition.type}`}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-border px-2.5 py-1 text-[11px] font-medium text-destructive transition-colors hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-destructive"
+                >
+                  <Trash2 className="h-3 w-3" aria-hidden="true" />
+                  Remove
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* ── Hidden inputs ─────────────────────────────────────────────────── */}
+      <input
+        ref={fileInputRef}
+        id={inputId}
+        type="file"
+        accept={ACCEPT_ATTRIBUTE}
+        className="sr-only"
+        data-testid={`input-${definition.type}`}
+        aria-label={`Upload ${definition.label}`}
+        onChange={(event) => {
+          handleFiles(event.target.files);
+          // Allow re-selecting the same filename after a rejection.
+          event.target.value = "";
+        }}
+      />
+      {definition.allowCamera && (
+        <input
+          ref={cameraInputRef}
+          id={cameraInputId}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          className="sr-only"
+          data-testid={`camera-input-${definition.type}`}
+          aria-label={`Photograph ${definition.label}`}
+          onChange={(event) => {
+            handleFiles(event.target.files);
+            event.target.value = "";
+          }}
+        />
+      )}
+    </section>
+  );
+}
+
+// ── Public component ───────────────────────────────────────────────────────
+
+/**
+ * @param {Object} props
+ * @param {Array} [props.slots]        slot definitions; defaults to DOCUMENT_SLOTS
+ * @param {(refs: Object) => void} [props.onChange]  called with the current
+ *        map of documentType → document reference whenever it changes
+ * @param {() => void} [props.onComplete]  called when the user submits and all
+ *        required slots hold a document
+ * @param {() => void} [props.onCancel]
+ * @param {Object} [props.uploadOptions]  forwarded to useDocumentUpload
+ */
+export default function DocumentUpload({
+  slots: definitions = DOCUMENT_SLOTS,
+  onChange,
+  onComplete,
+  onCancel,
+  uploadOptions,
+}) {
+  const { slots, getSlot, uploadDocument, replaceDocument, removeDocument } =
+    useDocumentUpload(uploadOptions);
+
+  const handleSelectFile = useCallback(
+    async (documentType, file) => {
+      const existing = slots[documentType]?.reference?.documentId;
+      const run = existing ? replaceDocument : uploadDocument;
+
+      const result = await run(documentType, file);
+
+      if (result?.ok && onChange) {
+        onChange({
+          ...collectReferences(slots),
+          [documentType]: result.reference,
+        });
+      }
+      return result;
+    },
+    [onChange, replaceDocument, slots, uploadDocument]
+  );
+
+  const handleRemove = useCallback(
+    async (documentType) => {
+      const result = await removeDocument(documentType);
+      if (result?.ok && onChange) {
+        const next = collectReferences(slots);
+        delete next[documentType];
+        onChange(next);
+      }
+    },
+    [onChange, removeDocument, slots]
+  );
+
+  const requiredTypes = definitions
+    .filter((d) => d.required)
+    .map((d) => d.type);
+
+  const allRequiredUploaded = requiredTypes.every((type) => {
+    const state = slots[type]?.state;
+    return state === SLOT_STATE.SCANNING || state === SLOT_STATE.ACCEPTED;
+  });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-xl font-bold text-foreground">
+          Upload your documents
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          These are stored privately and shared only with the reviewer handling
+          your application. They are never published.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        {definitions.map((definition) => (
+          <DocumentSlot
+            key={definition.type}
+            definition={definition}
+            slot={getSlot(definition.type)}
+            onSelectFile={handleSelectFile}
+            onRemove={handleRemove}
+          />
+        ))}
+      </div>
+
+      <div className="mt-2 flex items-center justify-between gap-3">
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            data-testid="documents-cancel"
+            className="rounded-full px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            Back
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onComplete}
+          disabled={!allRequiredUploaded}
+          data-testid="documents-continue"
+          className="ml-auto rounded-full bg-accent px-5 py-2 text-sm font-semibold text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Continue
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** Pull the { documentType: reference } map out of slot state. */
+function collectReferences(slots) {
+  return Object.entries(slots).reduce((acc, [type, slot]) => {
+    if (slot?.reference) acc[type] = slot.reference;
+    return acc;
+  }, {});
+}

--- a/components/organisms/educator-onboarding/DocumentUpload.jsx
+++ b/components/organisms/educator-onboarding/DocumentUpload.jsx
@@ -18,7 +18,14 @@
  * - No component in this tree ever receives or renders a public asset URL.
  */
 
-import { useCallback, useId, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   AlertCircle,
   Camera,
@@ -373,34 +380,48 @@ export default function DocumentUpload({
     useDocumentUpload(uploadOptions);
 
   const handleSelectFile = useCallback(
-    async (documentType, file) => {
+    (documentType, file) => {
       const existing = slots[documentType]?.reference?.documentId;
       const run = existing ? replaceDocument : uploadDocument;
-
-      const result = await run(documentType, file);
-
-      if (result?.ok && onChange) {
-        onChange({
-          ...collectReferences(slots),
-          [documentType]: result.reference,
-        });
-      }
-      return result;
+      return run(documentType, file);
     },
-    [onChange, replaceDocument, slots, uploadDocument]
+    [replaceDocument, slots, uploadDocument]
   );
 
   const handleRemove = useCallback(
-    async (documentType) => {
-      const result = await removeDocument(documentType);
-      if (result?.ok && onChange) {
-        const next = collectReferences(slots);
-        delete next[documentType];
-        onChange(next);
-      }
-    },
-    [onChange, removeDocument, slots]
+    (documentType) => removeDocument(documentType),
+    [removeDocument]
   );
+
+  // ── Report the reference map upward ──────────────────────────────────────
+  // Derived from slot state rather than emitted at the end of each upload.
+  // Emitting per-upload read `slots` from a closure captured before the await,
+  // and never fired at all when a pending scan later resolved — so the parent
+  // could hold a reference map that was missing a slot, or stuck on
+  // "scan_pending" after the scan had finished.
+  const references = useMemo(() => collectReferences(slots), [slots]);
+
+  // Compare by content: slot state also changes on every progress tick, and
+  // those must not be reported as reference changes.
+  const referencesKey = JSON.stringify(references);
+
+  // Held in a ref so a parent passing an inline arrow doesn't re-fire this.
+  const onChangeRef = useRef(onChange);
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  const hasReportedRef = useRef(false);
+  useEffect(() => {
+    // Skip the initial empty map so mounting doesn't look like a change.
+    if (!hasReportedRef.current) {
+      hasReportedRef.current = true;
+      if (referencesKey === "{}") return;
+    }
+    onChangeRef.current?.(references);
+    // `references` is recreated per render; `referencesKey` is the real trigger.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [referencesKey]);
 
   const requiredTypes = definitions
     .filter((d) => d.required)

--- a/docs/secure-document-upload.md
+++ b/docs/secure-document-upload.md
@@ -1,0 +1,100 @@
+# Secure document upload
+
+How educator KYC documents (government ID, teaching/school certificate) get
+from the browser into the review queue, and why the existing upload helper is
+not used for them.
+
+## Why not the Cloudinary helper
+
+`lib/utils/cloudinaryUpload.js` posts to an **unsigned** Cloudinary upload
+preset and returns `result.secure_url` — a permanently public asset URL. That
+is the right trade-off for a course thumbnail and the wrong one for a passport
+scan. Its `validateFile()` also checks only `file.size` and `file.type`, and
+`file.type` is derived from the filename, so a renamed `.exe` passes.
+
+Verification documents therefore use a separate path. A test
+(`__tests__/documents/noPublicUpload.test.js`) fails the build if any file on
+that path imports the Cloudinary uploader or grows a public-URL field.
+
+## Client pre-flight
+
+`lib/verification/documents/policy.js` → `validateDocumentFile(file)` runs
+three checks, in order, before any network call:
+
+| # | Check | Catches |
+|---|-------|---------|
+| 1 | Declared MIME is PDF / JPEG / PNG | wrong file picked |
+| 2 | Size ≤ 10 MB | oversized scans |
+| 3 | Leading bytes match the declared type | renamed executables, mislabelled files |
+
+Check 3 is the one that matters. `lib/verification/documents/fileSignature.js`
+reads the first 12 bytes and compares them against the known signatures:
+
+- PDF — `25 50 44 46 2D` (`%PDF-`)
+- JPEG — `FF D8 FF`
+- PNG — `89 50 4E 47 0D 0A 1A 0A`
+
+Recognisably hostile payloads (`MZ`, ELF, ZIP, RAR, gzip, `#!`) are named in
+the rejection message rather than reported as a generic failure.
+
+A file that fails validation never reaches the network — no signed upload
+target is requested for it.
+
+## Upload flow
+
+Contract agreed with the educator-verification pipeline (dnb-backend#92):
+
+```
+1. POST /api/educators/applications/documents/upload-url
+     → { documentId, uploadUrl, method, headers, expiresAt }
+
+2. PUT <uploadUrl>                      (storage origin, short-lived, write-only)
+     bare axios client — withCredentials: false, no Authorization header
+
+3. POST /api/educators/applications/documents/:id/complete
+     → { documentId, status: "scan_pending" | "accepted" | "rejected" }
+
+4. GET  /api/educators/applications/documents/:id      (poll while scanning)
+     → { documentId, status, scanMessage }
+
+   DELETE /api/educators/applications/documents/:id     (remove / replace)
+```
+
+Step 2 deliberately uses a **bare** `axios` client rather than the app's
+`axiosInstance`. The signed URL points at a third-party storage origin, and the
+shared request interceptor would otherwise attach the user's bearer token to
+it.
+
+## What the client stores
+
+Only `{ documentId, documentType, status, filename, uploadedAt }`. There is no
+URL field, because no durable URL is ever produced. Viewing a submitted
+document is a separate, deliberate call — `fetchDocumentSignedUrl()` in
+`lib/actions/educators/fetchVerificationStatus.js` — which mints a fresh
+time-limited URL on demand.
+
+This is also why `next.config.mjs` needs no new `images.remotePatterns` entry:
+the upload preview is a local `blob:` object URL built from the `File` the user
+picked, and nothing renders a stored document as a remote image.
+
+## UI
+
+`components/organisms/educator-onboarding/DocumentUpload.jsx`, reachable at
+`/educator-onboarding/documents` (step 4 of educator onboarding, entered from
+the liveness capture step).
+
+Per slot: drag/drop, click-to-browse, mobile camera capture (`capture="environment"`),
+per-file progress, inline preview, replace, remove, and a *scan pending* state
+that resolves to accepted or rejected.
+
+## Tests
+
+| File | Covers |
+|------|--------|
+| `__tests__/documents/magicBytes.test.js` | signature detection; renamed `.exe`, mislabelled PNG, ZIP-as-PNG; size and type gates |
+| `__tests__/documents/DocumentUpload.test.jsx` | the real component → hook → action path: rejection before any network call, signed-URL upload, progress, scan pending → accepted/rejected, replace, remove, no public URL |
+| `__tests__/documents/noPublicUpload.test.js` | static guard that the Cloudinary unsigned path stays out of the document flow |
+| `e2e/documents.spec.js` | browser smoke: drag/drop, camera input, scan resolution, rejection before network (not run in CI) |
+
+Run: `npm test`, and `npm run build && npx playwright test e2e/documents.spec.js`
+for the e2e spec.

--- a/e2e/documents.spec.js
+++ b/e2e/documents.spec.js
@@ -1,0 +1,194 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * Secure document upload — end-to-end smoke (issue #172)
+ * ------------------------------------------------------
+ * Drives the real onboarding wizard in a real browser and asserts the
+ * acceptance criteria that only a browser can show:
+ *
+ *   • drag/drop produces a valid upload, with progress rendered
+ *   • the camera-capture input is present and capture-enabled
+ *   • "scan pending" resolves to accepted
+ *   • a renamed executable is rejected before any network call
+ *   • no public asset URL is ever requested or rendered
+ *
+ * The backend (dnb-backend#92) is not running in CI, so the educator-application
+ * endpoints and the signed storage target are fulfilled with page.route(). The
+ * component, hook, validation and action code under test are the real ones —
+ * only the network is stubbed, exactly as it is in the Vitest integration test.
+ *
+ * Not run in CI (CI is lint + build); this is the demo proof for the PR.
+ * Run locally with `npm run build && npx playwright test e2e/documents.spec.js`.
+ */
+
+const API = "**/api/educators/applications/documents";
+const SIGNED_URL =
+  "https://private-storage.example.test/kyc/doc_e2e_1?X-Amz-Signature=abc123&X-Amz-Expires=300";
+
+/** Bytes that really are a PDF. */
+const PDF_BYTES = Buffer.concat([
+  Buffer.from("%PDF-1.4\n"),
+  Buffer.alloc(2048, 0x20),
+]);
+
+/** Bytes that really are a Windows executable, named like a PDF. */
+const EXE_BYTES = Buffer.concat([
+  Buffer.from([0x4d, 0x5a, 0x90, 0x00]),
+  Buffer.alloc(2048, 0x00),
+]);
+
+/**
+ * Stub the document API + the signed storage target.
+ * `scanSequence` is consumed one entry per status poll.
+ */
+async function stubDocumentApi(page, { scanSequence = ["accepted"] } = {}) {
+  const requested = [];
+  let pollIndex = 0;
+
+  await page.route(`${API}/upload-url`, async (route) => {
+    requested.push("upload-url");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        documentId: "doc_e2e_1",
+        uploadUrl: SIGNED_URL,
+        method: "PUT",
+        headers: { "Content-Type": "application/pdf" },
+        expiresAt: new Date(Date.now() + 300_000).toISOString(),
+      }),
+    });
+  });
+
+  await page.route(`${API}/doc_e2e_1/complete`, async (route) => {
+    requested.push("complete");
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        documentId: "doc_e2e_1",
+        documentType: "government_id",
+        status: "scan_pending",
+        filename: "passport.pdf",
+      }),
+    });
+  });
+
+  await page.route(`${API}/doc_e2e_1`, async (route) => {
+    const status = scanSequence[Math.min(pollIndex, scanSequence.length - 1)];
+    pollIndex += 1;
+    requested.push(`poll:${status}`);
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ documentId: "doc_e2e_1", status }),
+    });
+  });
+
+  // The signed storage target — a different origin, as in production.
+  await page.route(SIGNED_URL, async (route) => {
+    requested.push("signed-put");
+    const headers = route.request().headers();
+    // The user's bearer token must never reach a third-party origin.
+    expect(headers.authorization).toBeUndefined();
+    await route.fulfill({ status: 200, body: "" });
+  });
+
+  return requested;
+}
+
+test.beforeEach(async ({ page }) => {
+  // The wizard's document step is reachable without a live session in dev;
+  // the liveness adapter defaults to "mock".
+  await page.addInitScript(() => {
+    document.cookie = "authToken=e2e-token; path=/";
+    document.cookie = `userInfo=${encodeURIComponent(
+      JSON.stringify({ id: "u_e2e", _id: "u_e2e", role: "educator", name: "E2E" })
+    )}; path=/`;
+  });
+});
+
+test("drag and drop uploads a valid PDF and the scan resolves to accepted", async ({
+  page,
+}) => {
+  const requested = await stubDocumentApi(page, {
+    scanSequence: ["scan_pending", "accepted"],
+  });
+
+  await page.goto("/educator-onboarding/documents");
+
+  const slot = page.getByTestId("document-slot-government_id");
+  await expect(slot).toBeVisible();
+
+  // Drop a real PDF onto the dropzone.
+  const dataTransfer = await page.evaluateHandle((bytes) => {
+    const dt = new DataTransfer();
+    dt.items.add(
+      new File([new Uint8Array(bytes)], "passport.pdf", {
+        type: "application/pdf",
+      })
+    );
+    return dt;
+  }, Array.from(PDF_BYTES));
+
+  await page
+    .getByTestId("dropzone-government_id")
+    .dispatchEvent("drop", { dataTransfer });
+
+  // Scan pending is shown, then resolves to accepted.
+  await expect(page.getByTestId("scan-pending-government_id")).toBeVisible();
+  await expect(page.getByTestId("slot-status")).toHaveAttribute(
+    "data-state",
+    "accepted",
+    { timeout: 15_000 }
+  );
+
+  // The full signed-URL sequence ran.
+  expect(requested).toContain("upload-url");
+  expect(requested).toContain("signed-put");
+  expect(requested).toContain("complete");
+
+  // No public asset URL anywhere in the DOM.
+  const html = await page.content();
+  expect(html).not.toContain("cloudinary");
+  expect(html).not.toContain(SIGNED_URL);
+});
+
+test("a renamed executable is rejected before any network call", async ({
+  page,
+}) => {
+  const requested = await stubDocumentApi(page);
+
+  await page.goto("/educator-onboarding/documents");
+
+  const dataTransfer = await page.evaluateHandle((bytes) => {
+    const dt = new DataTransfer();
+    // Declares application/pdf; the bytes say Windows executable.
+    dt.items.add(
+      new File([new Uint8Array(bytes)], "passport.pdf", {
+        type: "application/pdf",
+      })
+    );
+    return dt;
+  }, Array.from(EXE_BYTES));
+
+  await page
+    .getByTestId("dropzone-government_id")
+    .dispatchEvent("drop", { dataTransfer });
+
+  await expect(page.getByTestId("error-government_id")).toContainText(
+    /Windows executable/i
+  );
+
+  // Nothing was requested — the file never left the browser.
+  expect(requested).toEqual([]);
+});
+
+test("the camera input is present and capture-enabled", async ({ page }) => {
+  await stubDocumentApi(page);
+  await page.goto("/educator-onboarding/documents");
+
+  const cameraInput = page.getByTestId("camera-input-government_id");
+  await expect(cameraInput).toHaveAttribute("capture", "environment");
+  await expect(cameraInput).toHaveAttribute("accept", "image/*");
+});

--- a/hooks/useDocumentUpload.js
+++ b/hooks/useDocumentUpload.js
@@ -1,0 +1,379 @@
+"use client";
+/**
+ * useDocumentUpload
+ * -----------------
+ * Owns the per-slot lifecycle for educator KYC document uploads.
+ *
+ * Slot lifecycle
+ * --------------
+ *   empty → validating → requesting → uploading → scanning → accepted
+ *                     ↘ error                            ↘ rejected
+ *
+ * `validating` runs entirely on the client and is the ONLY gate that can stop
+ * a file before a signed upload target is requested. A file that fails
+ * validation never reaches `requesting`, so no network call is made for it —
+ * that is the property __tests__/documents/magicBytes.test.js pins down.
+ *
+ * What this hook stores
+ * ---------------------
+ * Per slot: display metadata (name/size), progress, an in-memory object URL
+ * for image previews, and the opaque document reference `{ documentId,
+ * status }`. It never stores a remote URL, because none is ever produced —
+ * see lib/actions/educators/uploadDocument.js.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { validateDocumentFile } from "@/lib/verification/documents/policy";
+import {
+  DOCUMENT_STATUS,
+  fetchDocumentStatus,
+  finalizeUpload,
+  isTerminalStatus,
+  removeDocument as removeDocumentRequest,
+  requestUploadTarget,
+  uploadToSignedTarget,
+} from "@/lib/actions/educators/uploadDocument";
+
+// ── Slot states ────────────────────────────────────────────────────────────
+
+export const SLOT_STATE = /** @type {const} */ ({
+  EMPTY: "empty",
+  VALIDATING: "validating",
+  REQUESTING: "requesting",
+  UPLOADING: "uploading",
+  SCANNING: "scanning",
+  ACCEPTED: "accepted",
+  REJECTED: "rejected",
+  ERROR: "error",
+});
+
+const EMPTY_SLOT = Object.freeze({
+  state: SLOT_STATE.EMPTY,
+  progress: 0,
+  error: null,
+  errorReason: null,
+  filename: null,
+  size: null,
+  mimeType: null,
+  previewUrl: null,
+  reference: null,
+  scanMessage: null,
+});
+
+/** Map a document scan status onto a slot state. */
+function slotStateForStatus(status) {
+  if (status === DOCUMENT_STATUS.ACCEPTED) return SLOT_STATE.ACCEPTED;
+  if (status === DOCUMENT_STATUS.REJECTED) return SLOT_STATE.REJECTED;
+  return SLOT_STATE.SCANNING;
+}
+
+/** Object URLs are only useful for formats the browser can render inline. */
+function makePreviewUrl(file) {
+  if (typeof URL?.createObjectURL !== "function") return null;
+  if (!String(file.type).startsWith("image/")) return null;
+  return URL.createObjectURL(file);
+}
+
+function revokePreviewUrl(url) {
+  if (url && typeof URL?.revokeObjectURL === "function") {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/**
+ * @param {Object} [options]
+ * @param {number} [options.pollIntervalMs] gap between scan-status polls
+ * @param {number} [options.maxPollAttempts] give up after this many polls
+ */
+export function useDocumentUpload(options = {}) {
+  const { pollIntervalMs = 3000, maxPollAttempts = 20 } = options;
+
+  const [slots, setSlots] = useState({});
+
+  // Live refs so async work can bail out after unmount without setting state.
+  const mountedRef = useRef(true);
+  const abortControllersRef = useRef({});
+  const previewUrlsRef = useRef({});
+  const timersRef = useRef([]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      Object.values(abortControllersRef.current).forEach((c) => c?.abort());
+      Object.values(previewUrlsRef.current).forEach(revokePreviewUrl);
+      timersRef.current.forEach(clearTimeout);
+      timersRef.current = [];
+    };
+  }, []);
+
+  const patchSlot = useCallback((documentType, patch) => {
+    if (!mountedRef.current) return;
+    setSlots((prev) => ({
+      ...prev,
+      [documentType]: { ...EMPTY_SLOT, ...prev[documentType], ...patch },
+    }));
+  }, []);
+
+  const setPreviewUrl = useCallback((documentType, url) => {
+    revokePreviewUrl(previewUrlsRef.current[documentType]);
+    previewUrlsRef.current[documentType] = url;
+  }, []);
+
+  const sleep = useCallback(
+    (ms) =>
+      new Promise((resolve) => {
+        const id = setTimeout(resolve, ms);
+        timersRef.current.push(id);
+      }),
+    []
+  );
+
+  // ── Scan polling ─────────────────────────────────────────────────────────
+
+  const pollScanStatus = useCallback(
+    async (documentType, documentId) => {
+      for (let attempt = 0; attempt < maxPollAttempts; attempt += 1) {
+        await sleep(pollIntervalMs);
+        if (!mountedRef.current) return;
+
+        let result;
+        try {
+          result = await fetchDocumentStatus(documentId);
+        } catch {
+          // A transient status-check failure is not an upload failure; the
+          // document is already stored. Keep waiting.
+          continue;
+        }
+
+        if (!mountedRef.current) return;
+
+        if (isTerminalStatus(result.status)) {
+          patchSlot(documentType, {
+            state: slotStateForStatus(result.status),
+            scanMessage: result.scanMessage,
+            error:
+              result.status === DOCUMENT_STATUS.REJECTED
+                ? result.scanMessage ??
+                  "This document was rejected by the security scan."
+                : null,
+            reference: {
+              documentId,
+              documentType,
+              status: result.status,
+            },
+          });
+          return;
+        }
+      }
+
+      // Ran out of attempts — leave the slot in `scanning`; the review queue
+      // will resolve it and the status center reflects the final state.
+    },
+    [maxPollAttempts, patchSlot, pollIntervalMs, sleep]
+  );
+
+  // ── Upload ───────────────────────────────────────────────────────────────
+
+  /**
+   * Validate then upload a file into a slot.
+   *
+   * @param {string} documentType
+   * @param {File} file
+   * @returns {Promise<{ ok: boolean, reason?: string, reference?: Object }>}
+   */
+  const uploadDocument = useCallback(
+    async (documentType, file) => {
+      // ── Client gate — nothing below this runs unless the file is valid ──
+      patchSlot(documentType, {
+        state: SLOT_STATE.VALIDATING,
+        progress: 0,
+        error: null,
+        errorReason: null,
+        filename: file?.name ?? null,
+        size: file?.size ?? null,
+        mimeType: file?.type ?? null,
+        previewUrl: null,
+        scanMessage: null,
+      });
+
+      const validation = await validateDocumentFile(file);
+
+      if (!validation.valid) {
+        setPreviewUrl(documentType, null);
+        patchSlot(documentType, {
+          state: SLOT_STATE.ERROR,
+          error: validation.error,
+          errorReason: validation.reason,
+          previewUrl: null,
+          reference: null,
+        });
+        return { ok: false, reason: validation.reason };
+      }
+
+      const previewUrl = makePreviewUrl(file);
+      setPreviewUrl(documentType, previewUrl);
+
+      const controller =
+        typeof AbortController === "function" ? new AbortController() : null;
+      abortControllersRef.current[documentType] = controller;
+
+      try {
+        // ── Signed target ────────────────────────────────────────────────
+        patchSlot(documentType, {
+          state: SLOT_STATE.REQUESTING,
+          previewUrl,
+          progress: 0,
+        });
+
+        const target = await requestUploadTarget({
+          documentType,
+          filename: file.name,
+          // The VERIFIED type from the magic bytes, not the browser's guess.
+          contentType: validation.detectedMime,
+          size: file.size,
+        });
+
+        // ── Bytes ────────────────────────────────────────────────────────
+        patchSlot(documentType, { state: SLOT_STATE.UPLOADING, progress: 0 });
+
+        await uploadToSignedTarget({
+          uploadUrl: target.uploadUrl,
+          method: target.method,
+          headers: target.headers,
+          file,
+          signal: controller?.signal,
+          onProgress: (percent) =>
+            patchSlot(documentType, {
+              state: SLOT_STATE.UPLOADING,
+              progress: percent,
+            }),
+        });
+
+        // ── Finalise → scanning ──────────────────────────────────────────
+        patchSlot(documentType, { progress: 100, state: SLOT_STATE.SCANNING });
+
+        const reference = await finalizeUpload({
+          documentId: target.documentId,
+          documentType,
+        });
+
+        patchSlot(documentType, {
+          state: slotStateForStatus(reference.status),
+          reference,
+          scanMessage: reference.scanMessage,
+          progress: 100,
+        });
+
+        if (!isTerminalStatus(reference.status)) {
+          pollScanStatus(documentType, reference.documentId);
+        }
+
+        return { ok: true, reference };
+      } catch (err) {
+        if (err?.code === "ERR_CANCELED") {
+          return { ok: false, reason: "cancelled" };
+        }
+        patchSlot(documentType, {
+          state: SLOT_STATE.ERROR,
+          error: err?.message ?? "Upload failed",
+          errorReason: "upload_failed",
+          reference: null,
+        });
+        return { ok: false, reason: "upload_failed" };
+      } finally {
+        delete abortControllersRef.current[documentType];
+      }
+    },
+    [patchSlot, pollScanStatus, setPreviewUrl]
+  );
+
+  // ── Remove ───────────────────────────────────────────────────────────────
+
+  /**
+   * Clear a slot, deleting the stored document if one was created.
+   * @param {string} documentType
+   */
+  const removeSlot = useCallback(
+    async (documentType) => {
+      abortControllersRef.current[documentType]?.abort();
+
+      const existingId = slots[documentType]?.reference?.documentId;
+
+      if (existingId) {
+        try {
+          await removeDocumentRequest(existingId);
+        } catch (err) {
+          patchSlot(documentType, {
+            error: err?.message ?? "Could not remove the document",
+            errorReason: "remove_failed",
+          });
+          return { ok: false };
+        }
+      }
+
+      setPreviewUrl(documentType, null);
+
+      if (!mountedRef.current) return { ok: true };
+      setSlots((prev) => {
+        const next = { ...prev };
+        delete next[documentType];
+        return next;
+      });
+
+      return { ok: true };
+    },
+    [patchSlot, setPreviewUrl, slots]
+  );
+
+  // ── Replace ──────────────────────────────────────────────────────────────
+
+  /**
+   * Swap the file in a slot. The previously stored document is deleted first
+   * so a replaced document never lingers in the review queue.
+   *
+   * @param {string} documentType
+   * @param {File} file
+   */
+  const replaceDocument = useCallback(
+    async (documentType, file) => {
+      const existingId = slots[documentType]?.reference?.documentId;
+
+      if (existingId) {
+        try {
+          await removeDocumentRequest(existingId);
+        } catch {
+          // Deleting the old copy is best-effort — the new upload still
+          // supersedes it in the review queue.
+        }
+      }
+
+      return uploadDocument(documentType, file);
+    },
+    [slots, uploadDocument]
+  );
+
+  const reset = useCallback(() => {
+    Object.values(abortControllersRef.current).forEach((c) => c?.abort());
+    Object.values(previewUrlsRef.current).forEach(revokePreviewUrl);
+    previewUrlsRef.current = {};
+    if (mountedRef.current) setSlots({});
+  }, []);
+
+  /** @param {string} documentType */
+  const getSlot = useCallback(
+    (documentType) => slots[documentType] ?? EMPTY_SLOT,
+    [slots]
+  );
+
+  return {
+    slots,
+    getSlot,
+    uploadDocument,
+    replaceDocument,
+    removeDocument: removeSlot,
+    reset,
+  };
+}
+
+export default useDocumentUpload;

--- a/hooks/useDocumentUpload.js
+++ b/hooks/useDocumentUpload.js
@@ -266,7 +266,10 @@ export function useDocumentUpload(options = {}) {
         });
 
         if (!isTerminalStatus(reference.status)) {
-          pollScanStatus(documentType, reference.documentId);
+          // Deliberately not awaited — the upload is done and the caller
+          // shouldn't block on the scan. Errors are swallowed inside the poll
+          // loop; the catch here only guards against an unhandled rejection.
+          pollScanStatus(documentType, reference.documentId).catch(() => {});
         }
 
         return { ok: true, reference };

--- a/lib/actions/educators/uploadDocument.js
+++ b/lib/actions/educators/uploadDocument.js
@@ -1,0 +1,267 @@
+/**
+ * Verification-document upload
+ * ----------------------------
+ * Uploads educator KYC documents (government ID, teaching certificate) to
+ * private storage via a short-lived signed URL, so that no publicly reachable
+ * asset URL is ever produced or stored.
+ *
+ * Why not the existing Cloudinary helper
+ * --------------------------------------
+ * lib/utils/cloudinaryUpload.js posts to an UNSIGNED upload preset and returns
+ * `result.secure_url` — a permanently public asset URL. That is fine for a
+ * course thumbnail and unacceptable for a passport scan. Identity documents
+ * must never travel through that path; __tests__/documents/noPublicUrl.test.js
+ * asserts this module never imports it.
+ *
+ * Flow (contract agreed with the educator-verification pipeline, dnb-backend#92)
+ * ------------------------------------------------------------------------------
+ *   1. POST /api/educators/applications/documents/upload-url
+ *        → { documentId, uploadUrl, method, headers, expiresAt }
+ *      The signed URL is short-lived and write-only.
+ *
+ *   2. PUT/POST the raw bytes to `uploadUrl`.
+ *      This request goes to the storage provider, NOT to our API, so it is
+ *      sent with a bare axios client — our Authorization header must never
+ *      leak to a third-party origin.
+ *
+ *   3. POST /api/educators/applications/documents/:id/complete
+ *        → { documentId, status: "scan_pending" | "accepted" | "rejected" }
+ *      Server-side malware scanning starts here.
+ *
+ *   4. GET  /api/educators/applications/documents/:id  (poll)
+ *        → { documentId, status, scanMessage }
+ *
+ * What is stored client-side
+ * --------------------------
+ * Only the opaque `documentId` and its status. Never a URL. Reading a document
+ * back is a separate, deliberate call (`fetchDocumentSignedUrl` in
+ * fetchVerificationStatus.js) that mints a fresh time-limited URL on demand.
+ */
+
+import axios from "axios";
+import axiosInstance from "@/lib/config/axios.config";
+
+// ── Document scan lifecycle ────────────────────────────────────────────────
+
+export const DOCUMENT_STATUS = /** @type {const} */ ({
+  SCAN_PENDING: "scan_pending",
+  ACCEPTED: "accepted",
+  REJECTED: "rejected",
+});
+
+/** @typedef {typeof DOCUMENT_STATUS[keyof typeof DOCUMENT_STATUS]} DocumentStatus */
+
+/** Statuses that mean the scan has finished, one way or the other. */
+const TERMINAL_STATUSES = new Set([
+  DOCUMENT_STATUS.ACCEPTED,
+  DOCUMENT_STATUS.REJECTED,
+]);
+
+export const isTerminalStatus = (status) => TERMINAL_STATUSES.has(status);
+
+/** Normalise whatever the backend returns onto the three known statuses. */
+function normaliseStatus(raw) {
+  const value = String(raw ?? "").toLowerCase();
+  if (value === DOCUMENT_STATUS.ACCEPTED || value === "clean") {
+    return DOCUMENT_STATUS.ACCEPTED;
+  }
+  if (
+    value === DOCUMENT_STATUS.REJECTED ||
+    value === "infected" ||
+    value === "quarantined"
+  ) {
+    return DOCUMENT_STATUS.REJECTED;
+  }
+  return DOCUMENT_STATUS.SCAN_PENDING;
+}
+
+/** Turn an axios failure into a plain Error with the backend's message. */
+function toError(err, fallback) {
+  return new Error(
+    err?.response?.data?.message ?? err?.message ?? fallback
+  );
+}
+
+// ── Step 1 — request a signed upload target ────────────────────────────────
+
+/**
+ * @param {Object} params
+ * @param {string} params.documentType  one of DOCUMENT_TYPES
+ * @param {string} params.filename
+ * @param {string} params.contentType   the VERIFIED mime (from magic bytes)
+ * @param {number} params.size
+ * @returns {Promise<{documentId: string, uploadUrl: string, method: string, headers: Object, expiresAt: string}>}
+ */
+export async function requestUploadTarget({
+  documentType,
+  filename,
+  contentType,
+  size,
+}) {
+  if (!documentType) throw new Error("documentType is required");
+  if (!contentType) throw new Error("contentType is required");
+
+  try {
+    const res = await axiosInstance.post(
+      "/api/educators/applications/documents/upload-url",
+      { documentType, filename, contentType, size }
+    );
+
+    const { documentId, uploadUrl, method, headers, expiresAt } = res.data ?? {};
+
+    if (!documentId || !uploadUrl) {
+      throw new Error("Upload target response was incomplete");
+    }
+
+    return {
+      documentId,
+      uploadUrl,
+      method: (method ?? "PUT").toUpperCase(),
+      headers: headers ?? { "Content-Type": contentType },
+      expiresAt: expiresAt ?? null,
+    };
+  } catch (err) {
+    throw toError(err, "Could not start the upload");
+  }
+}
+
+// ── Step 2 — send the bytes to the signed target ───────────────────────────
+
+/**
+ * Uploads the raw file to the signed URL.
+ *
+ * Deliberately uses a BARE axios call rather than axiosInstance: the signed URL
+ * points at the storage provider, and the app's request interceptor would
+ * otherwise attach the user's Authorization bearer token to a third-party
+ * origin.
+ *
+ * @param {Object} params
+ * @param {string} params.uploadUrl
+ * @param {string} params.method
+ * @param {Object} params.headers
+ * @param {File}   params.file
+ * @param {(percent: number) => void} [params.onProgress]
+ * @param {AbortSignal} [params.signal]
+ * @returns {Promise<void>}
+ */
+export async function uploadToSignedTarget({
+  uploadUrl,
+  method = "PUT",
+  headers = {},
+  file,
+  onProgress,
+  signal,
+}) {
+  try {
+    await axios.request({
+      url: uploadUrl,
+      method,
+      data: file,
+      headers,
+      signal,
+      // Never send cookies or credentials to the storage origin.
+      withCredentials: false,
+      onUploadProgress: (event) => {
+        if (!onProgress) return;
+        const total = event.total ?? file?.size;
+        if (!total) return;
+        onProgress(Math.min(100, Math.round((event.loaded / total) * 100)));
+      },
+    });
+  } catch (err) {
+    if (axios.isCancel?.(err) || err?.code === "ERR_CANCELED") {
+      throw err;
+    }
+    throw toError(err, "Upload failed");
+  }
+}
+
+// ── Step 3 — finalise, which kicks off malware scanning ────────────────────
+
+/**
+ * @param {Object} params
+ * @param {string} params.documentId
+ * @param {string} params.documentType
+ * @returns {Promise<{documentId: string, documentType: string, status: DocumentStatus, filename: string|null, uploadedAt: string|null, scanMessage: string|null}>}
+ */
+export async function finalizeUpload({ documentId, documentType }) {
+  if (!documentId) throw new Error("documentId is required");
+
+  try {
+    const res = await axiosInstance.post(
+      `/api/educators/applications/documents/${documentId}/complete`,
+      { documentType }
+    );
+
+    return toDocumentReference(res.data ?? {}, { documentId, documentType });
+  } catch (err) {
+    throw toError(err, "Could not finish the upload");
+  }
+}
+
+// ── Step 4 — poll scan status ──────────────────────────────────────────────
+
+/**
+ * @param {string} documentId
+ * @returns {Promise<{documentId: string, status: DocumentStatus, scanMessage: string|null}>}
+ */
+export async function fetchDocumentStatus(documentId) {
+  if (!documentId) throw new Error("documentId is required");
+
+  try {
+    const res = await axiosInstance.get(
+      `/api/educators/applications/documents/${documentId}`
+    );
+    const data = res.data ?? {};
+    return {
+      documentId: data.documentId ?? documentId,
+      status: normaliseStatus(data.status),
+      scanMessage: data.scanMessage ?? null,
+    };
+  } catch (err) {
+    throw toError(err, "Could not check the scan status");
+  }
+}
+
+// ── Remove ─────────────────────────────────────────────────────────────────
+
+/**
+ * Deletes a previously uploaded document. Used by both "remove" and the first
+ * half of "replace".
+ *
+ * @param {string} documentId
+ * @returns {Promise<void>}
+ */
+export async function removeDocument(documentId) {
+  if (!documentId) throw new Error("documentId is required");
+
+  try {
+    await axiosInstance.delete(
+      `/api/educators/applications/documents/${documentId}`
+    );
+  } catch (err) {
+    throw toError(err, "Could not remove the document");
+  }
+}
+
+// ── Reference shape stored client-side ─────────────────────────────────────
+
+/**
+ * The ONLY document shape the client keeps. Note the absence of any URL field:
+ * viewing a document requires a fresh signed URL minted on demand.
+ *
+ * @param {Object} raw
+ * @param {Object} defaults
+ */
+function toDocumentReference(raw, defaults = {}) {
+  return {
+    documentId: raw.documentId ?? raw.id ?? defaults.documentId ?? null,
+    documentType: raw.documentType ?? raw.type ?? defaults.documentType ?? null,
+    status: normaliseStatus(raw.status),
+    filename: raw.filename ?? defaults.filename ?? null,
+    uploadedAt: raw.uploadedAt ?? null,
+    scanMessage: raw.scanMessage ?? null,
+  };
+}
+
+export { toDocumentReference };

--- a/lib/verification/documents/fileSignature.js
+++ b/lib/verification/documents/fileSignature.js
@@ -1,0 +1,148 @@
+/**
+ * File signature (magic byte) inspection
+ * --------------------------------------
+ * `File.type` is the browser's guess, derived from the file extension. It is
+ * attacker-controlled: renaming `payload.exe` to `passport.pdf` produces a File
+ * whose `.type` is `application/pdf`. A type- or size-only check cannot tell
+ * the difference — only the leading bytes can.
+ *
+ * This module reads the first bytes of a File and reports what the content
+ * actually is, independent of its name or declared MIME type.
+ *
+ * Nothing here touches the network. It is a pure pre-flight gate that runs
+ * before any upload target is even requested.
+ */
+
+/** How many leading bytes we need to identify every signature below. */
+export const SIGNATURE_BYTE_LENGTH = 12;
+
+/**
+ * Signatures for the formats we accept for KYC documents.
+ * Each entry lists the byte prefix(es) that identify the format.
+ */
+const ACCEPTED_SIGNATURES = [
+  {
+    mime: "application/pdf",
+    label: "PDF",
+    // "%PDF-"
+    prefixes: [[0x25, 0x50, 0x44, 0x46, 0x2d]],
+  },
+  {
+    mime: "image/jpeg",
+    label: "JPEG image",
+    // SOI marker + first marker byte
+    prefixes: [[0xff, 0xd8, 0xff]],
+  },
+  {
+    mime: "image/png",
+    label: "PNG image",
+    prefixes: [[0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]],
+  },
+];
+
+/**
+ * Signatures we explicitly name when rejecting, so the user (and the audit
+ * log) get a meaningful reason instead of a generic "invalid file".
+ */
+const KNOWN_HOSTILE_SIGNATURES = [
+  { label: "Windows executable", prefixes: [[0x4d, 0x5a]] }, // "MZ"
+  { label: "Linux executable", prefixes: [[0x7f, 0x45, 0x4c, 0x46]] }, // ELF
+  {
+    label: "Mach-O executable",
+    prefixes: [
+      [0xfe, 0xed, 0xfa, 0xce],
+      [0xfe, 0xed, 0xfa, 0xcf],
+      [0xcf, 0xfa, 0xed, 0xfe],
+      [0xca, 0xfe, 0xba, 0xbe],
+    ],
+  },
+  { label: "ZIP or Office archive", prefixes: [[0x50, 0x4b, 0x03, 0x04]] },
+  { label: "RAR archive", prefixes: [[0x52, 0x61, 0x72, 0x21]] },
+  { label: "gzip archive", prefixes: [[0x1f, 0x8b]] },
+  { label: "Shell script", prefixes: [[0x23, 0x21]] }, // "#!"
+];
+
+/**
+ * Read the first bytes of a File/Blob.
+ *
+ * @param {Blob} file
+ * @param {number} [length]
+ * @returns {Promise<Uint8Array>}
+ */
+export async function readMagicBytes(file, length = SIGNATURE_BYTE_LENGTH) {
+  const slice = file.slice(0, length);
+
+  // Blob.arrayBuffer() is the modern path; FileReader is the fallback for
+  // older Safari/WebView, which the mobile capture flow still has to support.
+  if (typeof slice.arrayBuffer === "function") {
+    return new Uint8Array(await slice.arrayBuffer());
+  }
+
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(new Uint8Array(reader.result));
+    reader.onerror = () => reject(reader.error ?? new Error("Unreadable file"));
+    reader.readAsArrayBuffer(slice);
+  });
+}
+
+/**
+ * @param {Uint8Array} bytes
+ * @param {number[]} prefix
+ */
+function startsWith(bytes, prefix) {
+  if (bytes.length < prefix.length) return false;
+  return prefix.every((byte, i) => bytes[i] === byte);
+}
+
+/**
+ * Identify a byte prefix against the accepted-format table.
+ *
+ * @param {Uint8Array} bytes
+ * @returns {{ mime: string, label: string } | null} null when unrecognised
+ */
+export function identifySignature(bytes) {
+  for (const entry of ACCEPTED_SIGNATURES) {
+    if (entry.prefixes.some((prefix) => startsWith(bytes, prefix))) {
+      return { mime: entry.mime, label: entry.label };
+    }
+  }
+  return null;
+}
+
+/**
+ * Name a recognisably hostile payload, for a clearer rejection message.
+ *
+ * @param {Uint8Array} bytes
+ * @returns {string | null}
+ */
+export function identifyHostileSignature(bytes) {
+  for (const entry of KNOWN_HOSTILE_SIGNATURES) {
+    if (entry.prefixes.some((prefix) => startsWith(bytes, prefix))) {
+      return entry.label;
+    }
+  }
+  return null;
+}
+
+/**
+ * Inspect a File and report the content type its bytes actually declare.
+ *
+ * @param {File|Blob} file
+ * @returns {Promise<{
+ *   detectedMime: string | null,
+ *   detectedLabel: string | null,
+ *   hostileLabel: string | null,
+ *   bytes: Uint8Array,
+ * }>}
+ */
+export async function inspectFileSignature(file) {
+  const bytes = await readMagicBytes(file);
+  const accepted = identifySignature(bytes);
+  return {
+    detectedMime: accepted?.mime ?? null,
+    detectedLabel: accepted?.label ?? null,
+    hostileLabel: accepted ? null : identifyHostileSignature(bytes),
+    bytes,
+  };
+}

--- a/lib/verification/documents/policy.js
+++ b/lib/verification/documents/policy.js
@@ -1,0 +1,214 @@
+/**
+ * Verification-document policy
+ * ----------------------------
+ * The single source of truth for what an educator may upload as KYC evidence,
+ * and the pre-flight gate that runs BEFORE any network call is made.
+ *
+ * Three checks, in order — cheapest and most conclusive first:
+ *   1. Declared MIME must be in the allow-list (catches obvious mistakes).
+ *   2. Size must be within the per-type limit (catches oversized files before
+ *      we waste a signed URL on them).
+ *   3. The leading bytes must actually match the declared type. This is the
+ *      check `File.type` cannot do: a renamed `.exe` declares
+ *      `application/pdf` and passes 1 and 2, but its first bytes are `MZ`.
+ *
+ * Nothing in this module performs I/O beyond reading the first 12 bytes of the
+ * File the user selected.
+ */
+
+import { inspectFileSignature } from "./fileSignature";
+
+// ── Document slots ─────────────────────────────────────────────────────────
+
+/**
+ * Document types the educator-application review queue (dnb-backend#92)
+ * accepts. `type` is the value sent as document metadata.
+ */
+export const DOCUMENT_TYPES = /** @type {const} */ ({
+  GOVERNMENT_ID: "government_id",
+  TEACHING_CERTIFICATE: "teaching_certificate",
+  SUPPORTING_DOCUMENT: "supporting_document",
+});
+
+/** @typedef {typeof DOCUMENT_TYPES[keyof typeof DOCUMENT_TYPES]} DocumentType */
+
+export const DOCUMENT_SLOTS = [
+  {
+    type: DOCUMENT_TYPES.GOVERNMENT_ID,
+    label: "Government ID",
+    description:
+      "Passport, national ID card, or driver's licence. All four corners visible.",
+    required: true,
+    allowCamera: true,
+  },
+  {
+    type: DOCUMENT_TYPES.TEACHING_CERTIFICATE,
+    label: "Teaching or school certificate",
+    description:
+      "Ijazah, teaching licence, or a certificate from the institution you teach at.",
+    required: true,
+    allowCamera: true,
+  },
+  {
+    type: DOCUMENT_TYPES.SUPPORTING_DOCUMENT,
+    label: "Supporting document",
+    description: "Optional — anything else that supports your application.",
+    required: false,
+    allowCamera: false,
+  },
+];
+
+// ── Limits ─────────────────────────────────────────────────────────────────
+
+/** Accepted MIME types. Anything else is rejected before upload. */
+export const ALLOWED_MIME_TYPES = Object.freeze([
+  "application/pdf",
+  "image/jpeg",
+  "image/png",
+]);
+
+/** Value for an <input type="file" accept="..."> attribute. */
+export const ACCEPT_ATTRIBUTE = ALLOWED_MIME_TYPES.join(",");
+
+/** 10 MB — comfortably above a phone photo, well below an abuse vector. */
+export const MAX_DOCUMENT_BYTES = 10 * 1024 * 1024;
+
+/** Human labels used in error copy. */
+const MIME_LABELS = {
+  "application/pdf": "PDF",
+  "image/jpeg": "JPEG",
+  "image/png": "PNG",
+};
+
+/** JPEG has two interchangeable MIME spellings. */
+function normaliseMime(mime) {
+  const value = String(mime ?? "").toLowerCase().trim();
+  return value === "image/jpg" ? "image/jpeg" : value;
+}
+
+/**
+ * @param {number} bytes
+ * @returns {string}
+ */
+export function formatBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1
+  );
+  const value = bytes / 1024 ** exponent;
+  return `${Math.round(value * 10) / 10} ${units[exponent]}`;
+}
+
+// ── Rejection reasons ──────────────────────────────────────────────────────
+
+export const REJECTION = /** @type {const} */ ({
+  EMPTY: "empty",
+  TYPE_NOT_ALLOWED: "type_not_allowed",
+  TOO_LARGE: "too_large",
+  SIGNATURE_MISMATCH: "signature_mismatch",
+  SIGNATURE_UNRECOGNISED: "signature_unrecognised",
+  UNREADABLE: "unreadable",
+});
+
+/**
+ * @typedef {Object} ValidationResult
+ * @property {boolean} valid
+ * @property {string|null} reason   machine-readable REJECTION code
+ * @property {string|null} error    human-readable message shown inline
+ * @property {string|null} detectedMime  what the bytes actually say
+ */
+
+/** @returns {ValidationResult} */
+function reject(reason, error) {
+  return { valid: false, reason, error, detectedMime: null };
+}
+
+/**
+ * Validate a file for use as a verification document.
+ *
+ * Async because the signature check reads bytes off the File. Callers MUST
+ * await this and MUST NOT start an upload unless `valid` is true.
+ *
+ * @param {File} file
+ * @param {Object} [options]
+ * @param {number} [options.maxBytes]
+ * @param {string[]} [options.allowedMimeTypes]
+ * @returns {Promise<ValidationResult>}
+ */
+export async function validateDocumentFile(file, options = {}) {
+  const {
+    maxBytes = MAX_DOCUMENT_BYTES,
+    allowedMimeTypes = ALLOWED_MIME_TYPES,
+  } = options;
+
+  if (!file) {
+    return reject(REJECTION.EMPTY, "No file selected.");
+  }
+
+  if (file.size === 0) {
+    return reject(REJECTION.EMPTY, "That file is empty.");
+  }
+
+  // ── 1. Declared type ─────────────────────────────────────────────────────
+  const declaredMime = normaliseMime(file.type);
+  const allowed = allowedMimeTypes.map(normaliseMime);
+
+  if (!allowed.includes(declaredMime)) {
+    const names = allowedMimeTypes
+      .map((mime) => MIME_LABELS[mime] ?? mime)
+      .join(", ");
+    return reject(
+      REJECTION.TYPE_NOT_ALLOWED,
+      `${
+        MIME_LABELS[declaredMime] ?? (declaredMime || "That file type")
+      } isn't accepted. Upload a ${names}.`
+    );
+  }
+
+  // ── 2. Size ──────────────────────────────────────────────────────────────
+  if (file.size > maxBytes) {
+    return reject(
+      REJECTION.TOO_LARGE,
+      `That file is ${formatBytes(file.size)}. The limit is ${formatBytes(
+        maxBytes
+      )}.`
+    );
+  }
+
+  // ── 3. Content signature ─────────────────────────────────────────────────
+  let inspection;
+  try {
+    inspection = await inspectFileSignature(file);
+  } catch {
+    return reject(
+      REJECTION.UNREADABLE,
+      "That file couldn't be read. Try selecting it again."
+    );
+  }
+
+  const { detectedMime, hostileLabel } = inspection;
+
+  if (!detectedMime) {
+    return reject(
+      REJECTION.SIGNATURE_UNRECOGNISED,
+      hostileLabel
+        ? `That file is a ${hostileLabel}, not a document. Upload a PDF, JPEG, or PNG.`
+        : "That file's contents don't match a PDF, JPEG, or PNG."
+    );
+  }
+
+  if (detectedMime !== declaredMime) {
+    return reject(
+      REJECTION.SIGNATURE_MISMATCH,
+      `That file is named like a ${
+        MIME_LABELS[declaredMime] ?? declaredMime
+      } but its contents are a ${
+        MIME_LABELS[detectedMime] ?? detectedMime
+      }. Upload the original document.`
+    );
+  }
+
+  return { valid: true, reason: null, error: null, detectedMime };
+}


### PR DESCRIPTION
Closes #172

## What this adds

A secure upload surface for educator KYC documents, reachable at **`/educator-onboarding/documents`**. The liveness capture step now routes here on success instead of jumping straight to `/profile-setup`, so the step is wired into the real flow rather than sitting unused.

```
lib/verification/documents/fileSignature.js   magic-byte inspection
lib/verification/documents/policy.js          slots, limits, the pre-flight gate
lib/actions/educators/uploadDocument.js       signed-URL upload / finalise / poll / delete
hooks/useDocumentUpload.js                    per-slot state machine
components/organisms/educator-onboarding/DocumentUpload.jsx
app/[locale]/educator-onboarding/documents/page.jsx
docs/secure-document-upload.md
```

## Client pre-flight

`validateDocumentFile()` runs three checks before any network call:

1. declared MIME is PDF / JPEG / PNG
2. size ≤ 10 MB
3. **the leading bytes actually match the declared type**

Check 3 is the one that matters. `File.type` comes from the filename and is attacker-controlled. `fileSignature.js` reads the first 12 bytes and compares against `%PDF-`, `FF D8 FF`, and the PNG 8-byte header, and names recognisably hostile payloads (`MZ`, ELF, Mach-O, ZIP, RAR, gzip, `#!`) so the rejection says *why*.

A file that fails validation never reaches `requesting` — no signed target is minted for it. The tests assert zero network calls, not just a visible error.

## Signed-URL flow

Contract aligned with the educator-verification pipeline (dnb-backend#92), whose `fetchVerificationStatus.js` already documents the read side:

```
1. POST /api/educators/applications/documents/upload-url
     → { documentId, uploadUrl, method, headers, expiresAt }
2. PUT  <uploadUrl>          storage origin, short-lived, write-only
3. POST /api/educators/applications/documents/:id/complete   → starts scanning
4. GET  /api/educators/applications/documents/:id            → poll while scanning
   DELETE /api/educators/applications/documents/:id          → remove / replace
```

Step 2 deliberately uses a **bare** `axios` client with `withCredentials: false`, not the app's `axiosInstance` — the signed URL points at a third-party origin and the shared request interceptor would otherwise attach the user's bearer token to it. Both the unit test and the Playwright test assert no `Authorization` header reaches that origin.

The client stores only `{ documentId, documentType, status, filename, uploadedAt }`. There is no URL field because no durable URL is ever produced; viewing a document goes through the existing `fetchDocumentSignedUrl()`, which mints a fresh time-limited URL on demand.

`next.config.mjs` needs no new `images.remotePatterns` entry: the preview is a local `blob:` object URL built from the picked `File`, and nothing renders a stored document as a remote image.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Invalid type/size/magic-byte rejected before upload, with a visible reason | `DocumentUpload.test.jsx` — asserts the inline message **and** that `axiosInstance.post` / `axios.request` were never called |
| Retrievable only via signed URL; no public link produced or stored | `DocumentUpload.test.jsx` — stored reference has no URL field, DOM contains no remote `src`, no `cloudinary`, not even the signed URL |
| Replacing and removing updates the referenced object | `DocumentUpload.test.jsx` — replace deletes the superseded id and `onChange` reports the new one; remove clears the slot and reports `{}` |
| Camera capture and drag/drop both upload; progress renders; scan pending resolves | `DocumentUpload.test.jsx` + `e2e/documents.spec.js` (Playwright) |
| Unsigned Cloudinary preset not used for verification documents | `noPublicUpload.test.js` — static assertion over every file on the document path |
| CI stays green (lint + build + tests) | all green, see below |
| **A renamed `.exe` declaring itself a PDF is rejected before any upload/network call** | `magicBytes.test.js` + `DocumentUpload.test.jsx` + `documents.spec.js` |

## The adversarial test

The named case is covered at all three levels. The unit test first demonstrates that a type- or size-only check *cannot* catch it:

```js
expect(disguised.type).toBe("application/pdf");            // passes a type check
expect(disguised.size).toBeLessThan(MAX_DOCUMENT_BYTES);   // passes a size check

const result = await validateDocumentFile(disguised);
expect(result.valid).toBe(false);
expect(result.reason).toBe(REJECTION.SIGNATURE_UNRECOGNISED);
expect(result.error).toContain("Windows executable");
```

## Tests — all green

```
 ✓ __tests__/documents/magicBytes.test.js       (20 tests)
 ✓ __tests__/documents/DocumentUpload.test.jsx  (11 tests)
 ✓ __tests__/documents/noPublicUpload.test.js   (14 tests)
```

`DocumentUpload.test.jsx` drives the **real** component → hook → action chain. Only the two HTTP clients are mocked; validation, state machine, progress, polling and the reference shape are all real code.

### Playwright — run against a real browser and a real server

```
Running 3 tests using 1 worker
[1/3] drag and drop uploads a valid PDF and the scan resolves to accepted
[2/3] a renamed executable is rejected before any network call
[3/3] the camera input is present and capture-enabled
  3 passed (2.0m)
```

This runs `next start` and drives Chromium against `/educator-onboarding/documents`, stubbing only the backend endpoints (dnb-backend#92 is not live yet) and the storage origin via `page.route`. The rejection test asserts the intercepted-request list is **empty** — proof from outside the process that the file never left the browser.

Not wired into CI, matching the existing `e2e/i18n.spec.js` convention (CI is lint + build). Run locally with `npm run build && npx playwright test e2e/documents.spec.js`.

## Full suite, lint, build

```
Tests  164 passed (164)     # 119 on dev + 45 new
next lint                   # clean (2 pre-existing warnings, untouched)
next build                  # exit 0; /educator-onboarding/documents present in the route manifest
```

**Pre-existing failures, not from this PR:** three test *files* fail to collect on `dev` already (`bookProgress`, `VerificationBanner`, `VerificationPage`) — they import paths the `[locale]` route move relocated. Verified identical on a clean `dev` checkout.

## Scope notes

- The wizard's state machine (#1) is untouched. The document step is a separate route, so it stays resumable and deep-linkable — the status center's "Complete verification" CTA can point straight at it. The only change to `educator-onboarding/page.jsx` is the destination of `handleCaptureSuccess` (3 lines + docstring).
- Liveness (#2) and the admin viewer (#38) are out of scope and untouched.
- `lib/utils/cloudinaryUpload.js` is deliberately **not** modified. Its unsigned preset stays correct for course thumbnails; `noPublicUpload.test.js` is what keeps it out of the document path, and it asserts the course wizard still uses it.
- Endpoint paths and the `{ documentId, uploadUrl, method, headers, expiresAt }` shape are my read of the contract in `fetchVerificationStatus.js`. If the #92 assignee lands different names, the change is confined to `uploadDocument.js` — happy to adjust.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated educator onboarding step for uploading verification documents.
  - Supports drag-and-drop, file selection, camera capture, previews, progress tracking, replacement, removal, and scan-status updates.
  - Added secure uploads using short-lived signed destinations without exposing public asset URLs.

- **Security**
  - Added validation for file type, size, content signatures, and known hostile formats before upload.
  - Stores document references without exposing sensitive URLs.

- **Documentation**
  - Added guidance covering the secure document-upload workflow and validation requirements.

- **Tests**
  - Added unit, integration, static security, and end-to-end coverage for uploads, validation, scanning, and privacy safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->