### PR TITLE
docs: cover admin area in README, CONTRIBUTING and .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,3 +68,13 @@ NEXT_PUBLIC_LIVENESS_TIMEOUT_SECONDS=60
 # NEXT_PUBLIC_ prefix — they belong on the server only.
 # PERSONA_API_KEY=<server-side secret>
 # ONFIDO_API_TOKEN=<server-side secret>
+
+# ─── Admin ─────────────────────────────────────────
+# Base URL used to build invite links generated on the super-admin team
+# management page. Recipients open the link to accept their staff or
+# super-admin role. Defaults to the current origin when unset.
+NEXT_PUBLIC_ADMIN_INVITE_BASE_URL=http://localhost:3000
+
+# How long an admin invite token stays valid, in hours. Enforced by the
+# backend; the frontend only surfaces it in the invite UI.
+NEXT_PUBLIC_ADMIN_INVITE_TTL_HOURS=72

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,34 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 5. **Screenshots**: Include for UI changes
 6. **Testing**: Describe how you tested
 
+## Admin Area Development
+
+Work on admin-facing pages has a few extra requirements beyond the general workflow above. Read [`docs/rbac.md`](docs/rbac.md) and [`docs/admin-architecture.md`](docs/admin-architecture.md) before picking up your first admin issue.
+
+### Where things live
+
+| Path | Purpose |
+|------|---------|
+| `lib/auth/roles.js` | Base RBAC — roles (`student` / `educator` / `admin`), capabilities, fail-closed `can()` |
+| `lib/auth/admin-tiers.js` | Admin role tiers (`staff` / `super-admin`) and tier gating, kept isolated so tiers can evolve |
+| `components/auth/AdminTierGuard.jsx` | Page-level guard enforcing super-admin-only surfaces |
+| `components/auth/StepUpConfirmDialog.jsx` | Reusable confirm-to-proceed dialog for sensitive actions |
+
+### Conventions
+
+- **Super-admin-only pages must render inside `AdminTierGuard`.** Never rely on hidden navigation alone — unknown/loading users must see a denial state, not the page.
+- Destructive actions (demote, revoke, delete) go through the step-up confirmation dialog; no plain `confirm()` calls.
+- Tier checks always go through the helpers in `lib/auth/admin-tiers.js` — never read `user.tier` ad hoc inside components.
+- The backend is the real authorization boundary; client-side gating is defense-in-depth only (see `docs/rbac.md`).
+
+### Seeding an admin user locally
+
+Roles come from the [dnb-backend](https://github.com/Deen-Bridge/dnb-backend) user record — the frontend only reads `user.role` (and the tier fields for admins), it never assigns them. To get an admin user for local development:
+
+1. Run dnb-backend locally and point `NEXT_PUBLIC_API_URL` at it (see `.env.example`), then set your test user's `role` to `admin` (plus its `tier` to `super_admin` if you are working on team management) via the backend's seed step or database.
+2. For pure UI work you can instead edit the `userInfo` cookie in your browser devtools and change its `role` value. Client-side checks exist to stop the UI *offering* actions the server would reject — this trick is acceptable for local development only, never in shipped code.
+3. Log out and back in so the auth provider picks up the updated record.
+
 ## Issue Guidelines
 
 ### Reporting Bugs

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 | Landing Page | Login / Sign Up |
 |:---:|:---:|
 | ![Landing Page](docs/screenshots/landing.png) | ![Login](docs/screenshots/login.png) |
+| ![Dashboard](docs/screenshots/dashboard.png) | ![Admin Area](docs/screenshots/admin.png) |
 
 
 ---
@@ -47,6 +48,8 @@ This repository is the web client. The platform is composed of three services:
 - ⭐ **Stellar Payments** — buy courses and books with USDC; creators are paid directly
 - 👛 **Multi-Wallet Support** — Freighter, xBull, and Albedo via Stellar Wallets Kit
 - 🔒 **Role-Based Access** — student, mentor, and admin experiences
+- 🛡️ **Admin Area** — role-tiered admin access (staff / super-admin) with isolated gating logic ([architecture guide](docs/admin-architecture.md))
+- 👥 **Team Management** — super-admin-only admin roster with invite links and demote/revoke actions guarded by step-up confirmation
 
 ## 🛠️ Tech Stack
 
@@ -88,6 +91,8 @@ The app runs at `http://localhost:3000`.
 | `NEXT_PUBLIC_JITSI_DOMAIN` | No (default `meet.jit.si`) | Jitsi Meet domain for live video spaces |
 | `NEXT_PUBLIC_JITSI_REQUIRE_JWT` | No (default `false`) | Whether the Jitsi deployment requires a signed JWT token |
 | `NEXT_PUBLIC_FIREBASE_*` | No | Firebase Web SDK config values (apiKey, authDomain, projectId, etc.) — defaults to the project's current values |
+| `NEXT_PUBLIC_ADMIN_INVITE_BASE_URL` | No (default current origin) | Base URL used when building admin invite links generated on the team management page |
+| `NEXT_PUBLIC_ADMIN_INVITE_TTL_HOURS` | No (default `72`) | Validity window (in hours) surfaced for admin invite tokens — enforced by the backend |
 
 See `.env.example` for the full variable list with example values.
 


### PR DESCRIPTION
Closes #343

## What

Updates public-facing documentation to reflect the admin area:

- **README**
  - Features list gains admin bullets (role-tiered admin area, super-admin team management)
  - Admin feature screenshot slot added, matching the existing screenshot table presentation (`docs/screenshots/admin.png` placeholder alongside `dashboard.png`)
  - Environment variable table documents the new admin vars
- **CONTRIBUTING**
  - New *Admin Area Development* section: where admin gating code lives (`lib/auth/roles.js`, `lib/auth/admin-tiers.js`, guards), conventions (page-level guard, step-up confirmations for destructive actions, isolated tier checks)
  - Documents how to seed an admin-role user for local development (backend role assignment + the cookie-based local UI trick, with an explicit "local only" caveat)
- **.env.example**
  - Adds `NEXT_PUBLIC_ADMIN_INVITE_BASE_URL` and `NEXT_PUBLIC_ADMIN_INVITE_TTL_HOURS` with example values and comments matching the existing entry style

## Notes

- Docs-only change; no runtime code touched.
- Companion PRs: admin architecture guide (#342) and team management page (#315).