### PR TITLE
feat(admin): feature flags management UI + useFeatureFlag hook (#313)

### DIFF
--- a/app/[locale]/admin/settings/flags/page.jsx
+++ b/app/[locale]/admin/settings/flags/page.jsx
@@ -1,0 +1,556 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Slider } from "@/components/ui/slider";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Flag,
+  Plus,
+  Search,
+  AlertTriangle,
+  Zap,
+  Users,
+  RefreshCw,
+  Check,
+  X,
+  Loader2,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+// Mock feature flags data
+const initialFlags = [
+  {
+    id: "1",
+    key: "ai-assistant",
+    description: "Enable AI-powered learning assistant for students",
+    enabled: true,
+    rolloutPercentage: 100,
+    isCritical: false,
+    createdAt: "2024-01-10",
+    updatedAt: "2024-01-15",
+  },
+  {
+    id: "2",
+    key: "live-sessions",
+    description: "Enable real-time video sessions between educators and students",
+    enabled: true,
+    rolloutPercentage: 75,
+    isCritical: false,
+    createdAt: "2024-01-08",
+    updatedAt: "2024-01-14",
+  },
+  {
+    id: "3",
+    key: "stellar-payments",
+    description: "Enable Stellar blockchain payment processing",
+    enabled: true,
+    rolloutPercentage: 100,
+    isCritical: true,
+    createdAt: "2024-01-01",
+    updatedAt: "2024-01-12",
+  },
+  {
+    id: "4",
+    key: "gamification",
+    description: "Enable badges, achievements, and learning streaks",
+    enabled: false,
+    rolloutPercentage: 0,
+    isCritical: false,
+    createdAt: "2024-01-05",
+    updatedAt: "2024-01-05",
+  },
+  {
+    id: "5",
+    key: "social-features",
+    description: "Enable following educators and social feeds",
+    enabled: true,
+    rolloutPercentage: 50,
+    isCritical: false,
+    createdAt: "2024-01-03",
+    updatedAt: "2024-01-11",
+  },
+  {
+    id: "6",
+    key: "maintenance-mode",
+    description: "Put the platform in maintenance mode - CRITICAL",
+    enabled: false,
+    rolloutPercentage: 0,
+    isCritical: true,
+    createdAt: "2024-01-01",
+    updatedAt: "2024-01-01",
+  },
+];
+
+// Kebab-case validation
+const isValidKebabCase = (str) => /^[a-z]+(-[a-z]+)*$/.test(str);
+
+// Format date
+const formatDate = (dateStr) => {
+  return new Date(dateStr).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+};
+
+export default function FeatureFlagsPage() {
+  const [flags, setFlags] = useState(initialFlags);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [loadingFlags, setLoadingFlags] = useState({});
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  // New flag form state
+  const [newFlag, setNewFlag] = useState({
+    key: "",
+    description: "",
+    isCritical: false,
+  });
+  const [keyError, setKeyError] = useState("");
+
+  // Filter flags based on search
+  const filteredFlags = useMemo(() => {
+    if (!searchQuery.trim()) return flags;
+    const query = searchQuery.toLowerCase();
+    return flags.filter(
+      (flag) =>
+        flag.key.toLowerCase().includes(query) ||
+        flag.description.toLowerCase().includes(query)
+    );
+  }, [flags, searchQuery]);
+
+  // Toggle flag with optimistic update
+  const handleToggle = useCallback(async (flagId, currentState) => {
+    // Optimistic update
+    setFlags((prev) =>
+      prev.map((f) => (f.id === flagId ? { ...f, enabled: !currentState } : f))
+    );
+    setLoadingFlags((prev) => ({ ...prev, [flagId]: true }));
+
+    try {
+      // Simulate API call
+      await new Promise((resolve, reject) => {
+        setTimeout(() => {
+          // Simulate occasional failure for demo
+          if (Math.random() < 0.1) {
+            reject(new Error("Failed to update flag"));
+          } else {
+            resolve();
+          }
+        }, 500);
+      });
+
+      // Update timestamp on success
+      setFlags((prev) =>
+        prev.map((f) =>
+          f.id === flagId
+            ? { ...f, updatedAt: new Date().toISOString().split("T")[0] }
+            : f
+        )
+      );
+    } catch (error) {
+      // Rollback on failure
+      setFlags((prev) =>
+        prev.map((f) => (f.id === flagId ? { ...f, enabled: currentState } : f))
+      );
+      console.error("Failed to toggle flag:", error);
+    } finally {
+      setLoadingFlags((prev) => ({ ...prev, [flagId]: false }));
+    }
+  }, []);
+
+  // Update rollout percentage
+  const handleRolloutChange = useCallback((flagId, percentage) => {
+    setFlags((prev) =>
+      prev.map((f) =>
+        f.id === flagId
+          ? {
+              ...f,
+              rolloutPercentage: percentage[0],
+              updatedAt: new Date().toISOString().split("T")[0],
+            }
+          : f
+      )
+    );
+  }, []);
+
+  // Validate and create new flag
+  const handleCreateFlag = useCallback(() => {
+    // Validate key format
+    if (!isValidKebabCase(newFlag.key)) {
+      setKeyError("Key must be in kebab-case (e.g., my-feature-flag)");
+      return;
+    }
+
+    // Check uniqueness
+    if (flags.some((f) => f.key === newFlag.key)) {
+      setKeyError("A flag with this key already exists");
+      return;
+    }
+
+    // Create new flag
+    const flag = {
+      id: String(Date.now()),
+      key: newFlag.key,
+      description: newFlag.description,
+      enabled: false,
+      rolloutPercentage: 0,
+      isCritical: newFlag.isCritical,
+      createdAt: new Date().toISOString().split("T")[0],
+      updatedAt: new Date().toISOString().split("T")[0],
+    };
+
+    setFlags((prev) => [flag, ...prev]);
+    setNewFlag({ key: "", description: "", isCritical: false });
+    setKeyError("");
+    setIsCreateOpen(false);
+  }, [newFlag, flags]);
+
+  // Refresh flags
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    // Simulate API refresh
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setIsRefreshing(false);
+  }, []);
+
+  // Stats
+  const enabledCount = flags.filter((f) => f.enabled).length;
+  const criticalCount = flags.filter((f) => f.isCritical).length;
+  const gradualRolloutCount = flags.filter(
+    (f) => f.enabled && f.rolloutPercentage < 100
+  ).length;
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={Flag}
+        title="Feature Flags"
+        subtitle="Manage feature toggles and gradual rollouts"
+        actions={
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+            >
+              <RefreshCw
+                className={cn("h-4 w-4 mr-2", isRefreshing && "animate-spin")}
+              />
+              Refresh
+            </Button>
+            <Dialog open={isCreateOpen} onOpenChange={setIsCreateOpen}>
+              <DialogTrigger asChild>
+                <Button size="sm">
+                  <Plus className="h-4 w-4 mr-2" />
+                  Create Flag
+                </Button>
+              </DialogTrigger>
+              <DialogContent>
+                <DialogHeader>
+                  <DialogTitle>Create Feature Flag</DialogTitle>
+                  <DialogDescription>
+                    Add a new feature flag to control feature availability.
+                  </DialogDescription>
+                </DialogHeader>
+                <div className="space-y-4 py-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="key">Flag Key</Label>
+                    <Input
+                      id="key"
+                      placeholder="my-feature-flag"
+                      value={newFlag.key}
+                      onChange={(e) => {
+                        setNewFlag((prev) => ({ ...prev, key: e.target.value }));
+                        setKeyError("");
+                      }}
+                      className={keyError ? "border-red-500" : ""}
+                    />
+                    {keyError && (
+                      <p className="text-xs text-red-500">{keyError}</p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      Must be lowercase kebab-case (e.g., my-feature)
+                    </p>
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="description">Description</Label>
+                    <Textarea
+                      id="description"
+                      placeholder="Describe what this flag controls..."
+                      value={newFlag.description}
+                      onChange={(e) =>
+                        setNewFlag((prev) => ({
+                          ...prev,
+                          description: e.target.value,
+                        }))
+                      }
+                    />
+                  </div>
+                  <div className="flex items-center gap-3">
+                    <Switch
+                      id="critical"
+                      checked={newFlag.isCritical}
+                      onCheckedChange={(checked) =>
+                        setNewFlag((prev) => ({ ...prev, isCritical: checked }))
+                      }
+                    />
+                    <Label htmlFor="critical" className="flex items-center gap-2">
+                      <AlertTriangle className="h-4 w-4 text-red-500" />
+                      Mark as Critical (Kill Switch)
+                    </Label>
+                  </div>
+                </div>
+                <DialogFooter>
+                  <Button variant="outline" onClick={() => setIsCreateOpen(false)}>
+                    Cancel
+                  </Button>
+                  <Button onClick={handleCreateFlag} disabled={!newFlag.key}>
+                    Create Flag
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+          </div>
+        }
+      />
+
+      {/* Stats Overview */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <Card>
+          <CardContent className="flex items-center gap-4 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-green-100">
+              <Zap className="h-5 w-5 text-green-600" />
+            </div>
+            <div>
+              <p className={cn(poppins_600.className, "text-2xl")}>{enabledCount}</p>
+              <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+                Active Flags
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex items-center gap-4 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-amber-100">
+              <Users className="h-5 w-5 text-amber-600" />
+            </div>
+            <div>
+              <p className={cn(poppins_600.className, "text-2xl")}>
+                {gradualRolloutCount}
+              </p>
+              <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+                Gradual Rollouts
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="flex items-center gap-4 p-4">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-red-100">
+              <AlertTriangle className="h-5 w-5 text-red-600" />
+            </div>
+            <div>
+              <p className={cn(poppins_600.className, "text-2xl")}>{criticalCount}</p>
+              <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+                Critical Flags
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Search */}
+      <div className="relative max-w-md">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Search flags..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="pl-10"
+        />
+      </div>
+
+      {/* Flags Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Feature Flags ({filteredFlags.length})</CardTitle>
+          <CardDescription>
+            Toggle features and control rollout percentages
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-[200px]">Flag Key</TableHead>
+                  <TableHead>Description</TableHead>
+                  <TableHead className="w-[100px]">Status</TableHead>
+                  <TableHead className="w-[200px]">Rollout</TableHead>
+                  <TableHead className="w-[120px]">Updated</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {filteredFlags.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={5}
+                      className="py-8 text-center text-muted-foreground"
+                    >
+                      No feature flags found
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  filteredFlags.map((flag) => (
+                    <TableRow
+                      key={flag.id}
+                      className={cn(
+                        flag.isCritical && "bg-red-50/50 hover:bg-red-50"
+                      )}
+                    >
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          <code
+                            className={cn(
+                              poppins_500.className,
+                              "rounded bg-muted px-2 py-1 text-sm"
+                            )}
+                          >
+                            {flag.key}
+                          </code>
+                          {flag.isCritical && (
+                            <Badge variant="destructive" className="text-xs">
+                              <AlertTriangle className="mr-1 h-3 w-3" />
+                              Critical
+                            </Badge>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm text-muted-foreground">
+                        {flag.description}
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex items-center gap-2">
+                          {loadingFlags[flag.id] ? (
+                            <Loader2 className="h-4 w-4 animate-spin" />
+                          ) : (
+                            <Switch
+                              checked={flag.enabled}
+                              onCheckedChange={() =>
+                                handleToggle(flag.id, flag.enabled)
+                              }
+                            />
+                          )}
+                          <Badge
+                            variant={flag.enabled ? "default" : "secondary"}
+                            className={cn(
+                              "text-xs",
+                              flag.enabled
+                                ? "bg-green-100 text-green-700"
+                                : "bg-gray-100 text-gray-600"
+                            )}
+                          >
+                            {flag.enabled ? (
+                              <Check className="mr-1 h-3 w-3" />
+                            ) : (
+                              <X className="mr-1 h-3 w-3" />
+                            )}
+                            {flag.enabled ? "ON" : "OFF"}
+                          </Badge>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="space-y-2">
+                          <div className="flex items-center justify-between">
+                            <span className="text-xs text-muted-foreground">
+                              {flag.rolloutPercentage}% of users
+                            </span>
+                          </div>
+                          <Slider
+                            value={[flag.rolloutPercentage]}
+                            onValueChange={(val) =>
+                              handleRolloutChange(flag.id, val)
+                            }
+                            max={100}
+                            step={5}
+                            disabled={!flag.enabled}
+                            className="w-full"
+                          />
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {formatDate(flag.updatedAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))
+                )}
+              </TableBody>
+            </Table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Usage Documentation */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Developer Usage</CardTitle>
+          <CardDescription>
+            How to consume feature flags in your components
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-lg bg-muted p-4">
+            <pre className="text-sm overflow-x-auto">
+              <code>{`// Import the hook
+import { useFeatureFlag } from "@/hooks/useFeatureFlag";
+
+// Use in your component
+function MyComponent() {
+  const { enabled, loading } = useFeatureFlag("ai-assistant");
+
+  if (loading) return <Skeleton />;
+  if (!enabled) return null;
+
+  return <AIAssistant />;
+}`}</code>
+            </pre>
+          </div>
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}

--- a/app/[locale]/dashboard/admin/settings/flags/page.jsx
+++ b/app/[locale]/dashboard/admin/settings/flags/page.jsx
@@ -1,0 +1,527 @@
+"use client";
+/**
+ * Feature-flags management page (#313).
+ * ---------------------------------------------------------------------------
+ * Super-admin surface (wrapped in `AdminTierGuard`) for viewing and editing the
+ * app's runtime feature flags. Mirrors the admin-team page's structure: a
+ * `PageShell` + `PageHeader`, a `Table` of flags, `Skeleton` loading, an
+ * `EmptyState`, and a create `Dialog` with inline validation.
+ *
+ * Behaviour highlights:
+ *   - The state Switch toggles **optimistically** (see `useFeatureFlags`) — the
+ *     UI flips instantly and reverts on failure with a toast.
+ *   - **Critical (kill-switch) flags** get a destructive-tinted row + warning
+ *     icon and require an explicit confirm before being turned OFF.
+ *   - The create form enforces a kebab-case key that's unique against existing
+ *     keys; submit stays disabled until the input is valid.
+ */
+import { useMemo, useState } from "react";
+import {
+  AlertTriangle,
+  Flag as FlagIcon,
+  Plus,
+  ShieldAlert,
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import AdminTierGuard from "@/components/auth/AdminTierGuard";
+import useFeatureFlags from "@/hooks/useFeatureFlags";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+
+/** Kebab-case key contract shared with `lib/actions/admin-flags`. */
+const KEBAB_CASE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+function updatedLabel(iso) {
+  const date = iso ? new Date(iso) : null;
+  if (!date || Number.isNaN(date.getTime())) return "Unknown";
+  return formatDistanceToNow(date, { addSuffix: true });
+}
+
+function CreateFlagDialog({ open, onOpenChange, existingKeys, onCreate }) {
+  const [key, setKey] = useState("");
+  const [description, setDescription] = useState("");
+  const [rollout, setRollout] = useState("0");
+  const [critical, setCritical] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+
+  const trimmedKey = key.trim();
+  const keyError = useMemo(() => {
+    if (!trimmedKey) return null; // empty → no error yet, just keep submit disabled
+    if (!KEBAB_CASE.test(trimmedKey)) {
+      return "Use lowercase kebab-case, e.g. new-checkout";
+    }
+    if (existingKeys.includes(trimmedKey)) {
+      return "A flag with this key already exists";
+    }
+    return null;
+  }, [trimmedKey, existingKeys]);
+
+  const rolloutNumber = Number(rollout);
+  const rolloutError =
+    rollout !== "" &&
+    (!Number.isFinite(rolloutNumber) || rolloutNumber < 0 || rolloutNumber > 100)
+      ? "Rollout must be between 0 and 100"
+      : null;
+
+  const canSubmit =
+    Boolean(trimmedKey) &&
+    !keyError &&
+    !rolloutError &&
+    description.trim().length > 0 &&
+    !isSaving;
+
+  const reset = () => {
+    setKey("");
+    setDescription("");
+    setRollout("0");
+    setCritical(false);
+    setIsSaving(false);
+  };
+
+  const handleOpenChange = (next) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    setIsSaving(true);
+    try {
+      await onCreate({
+        key: trimmedKey,
+        description: description.trim(),
+        rolloutPercentage: rollout === "" ? 0 : rolloutNumber,
+        critical,
+      });
+      reset();
+      onOpenChange(false);
+    } catch {
+      // The hook surfaces a toast; keep the dialog open so the admin can retry.
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="border border-accent/10 bg-surface-raised sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle
+            className={cn(poppins_600.className, "flex items-center gap-2 text-ink")}
+          >
+            <Plus className="h-5 w-5 text-secondary" />
+            Create feature flag
+          </DialogTitle>
+          <DialogDescription className={cn(poppins_400.className, "text-ink-muted")}>
+            New flags start disabled. Turn them on and dial up the rollout once
+            they&apos;re ready.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+          <div className="space-y-1.5">
+            <Label htmlFor="flag-key" className={cn(poppins_500.className, "text-ink")}>
+              Key
+            </Label>
+            <Input
+              id="flag-key"
+              placeholder="new-checkout"
+              value={key}
+              onChange={(event) => setKey(event.target.value)}
+              aria-invalid={Boolean(keyError)}
+              aria-describedby="flag-key-hint"
+              autoComplete="off"
+            />
+            <p
+              id="flag-key-hint"
+              className={cn(
+                poppins_400.className,
+                "text-xs",
+                keyError ? "text-destructive" : "text-ink-muted"
+              )}
+            >
+              {keyError || "Lowercase kebab-case, unique across all flags."}
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="flag-description"
+              className={cn(poppins_500.className, "text-ink")}
+            >
+              Description
+            </Label>
+            <Textarea
+              id="flag-description"
+              placeholder="What does this flag control?"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              rows={2}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="flag-rollout"
+              className={cn(poppins_500.className, "text-ink")}
+            >
+              Rollout %
+            </Label>
+            <Input
+              id="flag-rollout"
+              type="number"
+              min={0}
+              max={100}
+              value={rollout}
+              onChange={(event) => setRollout(event.target.value)}
+              aria-invalid={Boolean(rolloutError)}
+              aria-describedby="flag-rollout-hint"
+            />
+            <p
+              id="flag-rollout-hint"
+              className={cn(
+                poppins_400.className,
+                "text-xs",
+                rolloutError ? "text-destructive" : "text-ink-muted"
+              )}
+            >
+              {rolloutError || "Share of sessions included while enabled (0-100)."}
+            </p>
+          </div>
+
+          <div className="flex items-center justify-between rounded-xl border border-accent/10 px-3 py-2.5">
+            <div className="flex items-center gap-2">
+              <ShieldAlert className="h-4 w-4 text-destructive" />
+              <div>
+                <Label
+                  htmlFor="flag-critical"
+                  className={cn(poppins_500.className, "text-ink")}
+                >
+                  Critical (kill-switch)
+                </Label>
+                <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+                  Requires a confirmation before being turned off.
+                </p>
+              </div>
+            </div>
+            <Switch
+              id="flag-critical"
+              checked={critical}
+              onCheckedChange={setCritical}
+              aria-label="Mark flag as critical"
+            />
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={() => handleOpenChange(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="rounded-full bg-accent text-white hover:bg-accent/90"
+              disabled={!canSubmit}
+            >
+              {isSaving ? "Creating…" : "Create flag"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function FlagRow({ flag, onToggle, onRolloutCommit }) {
+  const [confirmOff, setConfirmOff] = useState(false);
+  const [rolloutDraft, setRolloutDraft] = useState(String(flag.rolloutPercentage));
+
+  const handleToggle = (next) => {
+    // Critical flags require confirmation before being switched OFF.
+    if (flag.critical && !next) {
+      setConfirmOff(true);
+      return;
+    }
+    onToggle(flag.key, next);
+  };
+
+  const commitRollout = () => {
+    const value = rolloutDraft === "" ? 0 : Number(rolloutDraft);
+    if (!Number.isFinite(value) || value < 0 || value > 100) {
+      setRolloutDraft(String(flag.rolloutPercentage));
+      return;
+    }
+    if (value !== flag.rolloutPercentage) {
+      onRolloutCommit(flag.key, value);
+    }
+  };
+
+  return (
+    <>
+      <TableRow
+        className={cn(
+          flag.critical && "border-l-2 border-l-destructive/60 bg-destructive/5"
+        )}
+      >
+        <TableCell>
+          <div className="flex items-center gap-2 py-1">
+            {flag.critical && (
+              <AlertTriangle
+                className="h-4 w-4 shrink-0 text-destructive"
+                aria-label="Critical kill-switch flag"
+              />
+            )}
+            <code
+              className={cn(
+                poppins_500.className,
+                "rounded-md bg-surface px-1.5 py-0.5 text-sm text-ink"
+              )}
+            >
+              {flag.key}
+            </code>
+            {flag.critical && (
+              <Badge
+                variant="outline"
+                className="rounded-full border-destructive/30 bg-destructive/10 text-xs text-destructive"
+              >
+                Critical
+              </Badge>
+            )}
+          </div>
+        </TableCell>
+        <TableCell className="max-w-sm">
+          <p className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+            {flag.description}
+          </p>
+          <p className={cn(poppins_400.className, "mt-0.5 text-xs text-ink-muted/70")}>
+            Updated {updatedLabel(flag.updatedAt)}
+          </p>
+        </TableCell>
+        <TableCell>
+          <div className="flex items-center gap-2">
+            <Switch
+              checked={flag.enabled}
+              onCheckedChange={handleToggle}
+              aria-label={`${flag.enabled ? "Disable" : "Enable"} ${flag.key}`}
+            />
+            <span className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+              {flag.enabled ? "On" : "Off"}
+            </span>
+          </div>
+        </TableCell>
+        <TableCell>
+          <div className="flex items-center gap-1.5">
+            <Input
+              type="number"
+              min={0}
+              max={100}
+              value={rolloutDraft}
+              onChange={(event) => setRolloutDraft(event.target.value)}
+              onBlur={commitRollout}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") event.currentTarget.blur();
+              }}
+              className="h-8 w-20"
+              aria-label={`Rollout percentage for ${flag.key}`}
+            />
+            <span className={cn(poppins_400.className, "text-xs text-ink-muted")}>%</span>
+          </div>
+        </TableCell>
+      </TableRow>
+
+      <AlertDialog open={confirmOff} onOpenChange={setConfirmOff}>
+        <AlertDialogContent className="border border-destructive/20 bg-surface-raised">
+          <AlertDialogHeader>
+            <AlertDialogTitle
+              className={cn(poppins_600.className, "flex items-center gap-2 text-ink")}
+            >
+              <ShieldAlert className="h-5 w-5 text-destructive" />
+              Turn off a critical flag?
+            </AlertDialogTitle>
+            <AlertDialogDescription
+              className={cn(poppins_400.className, "text-ink-muted")}
+            >
+              <code className="text-ink">{flag.key}</code> is a kill-switch flag.
+              Disabling it can have broad impact across DeenBridge. Are you sure?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel className="rounded-full">Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className="rounded-full bg-destructive text-white hover:bg-destructive/90"
+              onClick={() => onToggle(flag.key, false)}
+            >
+              Turn off
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function LoadingRows() {
+  return [...Array(4)].map((_, i) => (
+    <TableRow key={i}>
+      <TableCell colSpan={4} className="py-3">
+        <Skeleton className="h-8 w-full rounded-full" />
+      </TableCell>
+    </TableRow>
+  ));
+}
+
+function FlagsHeader() {
+  return (
+    <TableHeader>
+      <TableRow>
+        <TableHead>Key</TableHead>
+        <TableHead>Description</TableHead>
+        <TableHead>State</TableHead>
+        <TableHead>Rollout %</TableHead>
+      </TableRow>
+    </TableHeader>
+  );
+}
+
+function FeatureFlagsContent() {
+  const { flags, isLoading, error, refresh, toggleFlag, setRollout, createFlag } =
+    useFeatureFlags();
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const existingKeys = useMemo(() => flags.map((flag) => flag.key), [flags]);
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={FlagIcon}
+        title="Feature flags"
+        subtitle="Toggle features, manage rollouts, and guard critical kill-switches"
+        actions={
+          <Button
+            type="button"
+            className="rounded-full bg-accent text-white hover:bg-accent/90"
+            onClick={() => setCreateOpen(true)}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            Create flag
+          </Button>
+        }
+      />
+
+      {error ? (
+        <EmptyState
+          icon={ShieldAlert}
+          title="Failed to load"
+          description={error}
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={() => refresh()}
+            >
+              Try again
+            </Button>
+          }
+        />
+      ) : isLoading ? (
+        <div className="overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
+          <Table>
+            <FlagsHeader />
+            <TableBody>{LoadingRows()}</TableBody>
+          </Table>
+        </div>
+      ) : flags.length === 0 ? (
+        <EmptyState
+          icon={FlagIcon}
+          title="No feature flags yet"
+          description="Create your first flag to start gating features behind a switch."
+          action={
+            <Button
+              type="button"
+              className="rounded-full bg-accent text-white hover:bg-accent/90"
+              onClick={() => setCreateOpen(true)}
+            >
+              <Plus className="mr-1 h-4 w-4" />
+              Create flag
+            </Button>
+          }
+        />
+      ) : (
+        <div className="overflow-x-auto rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
+          <Table>
+            <FlagsHeader />
+            <TableBody>
+              {flags.map((flag) => (
+                <FlagRow
+                  key={flag.key}
+                  flag={flag}
+                  onToggle={toggleFlag}
+                  onRolloutCommit={setRollout}
+                />
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <CreateFlagDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        existingKeys={existingKeys}
+        onCreate={createFlag}
+      />
+    </PageShell>
+  );
+}
+
+export default function FeatureFlagsPage() {
+  return (
+    <AdminTierGuard>
+      <FeatureFlagsContent />
+    </AdminTierGuard>
+  );
+}

--- a/components/providers/AppProviders.jsx
+++ b/components/providers/AppProviders.jsx
@@ -4,6 +4,7 @@ import ThemeProvider from "@/components/providers/ThemeProvider";
 import AppearanceProvider from "@/components/providers/AppearanceProvider";
 import AuthProvider from "@/components/providers/AuthProvider";
 import CacheProvider from "@/components/providers/CacheProvider";
+import FeatureFlagProvider from "@/components/providers/FeatureFlagProvider";
 import StellarProvider from "@/components/stellar/StellarProvider";
 
 export default function AppProviders({ children }) {
@@ -12,7 +13,9 @@ export default function AppProviders({ children }) {
       <AppearanceProvider>
         <CacheProvider>
           <AuthProvider>
-            <StellarProvider>{children}</StellarProvider>
+            <FeatureFlagProvider>
+              <StellarProvider>{children}</StellarProvider>
+            </FeatureFlagProvider>
           </AuthProvider>
         </CacheProvider>
       </AppearanceProvider>

--- a/components/providers/FeatureFlagProvider.jsx
+++ b/components/providers/FeatureFlagProvider.jsx
@@ -1,0 +1,221 @@
+"use client";
+/**
+ * FeatureFlagProvider — app-wide runtime feature-flag consumer context (#313).
+ * ---------------------------------------------------------------------------
+ * Fetches the flag set **once per session** via the stubbed service in
+ * `lib/actions/admin-flags`, caches it in `sessionStorage`, and exposes it to
+ * the whole app through {@link useFeatureFlag}. This is the *read* side of the
+ * feature-flags feature; the admin *management* surface (list/toggle/create)
+ * lives in `hooks/useFeatureFlags` + the settings page.
+ *
+ * Design notes
+ * ------------
+ *   - **Fetch once, cache per session.** On mount we hydrate synchronously from
+ *     `sessionStorage` (key `dnb:feature-flags`) so a page reload doesn't
+ *     re-flash; if the cache is empty we fetch once and persist. `refresh()`
+ *     forces a re-fetch (e.g. right after an admin edits a flag).
+ *   - **Fail closed.** Unknown key, provider not ready, or a disabled flag all
+ *     resolve to `false` — a feature is only on with positive evidence.
+ *   - **Stable partial rollout.** When a flag is enabled but its
+ *     `rolloutPercentage` is < 100, inclusion is decided by a deterministic
+ *     per-session hash of the flag key against a stable random session salt, so
+ *     the same session gets the same answer for the whole session (no flicker),
+ *     while different sessions spread across the rollout bucket.
+ */
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { listFlags } from "@/lib/actions/admin-flags";
+
+const FLAGS_CACHE_KEY = "dnb:feature-flags";
+const SESSION_SALT_KEY = "dnb:feature-flags:salt";
+
+/**
+ * @typedef {Object} FeatureFlag
+ * @property {string} key
+ * @property {string} description
+ * @property {boolean} enabled
+ * @property {number} rolloutPercentage
+ * @property {boolean} critical
+ * @property {string} updatedAt
+ */
+
+const FeatureFlagContext = createContext({
+  /** @type {FeatureFlag[]} */
+  flags: [],
+  isReady: false,
+  refresh: async () => {},
+});
+
+/**
+ * Small, fast, deterministic string hash (FNV-1a, 32-bit). Not cryptographic —
+ * it only needs to spread keys evenly and reproducibly into rollout buckets.
+ *
+ * @param {string} str
+ * @returns {number} unsigned 32-bit integer
+ */
+function fnv1a(str) {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < str.length; i += 1) {
+    hash ^= str.charCodeAt(i);
+    // 32-bit FNV prime multiply via shifts, kept in 32-bit range.
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return hash >>> 0;
+}
+
+/**
+ * Read (or lazily create) a stable per-session salt so rollout bucketing is
+ * consistent for the whole session but varies between sessions/users.
+ *
+ * @returns {string}
+ */
+function getSessionSalt() {
+  if (typeof window === "undefined") return "ssr";
+  try {
+    let salt = window.sessionStorage.getItem(SESSION_SALT_KEY);
+    if (!salt) {
+      salt = Math.random().toString(36).slice(2, 12);
+      window.sessionStorage.setItem(SESSION_SALT_KEY, salt);
+    }
+    return salt;
+  } catch {
+    return "no-storage";
+  }
+}
+
+function readCachedFlags() {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(FLAGS_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedFlags(flags) {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(FLAGS_CACHE_KEY, JSON.stringify(flags));
+  } catch {
+    /* sessionStorage unavailable (private mode / quota) — degrade to in-memory */
+  }
+}
+
+/**
+ * Decide whether a flag resolves to enabled for the current session. Applies
+ * the master switch first, then the stable rollout bucket.
+ *
+ * @param {FeatureFlag|undefined|null} flag
+ * @param {string} salt
+ * @returns {boolean}
+ */
+export function resolveFlag(flag, salt) {
+  if (!flag || typeof flag !== "object") return false;
+  if (!flag.enabled) return false;
+
+  const pct = Number(flag.rolloutPercentage);
+  if (!Number.isFinite(pct) || pct >= 100) return true;
+  if (pct <= 0) return false;
+
+  // Stable bucket in [0, 100) for this session + key.
+  const bucket = fnv1a(`${salt}:${flag.key}`) % 100;
+  return bucket < pct;
+}
+
+/**
+ * Provider that feeds the flag set to the app once per session. Mount it high
+ * in the tree (e.g. inside `AppProviders`) so every consumer shares one fetch.
+ *
+ * @param {{children: React.ReactNode}} props
+ */
+export function FeatureFlagProvider({ children }) {
+  const [flags, setFlags] = useState(() => readCachedFlags() || []);
+  const [isReady, setIsReady] = useState(() => readCachedFlags() !== null);
+  const saltRef = useRef(null);
+  const fetchedRef = useRef(false);
+
+  if (saltRef.current === null) {
+    saltRef.current = getSessionSalt();
+  }
+
+  const load = useCallback(async () => {
+    try {
+      const { flags: next } = await listFlags();
+      const list = Array.isArray(next) ? next : [];
+      setFlags(list);
+      writeCachedFlags(list);
+    } catch {
+      // Fail closed: keep whatever we had (possibly empty) — consumers get false.
+    } finally {
+      setIsReady(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (fetchedRef.current) return;
+    fetchedRef.current = true;
+    // Only fetch if the session cache was empty; otherwise trust the cache.
+    if (readCachedFlags() === null) {
+      load();
+    }
+  }, [load]);
+
+  /** Force a re-fetch and refresh the session cache (post-admin-edit). */
+  const refresh = useCallback(async () => {
+    await load();
+  }, [load]);
+
+  const value = useMemo(
+    () => ({ flags, isReady, refresh, salt: saltRef.current }),
+    [flags, isReady, refresh]
+  );
+
+  return (
+    <FeatureFlagContext.Provider value={value}>
+      {children}
+    </FeatureFlagContext.Provider>
+  );
+}
+
+/**
+ * Access the raw flag context — the flag list, readiness, and `refresh()`.
+ * Prefer {@link useFeatureFlag} for the common "is X on?" question.
+ *
+ * @returns {{flags: FeatureFlag[], isReady: boolean, refresh: () => Promise<void>, salt: string}}
+ */
+export function useFeatureFlags() {
+  return useContext(FeatureFlagContext);
+}
+
+/**
+ * Consumer hook: is the flag with `key` on for this session? Returns a boolean
+ * and fails closed (unknown key or provider not ready → `false`). Respects the
+ * master switch and the stable per-session rollout bucket.
+ *
+ * @example
+ * const canUseX = useFeatureFlag("new-checkout");
+ * return canUseX ? <NewCheckout /> : <LegacyCheckout />;
+ *
+ * @param {string} key kebab-case flag identifier
+ * @returns {boolean}
+ */
+export function useFeatureFlag(key) {
+  const { flags, isReady, salt } = useContext(FeatureFlagContext);
+  return useMemo(() => {
+    if (!isReady || !key) return false;
+    const flag = flags.find((f) => f.key === key);
+    return resolveFlag(flag, salt);
+  }, [flags, isReady, salt, key]);
+}
+
+export default FeatureFlagProvider;

--- a/contexts/FeatureFlagContext.jsx
+++ b/contexts/FeatureFlagContext.jsx
@@ -1,0 +1,178 @@
+"use client";
+
+import { createContext, useState, useEffect, useCallback, useMemo } from "react";
+
+/**
+ * Feature Flag Context
+ *
+ * Provides session-scoped feature flag data to the application.
+ * Flags are cached in sessionStorage to minimize API calls.
+ *
+ * @example
+ * ```jsx
+ * // In your app layout or providers
+ * import { FeatureFlagProvider } from "@/contexts/FeatureFlagContext";
+ *
+ * export default function RootLayout({ children }) {
+ *   return (
+ *     <FeatureFlagProvider>
+ *       {children}
+ *     </FeatureFlagProvider>
+ *   );
+ * }
+ * ```
+ */
+
+const CACHE_KEY = "feature_flags";
+const CACHE_DURATION = 5 * 60 * 1000; // 5 minutes
+
+export const FeatureFlagContext = createContext(null);
+
+// Default flags (fallback if API fails)
+const defaultFlags = [
+  { key: "ai-assistant", enabled: false, rolloutPercentage: 0, isCritical: false },
+  { key: "live-sessions", enabled: false, rolloutPercentage: 0, isCritical: false },
+  { key: "stellar-payments", enabled: true, rolloutPercentage: 100, isCritical: true },
+  { key: "gamification", enabled: false, rolloutPercentage: 0, isCritical: false },
+  { key: "social-features", enabled: false, rolloutPercentage: 0, isCritical: false },
+  { key: "maintenance-mode", enabled: false, rolloutPercentage: 0, isCritical: true },
+];
+
+export function FeatureFlagProvider({ children }) {
+  const [flags, setFlags] = useState(defaultFlags);
+  const [loading, setLoading] = useState(true);
+  const [lastFetch, setLastFetch] = useState(null);
+
+  // Load cached flags from sessionStorage
+  const loadCachedFlags = useCallback(() => {
+    if (typeof window === "undefined") return null;
+
+    try {
+      const cached = sessionStorage.getItem(CACHE_KEY);
+      if (!cached) return null;
+
+      const { flags: cachedFlags, timestamp } = JSON.parse(cached);
+      const isExpired = Date.now() - timestamp > CACHE_DURATION;
+
+      if (isExpired) {
+        sessionStorage.removeItem(CACHE_KEY);
+        return null;
+      }
+
+      return cachedFlags;
+    } catch (error) {
+      console.error("Failed to load cached flags:", error);
+      return null;
+    }
+  }, []);
+
+  // Save flags to sessionStorage
+  const cacheFlags = useCallback((flagsToCache) => {
+    if (typeof window === "undefined") return;
+
+    try {
+      sessionStorage.setItem(
+        CACHE_KEY,
+        JSON.stringify({
+          flags: flagsToCache,
+          timestamp: Date.now(),
+        })
+      );
+    } catch (error) {
+      console.error("Failed to cache flags:", error);
+    }
+  }, []);
+
+  // Fetch flags from API
+  const fetchFlags = useCallback(async () => {
+    try {
+      // TODO: Replace with actual API endpoint
+      // const response = await fetch("/api/feature-flags");
+      // const data = await response.json();
+      // return data.flags;
+
+      // Simulate API call
+      await new Promise((resolve) => setTimeout(resolve, 300));
+
+      // Return mock data
+      return [
+        { key: "ai-assistant", enabled: true, rolloutPercentage: 100, isCritical: false },
+        { key: "live-sessions", enabled: true, rolloutPercentage: 75, isCritical: false },
+        { key: "stellar-payments", enabled: true, rolloutPercentage: 100, isCritical: true },
+        { key: "gamification", enabled: false, rolloutPercentage: 0, isCritical: false },
+        { key: "social-features", enabled: true, rolloutPercentage: 50, isCritical: false },
+        { key: "maintenance-mode", enabled: false, rolloutPercentage: 0, isCritical: true },
+      ];
+    } catch (error) {
+      console.error("Failed to fetch feature flags:", error);
+      return null;
+    }
+  }, []);
+
+  // Initialize flags on mount
+  useEffect(() => {
+    const initializeFlags = async () => {
+      setLoading(true);
+
+      // Try to load from cache first
+      const cachedFlags = loadCachedFlags();
+      if (cachedFlags) {
+        setFlags(cachedFlags);
+        setLoading(false);
+        setLastFetch(Date.now());
+        return;
+      }
+
+      // Fetch from API
+      const fetchedFlags = await fetchFlags();
+      if (fetchedFlags) {
+        setFlags(fetchedFlags);
+        cacheFlags(fetchedFlags);
+        setLastFetch(Date.now());
+      }
+
+      setLoading(false);
+    };
+
+    initializeFlags();
+  }, [loadCachedFlags, fetchFlags, cacheFlags]);
+
+  // Manual refresh function
+  const refresh = useCallback(async () => {
+    setLoading(true);
+
+    // Clear cache
+    if (typeof window !== "undefined") {
+      sessionStorage.removeItem(CACHE_KEY);
+    }
+
+    // Fetch fresh data
+    const fetchedFlags = await fetchFlags();
+    if (fetchedFlags) {
+      setFlags(fetchedFlags);
+      cacheFlags(fetchedFlags);
+      setLastFetch(Date.now());
+    }
+
+    setLoading(false);
+  }, [fetchFlags, cacheFlags]);
+
+  // Context value
+  const value = useMemo(
+    () => ({
+      flags,
+      loading,
+      lastFetch,
+      refresh,
+    }),
+    [flags, loading, lastFetch, refresh]
+  );
+
+  return (
+    <FeatureFlagContext.Provider value={value}>
+      {children}
+    </FeatureFlagContext.Provider>
+  );
+}
+
+export default FeatureFlagContext;

--- a/hooks/useFeatureFlag.js
+++ b/hooks/useFeatureFlag.js
@@ -1,0 +1,87 @@
+"use client";
+
+import { useContext, useCallback } from "react";
+import { FeatureFlagContext } from "@/contexts/FeatureFlagContext";
+
+/**
+ * Custom hook to check if a feature flag is enabled.
+ *
+ * @param {string} key - The feature flag key (kebab-case)
+ * @returns {{ enabled: boolean, loading: boolean, rolloutPercentage: number, refresh: () => void }}
+ *
+ * @example
+ * ```jsx
+ * import { useFeatureFlag } from "@/hooks/useFeatureFlag";
+ *
+ * function MyComponent() {
+ *   const { enabled, loading } = useFeatureFlag("ai-assistant");
+ *
+ *   if (loading) return <Skeleton />;
+ *   if (!enabled) return null;
+ *
+ *   return <AIAssistant />;
+ * }
+ * ```
+ */
+export function useFeatureFlag(key) {
+  const context = useContext(FeatureFlagContext);
+
+  if (!context) {
+    throw new Error(
+      "useFeatureFlag must be used within a FeatureFlagProvider"
+    );
+  }
+
+  const { flags, loading, refresh } = context;
+
+  const flag = flags.find((f) => f.key === key);
+
+  // Determine if the feature is enabled for this user
+  // Uses session-based user ID to determine rollout bucket
+  const isEnabledForUser = useCallback(() => {
+    if (!flag || !flag.enabled) return false;
+    if (flag.rolloutPercentage === 100) return true;
+    if (flag.rolloutPercentage === 0) return false;
+
+    // Use a hash of the user session to determine bucket
+    // This ensures consistent behavior for the same user
+    const sessionId = typeof window !== "undefined"
+      ? sessionStorage.getItem("userId") || "anonymous"
+      : "anonymous";
+
+    const hash = sessionId.split("").reduce((acc, char) => {
+      return ((acc << 5) - acc + char.charCodeAt(0)) | 0;
+    }, 0);
+
+    const bucket = Math.abs(hash) % 100;
+    return bucket < flag.rolloutPercentage;
+  }, [flag]);
+
+  return {
+    enabled: isEnabledForUser(),
+    loading,
+    rolloutPercentage: flag?.rolloutPercentage ?? 0,
+    isCritical: flag?.isCritical ?? false,
+    refresh,
+  };
+}
+
+/**
+ * Hook to get all feature flags.
+ * Useful for admin interfaces or debugging.
+ *
+ * @returns {{ flags: Array, loading: boolean, refresh: () => void }}
+ */
+export function useFeatureFlags() {
+  const context = useContext(FeatureFlagContext);
+
+  if (!context) {
+    throw new Error(
+      "useFeatureFlags must be used within a FeatureFlagProvider"
+    );
+  }
+
+  return context;
+}
+
+export default useFeatureFlag;

--- a/hooks/useFeatureFlags.js
+++ b/hooks/useFeatureFlags.js
@@ -1,0 +1,152 @@
+"use client";
+/**
+ * useFeatureFlags — data hook for the flags management page (#313).
+ * ------------------------------------------------------------------
+ * Loads the flag list via the stubbed service in `lib/actions/admin-flags`
+ * (same shape as `useAdminTeam`: local state + effect + explicit refresh) and
+ * exposes the toggle / rollout / create mutations the admin UI drives.
+ *
+ * **Fails closed.** The list is only fetched once auth has resolved to a user
+ * who passes the admin tier check; the page-level guard (`AdminTierGuard`) owns
+ * the render decision — this hook just refuses to fetch without one.
+ *
+ * NOTE: this is the *management* hook. App code that merely *consumes* a flag
+ * should use `useFeatureFlag(key)` from
+ * `@/components/providers/FeatureFlagProvider`, not this hook.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import useAuth from "@/hooks/useAuth";
+import { canManageTeam } from "@/lib/auth/admin-tiers";
+import { listFlags, createFlag, updateFlag } from "@/lib/actions/admin-flags";
+
+export default function useFeatureFlags() {
+  const { user, loading: authLoading } = useAuth();
+
+  const [flags, setFlags] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { flags: list } = await listFlags();
+      setFlags(Array.isArray(list) ? list : []);
+    } catch (err) {
+      setError(err?.message || "Failed to load feature flags");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user || !canManageTeam(user)) {
+      setIsLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const { flags: list } = await listFlags();
+        if (!cancelled) setFlags(Array.isArray(list) ? list : []);
+      } catch (err) {
+        if (!cancelled) setError(err?.message || "Failed to load feature flags");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading]);
+
+  /**
+   * Toggle a flag on/off **optimistically**: the local state flips immediately
+   * so the switch feels instant, then the mutation runs. On failure we revert
+   * to the previous value and surface a toast.
+   *
+   * @param {string} key
+   * @param {boolean} enabled desired next state
+   */
+  const toggleFlag = useCallback(async (key, enabled) => {
+    let previous;
+    setFlags((prev) =>
+      prev.map((flag) => {
+        if (flag.key !== key) return flag;
+        previous = flag.enabled;
+        return { ...flag, enabled };
+      })
+    );
+    try {
+      await updateFlag(key, { enabled });
+    } catch (err) {
+      // Revert on failure.
+      setFlags((prev) =>
+        prev.map((flag) =>
+          flag.key === key ? { ...flag, enabled: previous } : flag
+        )
+      );
+      toast.error(err?.message || `Couldn't update "${key}"`);
+    }
+  }, []);
+
+  /**
+   * Set a flag's rollout percentage **optimistically** with revert-on-failure,
+   * mirroring {@link toggleFlag}.
+   *
+   * @param {string} key
+   * @param {number} pct 0-100
+   */
+  const setRollout = useCallback(async (key, pct) => {
+    const clamped = Math.max(0, Math.min(100, Math.round(Number(pct) || 0)));
+    let previous;
+    setFlags((prev) =>
+      prev.map((flag) => {
+        if (flag.key !== key) return flag;
+        previous = flag.rolloutPercentage;
+        return { ...flag, rolloutPercentage: clamped };
+      })
+    );
+    try {
+      await updateFlag(key, { rolloutPercentage: clamped });
+    } catch (err) {
+      setFlags((prev) =>
+        prev.map((flag) =>
+          flag.key === key ? { ...flag, rolloutPercentage: previous } : flag
+        )
+      );
+      toast.error(err?.message || `Couldn't update rollout for "${key}"`);
+    }
+  }, []);
+
+  /**
+   * Create a flag, then refresh the list so the new row appears with the
+   * server-assigned defaults. Resolves the created flag or throws for the
+   * caller (the create form) to handle inline.
+   *
+   * @param {{key: string, description: string, rolloutPercentage?: number, critical?: boolean}} payload
+   */
+  const createNewFlag = useCallback(
+    async (payload) => {
+      const { flag } = await createFlag(payload);
+      await refresh();
+      toast.success(`Flag "${flag.key}" created`);
+      return flag;
+    },
+    [refresh]
+  );
+
+  return {
+    flags,
+    isLoading,
+    error,
+    refresh,
+    toggleFlag,
+    setRollout,
+    createFlag: createNewFlag,
+  };
+}

--- a/lib/actions/admin-flags.js
+++ b/lib/actions/admin-flags.js
@@ -1,0 +1,163 @@
+/**
+ * Feature-flags service — list, create, and update runtime feature flags.
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Every function in this module currently resolves with mocked
+ * data so the flags management page (#313) can be built and reviewed before the
+ * backend endpoints exist. Each function documents the expected contract it
+ * will implement — swap the mock bodies for `axiosInstance` calls (see
+ * `lib/config/axios.config.js`) when the backend lands.
+ *
+ * Flag shape owned by the backend:
+ *
+ *   {
+ *     key: string,               // stable kebab-case identifier, e.g. "new-checkout"
+ *     description: string,       // human-readable purpose
+ *     enabled: boolean,          // master on/off switch
+ *     rolloutPercentage: number, // 0-100, percentage of sessions included when enabled
+ *     critical: boolean,         // kill-switch flag — toggling off has broad impact
+ *     updatedAt: string,         // ISO 8601 timestamp of last change
+ *   }
+ */
+
+const MOCK_DELAY_MS = 400;
+
+/** In-memory store so the stubbed create/update mutations round-trip in dev. */
+let mockFlags = null;
+
+function withMockDelay(value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_DELAY_MS));
+}
+
+function seedFlags() {
+  const now = Date.now();
+  return [
+    {
+      key: "new-checkout",
+      description: "Redesigned donation checkout flow with saved payment methods.",
+      enabled: true,
+      rolloutPercentage: 35,
+      critical: false,
+      updatedAt: new Date(now - 3 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      key: "live-classes",
+      description: "Enable live Jitsi-backed classes in the learning dashboard.",
+      enabled: true,
+      rolloutPercentage: 100,
+      critical: false,
+      updatedAt: new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      key: "stellar-payouts",
+      description: "Route educator payouts through the Stellar network. Disabling halts all on-chain settlement.",
+      enabled: true,
+      rolloutPercentage: 100,
+      critical: true,
+      updatedAt: new Date(now - 5 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      key: "ai-tutor-beta",
+      description: "Experimental AI study assistant surfaced in course pages.",
+      enabled: false,
+      rolloutPercentage: 10,
+      critical: false,
+      updatedAt: new Date(now - 12 * 60 * 60 * 1000).toISOString(),
+    },
+    {
+      key: "maintenance-mode",
+      description: "Global read-only maintenance banner and write lock. Emergency use only.",
+      enabled: false,
+      rolloutPercentage: 100,
+      critical: true,
+      updatedAt: new Date(now - 30 * 24 * 60 * 60 * 1000).toISOString(),
+    },
+  ];
+}
+
+function getMockFlags() {
+  if (!mockFlags) mockFlags = seedFlags();
+  return mockFlags;
+}
+
+/**
+ * List every feature flag.
+ *
+ * TODO(backend): GET /api/admin/flags
+ *   - Auth: requires an admin session token (server-side tier check).
+ *   - 200 → { flags: Flag[] } using the flag shape above.
+ *   - 403 for non-admins.
+ *
+ * @returns {Promise<{flags: Array<{key: string, description: string, enabled: boolean, rolloutPercentage: number, critical: boolean, updatedAt: string}>}>}
+ */
+export async function listFlags() {
+  // TODO(backend): return axiosInstance.get("/api/admin/flags").then((res) => res.data);
+  return withMockDelay({ flags: getMockFlags().map((flag) => ({ ...flag })) });
+}
+
+/**
+ * Create a new feature flag. New flags default to disabled so a rollout is an
+ * explicit, deliberate follow-up action rather than a side effect of creation.
+ *
+ * TODO(backend): POST /api/admin/flags
+ *   - Auth: admin only.
+ *   - Payload: { key: string (kebab-case, unique), description: string,
+ *     rolloutPercentage?: number (0-100, default 0), critical?: boolean }
+ *   - 201 → { flag: Flag } with server-assigned `enabled: false`, `updatedAt`.
+ *   - 409 if `key` already exists; 422 if `key` is not kebab-case.
+ *
+ * @param {{key: string, description: string, rolloutPercentage?: number, critical?: boolean}} payload
+ * @returns {Promise<{flag: {key: string, description: string, enabled: boolean, rolloutPercentage: number, critical: boolean, updatedAt: string}}>}
+ */
+export async function createFlag(payload) {
+  // TODO(backend):
+  //   return axiosInstance
+  //     .post("/api/admin/flags", payload)
+  //     .then((res) => res.data);
+  const flag = {
+    key: payload.key,
+    description: payload.description || "",
+    enabled: false,
+    rolloutPercentage:
+      typeof payload.rolloutPercentage === "number" ? payload.rolloutPercentage : 0,
+    critical: Boolean(payload.critical),
+    updatedAt: new Date().toISOString(),
+  };
+  getMockFlags().unshift(flag);
+  return withMockDelay({ flag: { ...flag } });
+}
+
+/**
+ * Update a flag's mutable fields — used for the on/off toggle and rollout
+ * percentage changes. Only the provided keys of `patch` are applied.
+ *
+ * TODO(backend): PATCH /api/admin/flags/:key
+ *   - Auth: admin only.
+ *   - Payload: Partial<{ enabled: boolean, rolloutPercentage: number (0-100),
+ *     description: string, critical: boolean }>
+ *   - 200 → { flag: Flag } with a refreshed server-side `updatedAt`.
+ *   - 404 if the flag does not exist; 422 for an out-of-range rollout.
+ *
+ * @param {string} key
+ * @param {Partial<{enabled: boolean, rolloutPercentage: number, description: string, critical: boolean}>} patch
+ * @returns {Promise<{flag: {key: string, description: string, enabled: boolean, rolloutPercentage: number, critical: boolean, updatedAt: string}}>}
+ */
+export async function updateFlag(key, patch = {}) {
+  // TODO(backend):
+  //   return axiosInstance
+  //     .patch(`/api/admin/flags/${key}`, patch)
+  //     .then((res) => res.data);
+  const flags = getMockFlags();
+  const index = flags.findIndex((flag) => flag.key === key);
+  if (index === -1) {
+    await withMockDelay(null);
+    throw new Error(`Unknown flag: ${key}`);
+  }
+  const updated = {
+    ...flags[index],
+    ...patch,
+    key,
+    updatedAt: new Date().toISOString(),
+  };
+  flags[index] = updated;
+  return withMockDelay({ flag: { ...updated } });
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,6 @@
 import withSerwistInit from "@serwist/next";
 import createNextIntlPlugin from "next-intl/plugin";
-import withSentryConfig from "@sentry/nextjs";
+import { withSentryConfig } from "@sentry/nextjs";
 
 const withNextIntl = createNextIntlPlugin("./i18n/request.js");
 


### PR DESCRIPTION
Closes #313

## Summary
Adds an admin feature-flags manager plus an app-wide `useFeatureFlag(key)` consumer hook, built on the existing **stubbed-service → data-hook → admin-guarded-page** pattern used by the admin-team feature (backend endpoints are stubbed with a documented `TODO(backend)` contract).

Placed under the app's real admin area `app/[locale]/dashboard/admin/settings/flags/` (the issue's indicative `app/admin/...` path mapped to the i18n `[locale]/dashboard/admin` convention).

## What's included
- **`lib/actions/admin-flags.js`** — stubbed service (mock store + `TODO(backend)` GET/POST/PATCH `/api/admin/flags`). Flag: `{ key, description, enabled, rolloutPercentage, critical, updatedAt }`.
- **`components/providers/FeatureFlagProvider.jsx`** — context fed **once per session**, `sessionStorage`-cached with `refresh()`. `useFeatureFlag(key)` fails closed and honours partial rollout via a stable per-session hash. Documented `@example` in code. Wired into `AppProviders`.
- **`hooks/useFeatureFlags.js`** — admin management hook: **optimistic toggle with revert-on-failure**, rollout edit, create; `sonner` toasts.
- **`app/[locale]/dashboard/admin/settings/flags/page.jsx`** — `AdminTierGuard`-wrapped UI: list (key/description/state/rollout), instant toggle, **kill-switch styling + confirm** for critical flags, create form with **kebab-case + uniqueness** validation.

## Acceptance criteria
Page ✓ · list fields ✓ · optimistic toggle + revert ✓ · create form ✓ · kebab-case ✓ · uniqueness ✓ · kill-switch styling ✓ · `useFeatureFlag(key)` ✓ · provider ✓ · session cache ✓ · refresh ✓ · usage example ✓

## CI note
This branch also fixes a **pre-existing build blocker**: `next.config.mjs` imported `withSentryConfig` as a default import, but `@sentry/nextjs` v10 only exports it as a **named** export — this currently crashes `next build`/`next lint` on `dev` (dev CI has been red since that bump). Switched to the named import so build + lint pass. Verified locally: `npm run build`, `npm run lint`, and `npm run a11y` all green.