### PR TITLE
test(admin): Component tests for shared admin primitives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Run accessibility gate
         run: npm run a11y
 
+      - name: Run component tests
+        run: npm test
+
       - name: Build application
         run: npm run build
         env:

--- a/__tests__/admin/AdminTeamPage.test.jsx
+++ b/__tests__/admin/AdminTeamPage.test.jsx
@@ -1,0 +1,92 @@
+/**
+ * Admin team page — table loading / empty / error state tests (#340).
+ * -------------------------------------------------------------------
+ * The member table has no standalone `TableSkeleton` component; its
+ * loading (skeleton rows), empty, and error states are rendered by the page
+ * driven off `useAdminTeam`. These tests mock the hook to each state and assert
+ * the correct branch renders. The guard, auth, and data hook are mocked so the
+ * test targets the presentational branching only.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/config/font.config", () => ({
+  poppins_400: { className: "" },
+  poppins_500: { className: "" },
+  poppins_600: { className: "" },
+  ibmPlexArabic: { className: "", variable: "" },
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => ({ user: { id: "me", _id: "me" } }),
+  useAuth: () => ({ user: { id: "me", _id: "me" } }),
+}));
+
+// Bypass the super-admin page guard — its behaviour is out of scope here.
+vi.mock("@/components/auth/AdminTierGuard", () => ({
+  default: ({ children }) => children,
+}));
+
+const hookState = vi.hoisted(() => ({ current: null }));
+vi.mock("@/hooks/useAdminTeam", () => ({ default: () => hookState.current }));
+
+// Radix touches these layout/pointer APIs jsdom omits.
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  if (!window.ResizeObserver) {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+function makeState(overrides = {}) {
+  return {
+    admins: [],
+    isLoading: false,
+    error: null,
+    refresh: vi.fn(),
+    inviteAdmin: vi.fn(),
+    demoteMember: vi.fn(),
+    revokeMember: vi.fn(),
+    ...overrides,
+  };
+}
+
+let AdminTeamPage;
+beforeEach(async () => {
+  if (!AdminTeamPage) {
+    const mod = await import("@/app/[locale]/dashboard/admin/team/page");
+    AdminTeamPage = mod.default;
+  }
+});
+
+describe("AdminTeamPage — table states", () => {
+  it("renders skeleton loading rows while loading", () => {
+    hookState.current = makeState({ isLoading: true });
+    const { container } = render(<AdminTeamPage />);
+    // Table header renders and skeleton placeholders are present.
+    expect(screen.getByText("Member")).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+  });
+
+  it("renders the empty state when there are no admins", () => {
+    hookState.current = makeState({ admins: [] });
+    render(<AdminTeamPage />);
+    expect(screen.getByText(/no admins yet/i)).toBeInTheDocument();
+  });
+
+  it("renders the error state with the failure message", () => {
+    hookState.current = makeState({ error: "Service unavailable" });
+    render(<AdminTeamPage />);
+    expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+    expect(screen.getByText("Service unavailable")).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin/StepUpConfirmDialog.test.jsx
+++ b/__tests__/admin/StepUpConfirmDialog.test.jsx
@@ -1,0 +1,111 @@
+/**
+ * StepUpConfirmDialog — step-up confirm flow interaction tests (#340).
+ * --------------------------------------------------------------------
+ * The destructive-action confirmation dialog from #311: the confirm button
+ * stays locked until the actor types the exact challenge phrase, then runs the
+ * async `onConfirm`. These tests drive the real Radix dialog and assert the
+ * gating + confirm/cancel behaviour that protects every sensitive admin action.
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/config/font.config", () => ({
+  poppins_400: { className: "" },
+  poppins_500: { className: "" },
+  poppins_600: { className: "" },
+  ibmPlexArabic: { className: "", variable: "" },
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import StepUpConfirmDialog from "@/components/auth/StepUpConfirmDialog";
+
+// jsdom lacks the layout/pointer APIs Radix's dialog touches on mount.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  if (!window.ResizeObserver) {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+const PHRASE = "bilal@deenbridge.org";
+
+function renderDialog(overrides = {}) {
+  const onConfirm = overrides.onConfirm || vi.fn().mockResolvedValue(undefined);
+  const onOpenChange = overrides.onOpenChange || vi.fn();
+  render(
+    <StepUpConfirmDialog
+      open
+      onOpenChange={onOpenChange}
+      title="Revoke admin access"
+      description="Bilal's admin access will be removed."
+      confirmPhrase={PHRASE}
+      confirmLabel="Revoke"
+      onConfirm={onConfirm}
+    />
+  );
+  return { onConfirm, onOpenChange };
+}
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.clearAllMocks());
+
+describe("StepUpConfirmDialog", () => {
+  it("renders the title and challenge input while open", () => {
+    renderDialog();
+    expect(screen.getByText("Revoke admin access")).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  it("keeps the confirm button disabled until the phrase matches", () => {
+    renderDialog();
+    const confirm = screen.getByRole("button", { name: /revoke/i });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "wrong" } });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: PHRASE } });
+    expect(confirm).toBeEnabled();
+  });
+
+  it("matches the phrase case-insensitively and trims whitespace", () => {
+    renderDialog();
+    fireEvent.change(screen.getByRole("textbox"), {
+      target: { value: `  ${PHRASE.toUpperCase()} ` },
+    });
+    expect(screen.getByRole("button", { name: /revoke/i })).toBeEnabled();
+  });
+
+  it("runs onConfirm with the typed confirmation and closes on success", async () => {
+    const { onConfirm, onOpenChange } = renderDialog();
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: PHRASE } });
+    fireEvent.click(screen.getByRole("button", { name: /revoke/i }));
+
+    await waitFor(() =>
+      expect(onConfirm).toHaveBeenCalledWith({ confirmation: PHRASE })
+    );
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("cancel closes without running onConfirm", () => {
+    const { onConfirm, onOpenChange } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("does not run onConfirm when the phrase is wrong", () => {
+    const { onConfirm } = renderDialog();
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "nope" } });
+    fireEvent.click(screen.getByRole("button", { name: /revoke/i }));
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/admin/admin-team.service.test.js
+++ b/__tests__/admin/admin-team.service.test.js
@@ -1,0 +1,68 @@
+/**
+ * Admin-team service — audit/step-up evidence contract tests (#340).
+ * ------------------------------------------------------------------
+ * The service in `lib/actions/admin-team.js` is the seam the admin surfaces
+ * call for listing/inviting and for the demote/revoke mutations that carry the
+ * step-up confirmation forward as audit evidence. These tests pin the resolved
+ * shapes the UI depends on and, crucially, that the `confirmation` phrase is
+ * forwarded verbatim on the sensitive mutations.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  listAdmins,
+  createInvite,
+  demoteAdmin,
+  revokeAdmin,
+} from "@/lib/actions/admin-team";
+
+const TIERS = new Set(["staff", "super_admin"]);
+
+describe("listAdmins", () => {
+  it("resolves a list of members with the documented shape", async () => {
+    const { admins } = await listAdmins();
+    expect(Array.isArray(admins)).toBe(true);
+    expect(admins.length).toBeGreaterThan(0);
+    for (const member of admins) {
+      expect(typeof member.id).toBe("string");
+      expect(typeof member.email).toBe("string");
+      expect(TIERS.has(member.tier)).toBe(true);
+    }
+  });
+
+  it("includes at least one super_admin", async () => {
+    const { admins } = await listAdmins();
+    expect(admins.some((m) => m.tier === "super_admin")).toBe(true);
+  });
+});
+
+describe("createInvite", () => {
+  it("mints an invite with a token, link and expiry", async () => {
+    const { invite } = await createInvite({ tier: "staff" });
+    expect(invite.token).toMatch(/^inv_mock_/);
+    expect(invite.url).toContain(invite.token);
+    expect(invite.url).toContain("tier=staff");
+    expect(Number.isNaN(new Date(invite.expiresAt).getTime())).toBe(false);
+  });
+
+  it("defaults the tier in the link when none is provided", async () => {
+    const { invite } = await createInvite();
+    expect(invite.url).toContain("tier=staff");
+  });
+});
+
+describe("demoteAdmin", () => {
+  it("resolves the demoted tier and forwards the confirmation evidence", async () => {
+    const { admin } = await demoteAdmin("admin-002", { confirmation: "bilal@deenbridge.org" });
+    expect(admin.id).toBe("admin-002");
+    expect(admin.tier).toBe("staff");
+    expect(admin.confirmation).toBe("bilal@deenbridge.org");
+  });
+});
+
+describe("revokeAdmin", () => {
+  it("resolves a revoked acknowledgement for the target id", async () => {
+    const result = await revokeAdmin("admin-003", { confirmation: "zaynab@deenbridge.org" });
+    expect(result.revoked).toBe(true);
+    expect(result.adminId).toBe("admin-003");
+  });
+});

--- a/__tests__/admin/empty-state.test.jsx
+++ b/__tests__/admin/empty-state.test.jsx
@@ -1,0 +1,64 @@
+/**
+ * EmptyState — shared admin primitive render tests (#340).
+ * --------------------------------------------------------
+ * Covers the reusable empty/placeholder card used across the admin surfaces
+ * (member list "no admins yet", failed-load fallback, etc). Asserts only the
+ * component's stable public contract: title/heading, description, icon, and the
+ * action/children slot.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// font.config pulls next/font at module load; stub it so rendering never
+// depends on Next's build-time font pipeline.
+vi.mock("@/lib/config/font.config", () => ({
+  poppins_400: { className: "" },
+  poppins_500: { className: "" },
+  poppins_600: { className: "" },
+  ibmPlexArabic: { className: "", variable: "" },
+}));
+
+import { EmptyState } from "@/components/ui/empty-state";
+
+function StarIcon(props) {
+  return <svg data-testid="empty-icon" {...props} />;
+}
+
+describe("EmptyState", () => {
+  it("renders the title and description", () => {
+    render(<EmptyState title="No admins yet" description="Invite your first teammate." />);
+    expect(screen.getByText("No admins yet")).toBeInTheDocument();
+    expect(screen.getByText("Invite your first teammate.")).toBeInTheDocument();
+  });
+
+  it("falls back to the `heading` prop when `title` is absent", () => {
+    render(<EmptyState heading="Nothing here" />);
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+  });
+
+  it("renders a provided icon component", () => {
+    render(<EmptyState icon={StarIcon} title="Empty" />);
+    expect(screen.getByTestId("empty-icon")).toBeInTheDocument();
+  });
+
+  it("renders an action element in the action slot", () => {
+    render(
+      <EmptyState title="Failed to load" action={<button type="button">Try again</button>} />
+    );
+    expect(screen.getByRole("button", { name: /try again/i })).toBeInTheDocument();
+  });
+
+  it("renders children as the action when no `action` is given", () => {
+    render(
+      <EmptyState title="Empty">
+        <button type="button">Invite admin</button>
+      </EmptyState>
+    );
+    expect(screen.getByRole("button", { name: /invite admin/i })).toBeInTheDocument();
+  });
+
+  it("does not render an icon container when no icon is provided", () => {
+    const { container } = render(<EmptyState title="Empty" />);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+});

--- a/__tests__/admin/useAdminTeam.test.jsx
+++ b/__tests__/admin/useAdminTeam.test.jsx
@@ -1,0 +1,134 @@
+/**
+ * useAdminTeam — admin-team data + mutation hook tests (#340).
+ * -----------------------------------------------------------
+ * Drives the hook that backs the member table: initial load, and the
+ * demote/revoke mutations that update the local list in place. The failure
+ * paths assert the list is left intact when a mutation rejects (no partial /
+ * corrupted state) — the rollback guarantee the UI relies on.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// Authenticated super-admin so the hook's fail-closed guard lets it fetch.
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => ({ user: { id: "me", role: "admin", tier: "super_admin" }, loading: false }),
+  useAuth: () => ({ user: { id: "me", role: "admin", tier: "super_admin" }, loading: false }),
+}));
+
+vi.mock("@/lib/auth/admin-tiers", () => ({
+  canManageTeam: () => true,
+}));
+
+const mocks = vi.hoisted(() => ({
+  listAdmins: vi.fn(),
+  createInvite: vi.fn(),
+  demoteAdmin: vi.fn(),
+  revokeAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/admin-team", () => ({
+  listAdmins: mocks.listAdmins,
+  createInvite: mocks.createInvite,
+  demoteAdmin: mocks.demoteAdmin,
+  revokeAdmin: mocks.revokeAdmin,
+}));
+
+import useAdminTeam from "@/hooks/useAdminTeam";
+
+const SUPER = { id: "a1", name: "Amina", email: "amina@x.org", tier: "super_admin" };
+const STAFF = { id: "a2", name: "Bilal", email: "bilal@x.org", tier: "staff" };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.listAdmins.mockResolvedValue({ admins: [{ ...SUPER }, { ...STAFF }] });
+});
+
+async function mountLoaded() {
+  const view = renderHook(() => useAdminTeam());
+  await waitFor(() => expect(view.result.current.isLoading).toBe(false));
+  return view;
+}
+
+describe("useAdminTeam — load", () => {
+  it("loads the member list and clears the loading flag", async () => {
+    const { result } = await mountLoaded();
+    expect(result.current.admins).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a message when the list fails to load", async () => {
+    mocks.listAdmins.mockRejectedValueOnce(new Error("network down"));
+    const { result } = renderHook(() => useAdminTeam());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).toBe("network down");
+  });
+});
+
+describe("useAdminTeam — demote", () => {
+  it("updates the member's tier to staff on success", async () => {
+    mocks.demoteAdmin.mockResolvedValueOnce({ admin: { id: "a1", tier: "staff" } });
+    const { result } = await mountLoaded();
+
+    await act(async () => {
+      await result.current.demoteMember("a1", { confirmation: "amina@x.org" });
+    });
+
+    expect(mocks.demoteAdmin).toHaveBeenCalledWith("a1", { confirmation: "amina@x.org" });
+    expect(result.current.admins.find((m) => m.id === "a1").tier).toBe("staff");
+  });
+
+  it("leaves the list unchanged when the demote rejects (rollback)", async () => {
+    mocks.demoteAdmin.mockRejectedValueOnce(new Error("403"));
+    const { result } = await mountLoaded();
+
+    await act(async () => {
+      await expect(result.current.demoteMember("a1")).rejects.toThrow("403");
+    });
+
+    // The optimistic list must not be mutated on failure.
+    expect(result.current.admins.find((m) => m.id === "a1").tier).toBe("super_admin");
+    expect(result.current.admins).toHaveLength(2);
+  });
+});
+
+describe("useAdminTeam — revoke", () => {
+  it("removes the member from the list on success", async () => {
+    mocks.revokeAdmin.mockResolvedValueOnce({ revoked: true, adminId: "a2" });
+    const { result } = await mountLoaded();
+
+    await act(async () => {
+      await result.current.revokeMember("a2", { confirmation: "bilal@x.org" });
+    });
+
+    expect(result.current.admins.some((m) => m.id === "a2")).toBe(false);
+    expect(result.current.admins).toHaveLength(1);
+  });
+
+  it("keeps the member when the revoke rejects (rollback)", async () => {
+    mocks.revokeAdmin.mockRejectedValueOnce(new Error("boom"));
+    const { result } = await mountLoaded();
+
+    await act(async () => {
+      await expect(result.current.revokeMember("a2")).rejects.toThrow("boom");
+    });
+
+    expect(result.current.admins.some((m) => m.id === "a2")).toBe(true);
+    expect(result.current.admins).toHaveLength(2);
+  });
+});
+
+describe("useAdminTeam — invite", () => {
+  it("returns the minted invite from the service", async () => {
+    mocks.createInvite.mockResolvedValueOnce({ invite: { token: "inv_mock_x", url: "u", expiresAt: "e" } });
+    const { result } = await mountLoaded();
+
+    let invite;
+    await act(async () => {
+      invite = await result.current.inviteAdmin({ tier: "staff" });
+    });
+
+    expect(invite.token).toBe("inv_mock_x");
+  });
+});


### PR DESCRIPTION
Closes #340

As requested by the issue, the testing stack was **proposed in an issue comment first** (https://github.com/Deen-Bridge/dnb-frontend/issues/340#issuecomment-5400599865) before writing any code.

## Stack
**Vitest + @testing-library/react + @testing-library/jest-dom + @testing-library/user-event + jsdom** — lightweight, ESM-native, no Next/webpack coupling. These devDependencies and the `vitest.config.js` / `vitest.setup.js` scaffolding already exist on `dev`; this PR adds the admin-primitive coverage and wires tests into CI.

## Tests added (`__tests__/admin/`)
- **`empty-state.test.jsx`** — `EmptyState` render tests: title, `heading` fallback, icon, action slot, children-as-action, no-icon case.
- **`StepUpConfirmDialog.test.jsx`** — step-up confirm flow: confirm button gated until the challenge phrase matches (case-insensitive/trimmed), `onConfirm` runs with the typed confirmation and the dialog closes on success, cancel/wrong-phrase never fire the mutation.
- **`admin-team.service.test.js`** — admin-team service (audit/step-up evidence): `listAdmins` shape + tiers, `createInvite` token/link/expiry, `demoteAdmin`/`revokeAdmin` resolve the documented shape and forward the `confirmation` evidence verbatim.
- **`useAdminTeam.test.jsx`** — the admin data/mutation hook: initial load, load-error message, demote updates tier in place, revoke removes the member, and **failed mutations leave the list intact (rollback)**; invite returns the minted invite.
- **`AdminTeamPage.test.jsx`** — the member table's **loading (skeleton rows) / empty / error** states (there is no standalone `TableSkeleton` component; these states are rendered by the page off `useAdminTeam`).

## CI
`.github/workflows/ci.yml` — added an `npm test` step to the existing **Lint and Build** job (after the a11y gate, before build). Single job, no extra runners; tests don't require the build.

Coverage is focused on the shared admin primitives only.