### PR TITLE
feat(admin): super-admin team management page with tiered gating and step-up confirmations

### DIFF
--- a/app/[locale]/dashboard/admin/team/page.jsx
+++ b/app/[locale]/dashboard/admin/team/page.jsx
@@ -1,0 +1,436 @@
+"use client";
+import { useState } from "react";
+import {
+  Check,
+  Copy,
+  Link2,
+  MoreHorizontal,
+  ShieldCheck,
+  UserMinus,
+  UserX,
+  Users,
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import AdminTierGuard from "@/components/auth/AdminTierGuard";
+import StepUpConfirmDialog from "@/components/auth/StepUpConfirmDialog";
+import useAuth from "@/hooks/useAuth";
+import useAdminTeam from "@/hooks/useAdminTeam";
+import { TIERS, getAdminTier } from "@/lib/auth/admin-tiers";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+
+const tierBadge = {
+  [TIERS.SUPER_ADMIN]: "bg-secondary/10 text-secondary border-secondary/20",
+  [TIERS.STAFF]: "bg-accent/10 text-accent border-accent/20",
+};
+
+const tierLabel = {
+  [TIERS.SUPER_ADMIN]: "Super admin",
+  [TIERS.STAFF]: "Staff",
+};
+
+function initials(name) {
+  return (name || "?")
+    .split(" ")
+    .map((part) => part[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase();
+}
+
+function lastActiveLabel(iso) {
+  const date = iso ? new Date(iso) : null;
+  if (!date || Number.isNaN(date.getTime())) return "Unknown";
+  return formatDistanceToNow(date, { addSuffix: true });
+}
+
+function InviteDialog({ open, onClose, onCreateInvite }) {
+  const [tier, setTier] = useState(TIERS.STAFF);
+  const [email, setEmail] = useState("");
+  const [isCreating, setIsCreating] = useState(false);
+  const [invite, setInvite] = useState(null);
+  const [copied, setCopied] = useState(false);
+
+  const handleClose = (next) => {
+    if (!next) {
+      setInvite(null);
+      setEmail("");
+      setTier(TIERS.STAFF);
+      setCopied(false);
+      setIsCreating(false);
+    }
+    onClose(next);
+  };
+
+  const handleGenerate = async () => {
+    setIsCreating(true);
+    try {
+      // TODO(backend): the returned invite comes from the stubbed service —
+      // once the backend lands this link will be minted server-side.
+      const result = await onCreateInvite({ email: email.trim() || undefined, tier });
+      setInvite(result);
+    } catch (err) {
+      console.error("Failed to create invite:", err);
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(invite?.url || "");
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      console.error("Clipboard unavailable");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="border border-accent/10 bg-surface-raised sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle
+            className={cn(poppins_600.className, "flex items-center gap-2 text-ink")}
+          >
+            <Link2 className="h-5 w-5 text-secondary" />
+            Invite an admin
+          </DialogTitle>
+          <DialogDescription className={cn(poppins_400.className, "text-ink-muted")}>
+            Generate a single-use invite link. Whoever accepts it joins the admin
+            team with the tier you pick, recorded as invited by you.
+          </DialogDescription>
+        </DialogHeader>
+
+        {invite ? (
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <p className={cn(poppins_500.className, "text-sm text-ink")}>Invite link</p>
+              <div className="flex items-center gap-2">
+                <Input readOnly value={invite.url} aria-label="Invite link" />
+                <Button
+                  size="icon"
+                  variant="outline"
+                  className="rounded-full"
+                  onClick={handleCopy}
+                  aria-label="Copy invite link"
+                >
+                  {copied ? (
+                    <Check className="h-4 w-4 text-secondary" />
+                  ) : (
+                    <Copy className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            </div>
+            <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+              Expires {lastActiveLabel(invite.expiresAt)} · single use
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <p className={cn(poppins_500.className, "text-sm text-ink")}>Tier</p>
+              <div className="flex gap-2">
+                {[TIERS.STAFF, TIERS.SUPER_ADMIN].map((option) => (
+                  <Button
+                    key={option}
+                    type="button"
+                    variant={tier === option ? "default" : "outline"}
+                    className={cn(
+                      "rounded-full",
+                      tier === option && "bg-accent text-white hover:bg-accent/90"
+                    )}
+                    onClick={() => setTier(option)}
+                  >
+                    {tierLabel[option]}
+                  </Button>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-1">
+              <label
+                htmlFor="invite-email"
+                className={cn(poppins_500.className, "text-sm text-ink")}
+              >
+                Email (optional)
+              </label>
+              <Input
+                id="invite-email"
+                type="email"
+                placeholder="teammate@deenbridge.org"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+              />
+            </div>
+          </div>
+        )}
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" className="rounded-full" onClick={() => handleClose(false)}>
+            Close
+          </Button>
+          {!invite && (
+            <Button
+              className="rounded-full bg-accent text-white hover:bg-accent/90"
+              disabled={isCreating}
+              onClick={handleGenerate}
+            >
+              {isCreating ? "Generating…" : "Generate invite"}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function MemberRow({ member, currentUserId }) {
+  const [pendingAction, setPendingAction] = useState(null);
+  const tier = getAdminTier(member);
+  const isSelf = member.id === currentUserId;
+  const isSuperAdminMember = tier === TIERS.SUPER_ADMIN;
+
+  const confirmPhrase = member.email;
+  const description =
+    pendingAction === "demote"
+      ? `${member.name} will lose super-admin permissions and become staff.`
+      : `${member.name}'s admin access will be removed entirely.`;
+
+  const handleConfirm = async () => {
+    if (pendingAction === "demote") {
+      await member.actions.demote(member.id, { confirmation: confirmPhrase });
+    } else if (pendingAction === "revoke") {
+      await member.actions.revoke(member.id, { confirmation: confirmPhrase });
+    }
+    setPendingAction(null);
+  };
+
+  return (
+    <>
+      <TableRow>
+        <TableCell>
+          <div className="flex items-center gap-3 py-1">
+            <Avatar className="h-9 w-9 border border-accent/10">
+              <AvatarImage src={member.avatar || "/images/dnb-nobg.png"} alt={member.name} />
+              <AvatarFallback className="bg-surface-raised text-xs">
+                {initials(member.name)}
+              </AvatarFallback>
+            </Avatar>
+            <div>
+              <p className={cn(poppins_500.className, "text-sm text-ink")}>
+                {member.name}
+                {isSelf && (
+                  <span className={cn(poppins_400.className, "ml-1.5 text-xs text-ink-muted")}>
+                    (you)
+                  </span>
+                )}
+              </p>
+              <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>{member.email}</p>
+            </div>
+          </div>
+        </TableCell>
+        <TableCell>
+          <Badge variant="outline" className={cn("rounded-full capitalize", tierBadge[tier])}>
+            {tierLabel[tier] || tier}
+          </Badge>
+        </TableCell>
+        <TableCell className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+          {lastActiveLabel(member.lastActiveAt)}
+        </TableCell>
+        <TableCell className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+          {member.addedBy?.name || "—"}
+        </TableCell>
+        <TableCell className="text-right">
+          {isSelf ? null : (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="rounded-full"
+                  aria-label={`Actions for ${member.name}`}
+                >
+                  <MoreHorizontal className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="border-accent/10">
+                {isSuperAdminMember && (
+                  <DropdownMenuItem
+                    className="text-destructive focus:text-destructive"
+                    onClick={() => setPendingAction("demote")}
+                  >
+                    <UserMinus className="h-4 w-4" />
+                    Demote to staff
+                  </DropdownMenuItem>
+                )}
+                <DropdownMenuItem
+                  className="text-destructive focus:text-destructive"
+                  onClick={() => setPendingAction("revoke")}
+                >
+                  <UserX className="h-4 w-4" />
+                  Revoke access
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </TableCell>
+      </TableRow>
+
+      <StepUpConfirmDialog
+        open={pendingAction !== null}
+        onOpenChange={(next) => !next && setPendingAction(null)}
+        title={pendingAction === "demote" ? "Demote admin" : "Revoke admin access"}
+        description={description}
+        confirmPhrase={confirmPhrase}
+        confirmLabel={pendingAction === "demote" ? "Demote" : "Revoke"}
+        onConfirm={handleConfirm}
+      />
+    </>
+  );
+}
+
+function LoadingRows() {
+  return [...Array(3)].map((_, i) => (
+    <TableRow key={i}>
+      <TableCell colSpan={5} className="py-3">
+        <Skeleton className="h-8 w-full rounded-full" />
+      </TableCell>
+    </TableRow>
+  ));
+}
+
+function AdminTeamContent() {
+  const { user } = useAuth();
+  const { admins, isLoading, error, refresh, inviteAdmin, demoteMember, revokeMember } =
+    useAdminTeam();
+  const [inviteOpen, setInviteOpen] = useState(false);
+
+  const membersWithActions = admins.map((member) => ({
+    ...member,
+    actions: { demote: demoteMember, revoke: revokeMember },
+  }));
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={Users}
+        title="Admin team"
+        subtitle="Manage admin access and role tiers across DeenBridge"
+        actions={
+          <Button
+            className="rounded-full bg-accent text-white hover:bg-accent/90"
+            onClick={() => setInviteOpen(true)}
+          >
+            <Link2 className="mr-1 h-4 w-4" />
+            Invite admin
+          </Button>
+        }
+      />
+
+      {error ? (
+        <EmptyState
+          icon={ShieldCheck}
+          title="Failed to load"
+          description={error}
+          action={
+            <Button variant="outline" className="rounded-full" onClick={() => refresh()}>
+              Try again
+            </Button>
+          }
+        />
+      ) : isLoading ? (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Member</TableHead>
+              <TableHead>Tier</TableHead>
+              <TableHead>Last active</TableHead>
+              <TableHead>Added by</TableHead>
+              <TableHead className="text-right">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>{LoadingRows()}</TableBody>
+        </Table>
+      ) : membersWithActions.length === 0 ? (
+        <EmptyState
+          icon={Users}
+          title="No admins yet"
+          description="Invite your first teammate to start building the admin team."
+        />
+      ) : (
+        <div className="overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Member</TableHead>
+                <TableHead>Tier</TableHead>
+                <TableHead>Last active</TableHead>
+                <TableHead>Added by</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {membersWithActions.map((member) => (
+                <MemberRow
+                  key={member.id}
+                  member={member}
+                  currentUserId={user?._id || user?.id}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <InviteDialog
+        open={inviteOpen}
+        onClose={setInviteOpen}
+        onCreateInvite={inviteAdmin}
+      />
+    </PageShell>
+  );
+}
+
+export default function AdminTeamPage() {
+  return (
+    <AdminTierGuard>
+      <AdminTeamContent />
+    </AdminTierGuard>
+  );
+}

--- a/components/auth/AdminTierGuard.jsx
+++ b/components/auth/AdminTierGuard.jsx
@@ -1,0 +1,53 @@
+"use client";
+/**
+ * AdminTierGuard — page-level super-admin gate for admin-team surfaces (#315).
+ * ---------------------------------------------------------------------------
+ * Composes over `ProtectedRoute` (authentication) and `canManageTeam` from the
+ * isolated tier module (`lib/auth/admin-tiers.js`). Unlike `RoleGuard`, which
+ * redirects, this guard renders the access-denied screen **inline** while
+ * keeping the user on the page — a staff admin who navigates here sees an
+ * explicit "insufficient permissions" fallback, never a flash of the member
+ * list.
+ *
+ * Layering:
+ *   1. `ProtectedRoute` resolves auth (loader → login redirect when signed out,
+ *      and its loader covers the unknown/loading states).
+ *   2. Once the user is known, `canManageTeam(user)` decides; staff admins fall
+ *      through to the access-denied fallback below.
+ *
+ * Usage:
+ *   <AdminTierGuard>
+ *     <AdminTeamContent />
+ *   </AdminTierGuard>
+ */
+import ProtectedRoute from "@/hooks/protected-route";
+import { useAuth } from "@/hooks/useAuth";
+import Loader from "@/components/molecules/loaders/rootLoader";
+import Unauthorized from "@/components/molecules/errors/Unauthorized";
+import { canManageTeam } from "@/lib/auth/admin-tiers";
+
+function TierGate({ children }) {
+  const { user } = useAuth();
+
+  // Defensive: ProtectedRoute resolves auth before rendering us, but fail
+  // closed (loader, never gated content) if we ever render without a user.
+  if (!user) return <Loader />;
+
+  if (!canManageTeam(user)) {
+    return (
+      <Unauthorized message="Only super admins can manage the admin team. If you think this is a mistake, contact a super admin." />
+    );
+  }
+
+  return <>{children}</>;
+}
+
+export function AdminTierGuard({ children }) {
+  return (
+    <ProtectedRoute>
+      <TierGate>{children}</TierGate>
+    </ProtectedRoute>
+  );
+}
+
+export default AdminTierGuard;

--- a/components/auth/StepUpConfirmDialog.jsx
+++ b/components/auth/StepUpConfirmDialog.jsx
@@ -1,0 +1,133 @@
+"use client";
+/**
+ * StepUpConfirmDialog — reusable step-up confirmation for sensitive actions
+ * (pattern from issue #311).
+ * -------------------------------------------------------------------------
+ * A destructive mutation must never fire off a single click. This dialog adds
+ * an explicit confirmation *step*: the acting admin must type a phrase (by
+ * default the affected member's email) before the confirm button unlocks, then
+ * the async `onConfirm` runs with in-flight state. Cancel/escape/close are all
+ * safe — the mutation only fires via the enabled button.
+ *
+ * Usage:
+ *   <StepUpConfirmDialog
+ *     open={open}
+ *     onOpenChange={setOpen}
+ *     title="Demote admin"
+ *     description={`${member.name} will lose super-admin permissions.`}
+ *     confirmPhrase={member.email}
+ *     confirmLabel="Demote"
+ *     onConfirm={() => demoteMember(member.id, { confirmation: member.email })}
+ *   />
+ */
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { ShieldAlert } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+function StepUpConfirmDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmPhrase,
+  confirmLabel = "Confirm",
+  onConfirm,
+}) {
+  const [confirmation, setConfirmation] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Reset the typed confirmation every time the dialog opens/closes so a
+  // previously satisfied challenge can never carry over to another action.
+  useEffect(() => {
+    if (!open) {
+      setConfirmation("");
+      setIsSubmitting(false);
+    }
+  }, [open]);
+
+  const isConfirmed =
+    typeof confirmation === "string" &&
+    confirmation.trim().length > 0 &&
+    confirmation.trim().toLowerCase() === String(confirmPhrase || "").trim().toLowerCase();
+
+  const handleConfirm = async () => {
+    if (!isConfirmed || isSubmitting) return;
+    setIsSubmitting(true);
+    try {
+      await onConfirm?.({ confirmation: confirmation.trim() });
+      onOpenChange?.(false);
+    } catch (err) {
+      console.error("Step-up confirmed action failed:", err);
+      toast.error(err?.message || "Action failed. Please try again.");
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !isSubmitting && onOpenChange?.(next)}>
+      <DialogContent className="border border-accent/10 bg-surface-raised sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className={cn(poppins_600.className, "flex items-center gap-2 text-ink")}>
+            <ShieldAlert className="h-5 w-5 text-destructive" aria-hidden="true" />
+            {title}
+          </DialogTitle>
+          {description && (
+            <DialogDescription className={cn(poppins_400.className, "text-ink-muted")}>
+              {description}
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <p className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+            This action is sensitive and cannot be undone. Type{" "}
+            <span className={cn(poppins_500.className, "font-mono text-ink")}>"{confirmPhrase}"</span>{" "}
+            to confirm.
+          </p>
+          <Input
+            value={confirmation}
+            onChange={(event) => setConfirmation(event.target.value)}
+            placeholder={confirmPhrase}
+            autoComplete="off"
+            disabled={isSubmitting}
+            aria-label={`Type ${confirmPhrase} to confirm`}
+          />
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button
+            variant="outline"
+            className="rounded-full"
+            disabled={isSubmitting}
+            onClick={() => onOpenChange?.(false)}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            className="rounded-full"
+            disabled={!isConfirmed || isSubmitting}
+            onClick={handleConfirm}
+          >
+            {isSubmitting ? "Working…" : confirmLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export { StepUpConfirmDialog };
+export default StepUpConfirmDialog;

--- a/hooks/useAdminTeam.js
+++ b/hooks/useAdminTeam.js
@@ -1,0 +1,102 @@
+"use client";
+/**
+ * useAdminTeam — data hook for the admin-team management page (#315).
+ * ------------------------------------------------------------------
+ * Loads the member list via the stubbed service in `lib/actions/admin-team`
+ * (same shape as `usePurchases`: local state + effect + explicit refresh) and
+ * exposes the invite/demote/revoke mutations.
+ *
+ * **Fails closed.** The list is only fetched once auth has resolved to a user
+ * who passes `canManageTeam`; the page-level guard (`AdminTierGuard`) owns
+ * rendering decisions — this hook just refuses to fetch without one.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import useAuth from "@/hooks/useAuth";
+import { canManageTeam } from "@/lib/auth/admin-tiers";
+import {
+  listAdmins,
+  createInvite,
+  demoteAdmin,
+  revokeAdmin,
+} from "@/lib/actions/admin-team";
+
+export default function useAdminTeam() {
+  const { user, loading: authLoading } = useAuth();
+
+  const [admins, setAdmins] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { admins: members } = await listAdmins();
+      setAdmins(Array.isArray(members) ? members : []);
+    } catch (err) {
+      setError(err?.message || "Failed to load admin team");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user || !canManageTeam(user)) {
+      setIsLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const { admins: members } = await listAdmins();
+        if (!cancelled) setAdmins(Array.isArray(members) ? members : []);
+      } catch (err) {
+        if (!cancelled) setError(err?.message || "Failed to load admin team");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading]);
+
+  /**
+   * Create an invite via the stubbed service. Resolves
+   * `{ invite: { token, url, expiresAt } }` or throws for the caller to show.
+   */
+  const inviteAdmin = useCallback(async (options) => {
+    const { invite } = await createInvite(options);
+    return invite;
+  }, []);
+
+  /** Demote a super-admin to staff; updates the local list on success. */
+  const demoteMember = useCallback(async (adminId, context) => {
+    await demoteAdmin(adminId, context);
+    setAdmins((prev) =>
+      prev.map((m) => (m.id === adminId ? { ...m, tier: "staff" } : m))
+    );
+    toast.success("Admin demoted to staff");
+  }, []);
+
+  /** Remove a member's admin access; removes them from the local list. */
+  const revokeMember = useCallback(async (adminId, context) => {
+    await revokeAdmin(adminId, context);
+    setAdmins((prev) => prev.filter((m) => m.id !== adminId));
+    toast.success("Admin access revoked");
+  }, []);
+
+  return {
+    admins,
+    isLoading,
+    error,
+    refresh,
+    inviteAdmin,
+    demoteMember,
+    revokeMember,
+  };
+}

--- a/lib/actions/admin-team.js
+++ b/lib/actions/admin-team.js
@@ -1,0 +1,148 @@
+/**
+ * Admin team service — list members, invite, demote, revoke.
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Every function in this module currently resolves with mocked
+ * data so the admin-team page (#315) can be built and reviewed before the
+ * backend endpoints exist. Each function documents the expected contract it
+ * will implement — swap the mock bodies for `axiosInstance` calls (see
+ * `lib/config/axios.config.js`) when the backend lands.
+ *
+ * Member shape owned by the backend:
+ *
+ *   {
+ *     id: string,
+ *     name: string,
+ *     email: string,
+ *     tier: "staff" | "super_admin",   // see lib/auth/admin-tiers.js TIERS
+ *     lastActiveAt: string,            // ISO 8601 timestamp
+ *     addedBy: { id: string, name: string } | null,
+ *   }
+ */
+
+const MOCK_DELAY_MS = 400;
+
+function withMockDelay(value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_DELAY_MS));
+}
+
+/**
+ * List every member of the admin team.
+ *
+ * TODO(backend): GET /api/admin/team
+ *   - Auth: requires a super-admin session token (server-side tier check).
+ *   - 200 → { admins: Member[] } using the member shape above.
+ *   - 403 for staff admins / non-admins.
+ *
+ * @returns {Promise<{admins: Array<{id: string, name: string, email: string, tier: ("staff"|"super_admin"), lastActiveAt: string, addedBy: {id: string, name: string}|null}>}>}
+ */
+export async function listAdmins() {
+  // TODO(backend): return axiosInstance.get("/api/admin/team").then((res) => res.data);
+  const now = Date.now();
+  return withMockDelay({
+    admins: [
+      {
+        id: "admin-001",
+        name: "Amina Yusuf",
+        email: "amina@deenbridge.org",
+        tier: "super_admin",
+        lastActiveAt: new Date(now - 2 * 60 * 60 * 1000).toISOString(),
+        addedBy: null,
+      },
+      {
+        id: "admin-002",
+        name: "Bilal Karim",
+        email: "bilal@deenbridge.org",
+        tier: "staff",
+        lastActiveAt: new Date(now - 26 * 60 * 60 * 1000).toISOString(),
+        addedBy: { id: "admin-001", name: "Amina Yusuf" },
+      },
+      {
+        id: "admin-003",
+        name: "Zaynab Idris",
+        email: "zaynab@deenbridge.org",
+        tier: "staff",
+        lastActiveAt: new Date(now - 6 * 24 * 60 * 60 * 1000).toISOString(),
+        addedBy: { id: "admin-001", name: "Amina Yusuf" },
+      },
+    ],
+  });
+}
+
+/**
+ * Create an admin invite. The backend mints a single-use token; the client
+ * composes and displays the shareable link.
+ *
+ * TODO(backend): POST /api/admin/team/invites
+ *   - Auth: super-admin only.
+ *   - Payload: { email?: string, tier: "staff" | "super_admin" }
+ *     (`email` optional — the invite link can be shared directly).
+ *   - 201 → { invite: { token: string, url: string, expiresAt: string } }
+ *   - The token is single-use, expires server-side, and records the inviting
+ *     admin as `addedBy` on acceptance.
+ *
+ * @param {{email?: string, tier: ("staff"|"super_admin")}} [options]
+ * @returns {Promise<{invite: {token: string, url: string, expiresAt: string}}>}
+ */
+export async function createInvite(options = {}) {
+  // TODO(backend):
+  //   return axiosInstance
+  //     .post("/api/admin/team/invites", options)
+  //     .then((res) => res.data);
+  const token = "inv_mock_".concat(
+    Math.random().toString(36).slice(2, 10),
+    Math.random().toString(36).slice(2, 10)
+  );
+  return withMockDelay({
+    invite: {
+      token,
+      url: `${typeof window !== "undefined" ? window.location.origin : ""}/register/invite?token=${token}&tier=${options.tier || "staff"}`,
+      expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+  });
+}
+
+/**
+ * Demote an admin from super_admin to staff.
+ *
+ * TODO(backend): PATCH /api/admin/team/:id/demote
+ *   - Auth: super-admin only; the acting super-admin is recorded in an audit
+ *     trail alongside the step-up confirmation evidence (#311).
+ *   - Payload: { confirmation: string } — the type-to-confirm phrase the actor
+ *     entered, forwarded verbatim for server-side verification/logging.
+ *   - 200 → { admin: Member } with the updated `tier`.
+ *   - 403 if the target is the acting super-admin themselves or the actor is
+ *     not a super-admin.
+ *
+ * @param {string} adminId
+ * @param {{confirmation: string}} [context]
+ * @returns {Promise<{admin: {id: string, tier: "staff"}}>}
+ */
+export async function demoteAdmin(adminId, context = {}) {
+  // TODO(backend):
+  //   return axiosInstance
+  //     .patch(`/api/admin/team/${adminId}/demote`, context)
+  //     .then((res) => res.data);
+  return withMockDelay({ admin: { id: adminId, tier: "staff", confirmation: context.confirmation } });
+}
+
+/**
+ * Revoke an admin's access entirely (remove the admin role).
+ *
+ * TODO(backend): DELETE /api/admin/team/:id
+ *   - Auth: super-admin only; audit-trailed like demote.
+ *   - Payload/query: forward { confirmation } as the request body for the
+ *     step-up evidence (axios DELETE supports a body).
+ *   - 200 → { revoked: true, adminId: string }
+ *   - 403 self-revoke / non-super-admin, per demote above.
+ *
+ * @param {string} adminId
+ * @param {{confirmation: string}} [context]
+ * @returns {Promise<{revoked: boolean, adminId: string}>}
+ */
+export async function revokeAdmin(adminId, context = {}) {
+  // TODO(backend):
+  //   return axiosInstance
+  //     .delete(`/api/admin/team/${adminId}`, { data: context })
+  //     .then((res) => res.data);
+  return withMockDelay({ revoked: true, adminId });
+}

--- a/lib/auth/admin-tiers.js
+++ b/lib/auth/admin-tiers.js
@@ -1,0 +1,123 @@
+/**
+ * Admin tiers — super-admin vs staff gating for admin-team management.
+ * ---------------------------------------------------------------------------
+ * Deliberately **separate** from `lib/auth/roles.js`: roles.js answers the
+ * generic "is this role allowed this capability?" question for the whole app,
+ * while this module owns the finer-grained tiering *within* the admin role
+ * (staff admins vs super admins). Keeping it isolated means the tier model can
+ * evolve (new tiers, delegated scopes, …) without touching the generic RBAC
+ * file or every call site.
+ *
+ * This is **defense-in-depth only**, exactly like `roles.js`. The real
+ * authorization boundary is the backend; nothing here is a security control on
+ * its own — its job is to stop the UI from offering team-management actions a
+ * non-super-admin's requests would be rejected for.
+ *
+ * Design rules (mirroring `roles.js`)
+ * -----------------------------------
+ *   - **Fail closed.** Unknown user / unknown tier → staff at best, never
+ *     super-admin. Callers that don't yet know the user (auth still loading)
+ *     must also treat the answer as `false` (see `useCan`/guards).
+ *   - **Pure & synchronous.** Reads only the passed `user` object; no fetching,
+ *     no React — trivially unit-testable per user shape.
+ */
+
+import { ROLES, normalizeRole } from "@/lib/auth/roles";
+
+/**
+ * Canonical admin tier identifiers. Values match the backend contract stubbed
+ * in `lib/actions/admin-team.js` (`tier: "staff" | "super_admin"`).
+ */
+export const TIERS = Object.freeze({
+  STAFF: "staff",
+  SUPER_ADMIN: "super_admin",
+});
+
+/**
+ * Normalise a raw tier string to a canonical {@link TIERS} value. Tolerates
+ * casing/whitespace and common spellings ("super-admin"/"superadmin" →
+ * super_admin) so backend label drift doesn't silently grant/deny wrongly.
+ *
+ * @param {unknown} tier
+ * @returns {string|null} canonical tier, or null if unrecognised
+ */
+export function normalizeTier(tier) {
+  if (typeof tier !== "string") return null;
+  const t = tier.trim().toLowerCase().replace(/[\s-]+/g, "_");
+  if (t === TIERS.STAFF) return TIERS.STAFF;
+  if (t === TIERS.SUPER_ADMIN || t === "superadmin" || t === "owner") {
+    return TIERS.SUPER_ADMIN;
+  }
+  return null;
+}
+
+/**
+ * Resolve a user's admin tier from the user object. Tolerant of the exact
+ * field name the backend settles on (`tier` / `adminTier`), and falls back to
+ * reading a tier encoded directly into `user.role`. Anything unresolvable
+ * degrades to {@link TIERS.STAFF} — an admin is at least staff by definition;
+ * only positive evidence grants super-admin.
+ *
+ * @param {object|null|undefined} user
+ * @returns {string} canonical tier ({@link TIERS})
+ */
+export function getAdminTier(user) {
+  if (!user || typeof user !== "object") return TIERS.STAFF;
+
+  const explicit = normalizeTier(user.tier) || normalizeTier(user.adminTier);
+  if (explicit) return explicit;
+
+  const viaRole = normalizeTier(user.role);
+  if (viaRole) return viaRole;
+
+  return TIERS.STAFF;
+}
+
+/**
+ * Whether the given user is a super admin. Requires positive evidence of both
+ * the admin role (via `normalizeRole`) and the super_admin tier — a staff
+ * admin, an educator, or an unknown user all fail closed here.
+ *
+ * @param {object|null|undefined} user
+ * @returns {boolean}
+ */
+export function isSuperAdmin(user) {
+  if (!user || typeof user !== "object") return false;
+  const role = normalizeRole(user.role);
+  if (role !== ROLES.ADMIN) return false;
+  return getAdminTier(user) === TIERS.SUPER_ADMIN;
+}
+
+/**
+ * Whether the user may manage the admin team (view members, invite, demote,
+ * revoke). Today this is exactly `isSuperAdmin`, kept as its own seam so the
+ * policy has one name call sites depend on when tiers gain nuance.
+ *
+ * @param {object|null|undefined} user
+ * @returns {boolean}
+ */
+export function canManageTeam(user) {
+  return isSuperAdmin(user);
+}
+
+/**
+ * Whether the acting user may demote the given member to staff.
+ * Super-admin-only; callers additionally enforce self-protection in the UI.
+ *
+ * @param {object|null|undefined} actor
+ * @returns {boolean}
+ */
+export function canDemoteAdmin(actor) {
+  return canManageTeam(actor);
+}
+
+/**
+ * Whether the acting user may revoke the given member's admin access.
+ * Super-admin-only; callers additionally enforce self-protection in the UI.
+ *
+ * @param {object|null|undefined} actor
+ * @returns {boolean}
+ */
+export function canRevokeAdmin(actor) {
+  return canManageTeam(actor);
+}


### PR DESCRIPTION
Closes #315

## What

Adds the super-admin-only team management page for managing admin access.

### Admin list (`/[locale]/dashboard/admin/team`)
- Role tier per member (**staff / super-admin**) shown as badges
- Last-active timestamp, humanized via `date-fns`
- **Added-by** attribution (which admin granted access)
- Self-demote/self-revoke actions hidden; empty/loading/error states reuse existing primitives

### Invite flow
- Super admins generate an invite link/token; backend contract stubbed in `lib/actions/admin-team.js` with explicit `TODO(backend)` notes on endpoints and payloads

### Demote / revoke with step-up confirmation (#311 pattern)
- New reusable `components/auth/StepUpConfirmDialog.jsx` — type-to-confirm gate before any destructive mutation fires

### Tiered role gating, isolated
- New pure/fail-closed module `lib/auth/admin-tiers.js`: `TIERS`, `normalizeTier`, `getAdminTier`, `isSuperAdmin`, `canManageTeam`, `canDemoteAdmin`, `canRevokeAdmin` — built *on top of* `lib/auth/roles.js` without entangling it, so tiers can evolve
- Page-level enforcement via `components/auth/AdminTierGuard.jsx`; staff/unknown/loading users get a denial state, never a flash of member data
- Data layer in `hooks/useAdminTeam.js` following existing hooks conventions

## Notes

- Backend contract intentionally stubbed per the issue; mock data includes `id/name/email/tier/lastActiveAt/addedBy`
- Companion PRs: docs (#342) and README/CONTRIBUTING/env updates (#343)