### PR TITLE
feat(admin): scheduled report digests configuration (#306)

### DIFF
--- a/app/[locale]/dashboard/admin/settings/digests/page.jsx
+++ b/app/[locale]/dashboard/admin/settings/digests/page.jsx
@@ -1,0 +1,525 @@
+"use client";
+/**
+ * Scheduled report digests configuration page (#306).
+ * ---------------------------------------------------------------------------
+ * Super-admin surface (wrapped in `AdminTierGuard`) for configuring the
+ * recurring digest emails the backend sends. Mirrors the feature-flags page's
+ * structure: a `PageShell` + `PageHeader`, `Card` sections, `Skeleton` loading,
+ * an `EmptyState` error path, and inline field validation.
+ *
+ * Frontend owns configuration UX only — the backend runs the schedule and sends
+ * the emails. Three sections:
+ *   (a) per-type toggles (Moderation / Revenue / Signups summaries);
+ *   (b) a delivery-schedule picker (day / hour / minute / timezone) with a
+ *       read-only cron preview + human sentence;
+ *   (c) recipient management (add email → removable chips, inline validation).
+ *
+ * Save is disabled while the client-side validation (`validateDigestConfig`)
+ * fails, so a malformed cron-ish selection can never be submitted.
+ */
+import { useMemo, useState } from "react";
+import {
+  CalendarClock,
+  Clock,
+  Mail,
+  Plus,
+  Save,
+  ShieldAlert,
+  TriangleAlert,
+  X,
+} from "lucide-react";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import AdminTierGuard from "@/components/auth/AdminTierGuard";
+import useDigestConfig from "@/hooks/useDigestConfig";
+import {
+  ALLOWED_MINUTES,
+  DAY_LABELS,
+  isValidEmail,
+  scheduleToCron,
+  TIMEZONES,
+} from "@/lib/actions/admin-digests";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+/** Static copy for each digest toggle, in display order. */
+const DIGEST_META = [
+  {
+    type: "moderation",
+    label: "Moderation summary",
+    description:
+      "Pending reports, flagged content, and recent moderation actions.",
+  },
+  {
+    type: "revenue",
+    label: "Revenue summary",
+    description: "Donations, payouts, and settlement totals for the period.",
+  },
+  {
+    type: "signups",
+    label: "Signups summary",
+    description: "New learners and educators who joined since the last digest.",
+  },
+];
+
+const HOURS = Array.from({ length: 24 }, (_, h) => h);
+
+const pad2 = (n) => String(n).padStart(2, "0");
+
+/** "Every Monday at 09:00 (UTC)" from a schedule object. */
+function humanSchedule(schedule) {
+  const day = DAY_LABELS[schedule?.dayOfWeek];
+  if (!day || !Number.isInteger(schedule?.hour) || !Number.isInteger(schedule?.minute)) {
+    return "Incomplete schedule";
+  }
+  return `Every ${day} at ${pad2(schedule.hour)}:${pad2(schedule.minute)} (${
+    schedule.timezone || "UTC"
+  })`;
+}
+
+/** One digest on/off row. */
+function DigestToggleRow({ meta, enabled, onToggle }) {
+  const switchId = `digest-${meta.type}`;
+  return (
+    <div className="flex items-start justify-between gap-4 rounded-xl border border-accent/10 px-4 py-3">
+      <div className="space-y-0.5">
+        <Label htmlFor={switchId} className={cn(poppins_500.className, "text-ink")}>
+          {meta.label}
+        </Label>
+        <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+          {meta.description}
+        </p>
+      </div>
+      <Switch
+        id={switchId}
+        checked={enabled}
+        onCheckedChange={() => onToggle(meta.type)}
+        aria-label={`${enabled ? "Disable" : "Enable"} ${meta.label}`}
+      />
+    </div>
+  );
+}
+
+function FieldError({ id, message }) {
+  if (!message) return null;
+  return (
+    <p id={id} className={cn(poppins_400.className, "text-xs text-destructive")}>
+      {message}
+    </p>
+  );
+}
+
+function DigestsContent() {
+  const {
+    config,
+    toggleDigest,
+    setSchedule,
+    addRecipient,
+    removeRecipient,
+    errors,
+    warning,
+    isValid,
+    isLoading,
+    isSaving,
+    error,
+    save,
+    refresh,
+  } = useDigestConfig();
+
+  const [emailDraft, setEmailDraft] = useState("");
+
+  const draftEmail = emailDraft.trim();
+  const draftEmailError = useMemo(() => {
+    if (!draftEmail) return null;
+    if (!isValidEmail(draftEmail)) return "Enter a valid email address.";
+    if (
+      config?.recipients?.some(
+        (r) => r.toLowerCase() === draftEmail.toLowerCase()
+      )
+    ) {
+      return "That recipient is already on the list.";
+    }
+    return null;
+  }, [draftEmail, config?.recipients]);
+
+  const cronPreview = config ? scheduleToCron(config.schedule) : "";
+
+  const handleAddRecipient = () => {
+    if (!draftEmail || draftEmailError) return;
+    if (addRecipient(draftEmail)) setEmailDraft("");
+  };
+
+  if (error) {
+    return (
+      <PageShell>
+        <PageHeader
+          icon={CalendarClock}
+          title="Scheduled digests"
+          subtitle="Configure recurring report emails for the admin team"
+        />
+        <EmptyState
+          icon={ShieldAlert}
+          title="Failed to load"
+          description={error}
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={() => refresh()}
+            >
+              Try again
+            </Button>
+          }
+        />
+      </PageShell>
+    );
+  }
+
+  if (isLoading || !config) {
+    return (
+      <PageShell>
+        <PageHeader
+          icon={CalendarClock}
+          title="Scheduled digests"
+          subtitle="Configure recurring report emails for the admin team"
+        />
+        <div className="space-y-6">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} className="h-48 w-full rounded-2xl" />
+          ))}
+        </div>
+      </PageShell>
+    );
+  }
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={CalendarClock}
+        title="Scheduled digests"
+        subtitle="Configure recurring report emails for the admin team"
+        actions={
+          <Button
+            type="button"
+            className="rounded-full bg-accent text-white hover:bg-accent/90"
+            onClick={() => save()}
+            disabled={!isValid || isSaving}
+          >
+            <Save className="mr-1 h-4 w-4" />
+            {isSaving ? "Saving…" : "Save changes"}
+          </Button>
+        }
+      />
+
+      {warning && (
+        <div className="flex items-center gap-2 rounded-xl border border-highlight/30 bg-highlight/10 px-4 py-2.5">
+          <TriangleAlert className="h-4 w-4 shrink-0 text-highlight" aria-hidden="true" />
+          <p className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+            {warning}
+          </p>
+        </div>
+      )}
+
+      {/* (a) Digest-type toggles */}
+      <Card className="rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
+        <CardHeader>
+          <CardTitle className={cn(poppins_600.className, "text-ink")}>
+            Report types
+          </CardTitle>
+          <CardDescription className={cn(poppins_400.className, "text-ink-muted")}>
+            Choose which summaries the scheduled digest includes.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {DIGEST_META.map((meta) => (
+            <DigestToggleRow
+              key={meta.type}
+              meta={meta}
+              enabled={Boolean(config.digests?.[meta.type]?.enabled)}
+              onToggle={toggleDigest}
+            />
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* (b) Delivery schedule */}
+      <Card className="rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
+        <CardHeader>
+          <CardTitle
+            className={cn(poppins_600.className, "flex items-center gap-2 text-ink")}
+          >
+            <Clock className="h-5 w-5 text-secondary" />
+            Delivery schedule
+          </CardTitle>
+          <CardDescription className={cn(poppins_400.className, "text-ink-muted")}>
+            Digests are sent once a week at the day and time you pick.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {/* Day of week */}
+            <div className="space-y-1.5">
+              <Label htmlFor="schedule-day" className={cn(poppins_500.className, "text-ink")}>
+                Day
+              </Label>
+              <Select
+                value={String(config.schedule.dayOfWeek)}
+                onValueChange={(value) => setSchedule({ dayOfWeek: Number(value) })}
+              >
+                <SelectTrigger
+                  id="schedule-day"
+                  className="w-full"
+                  aria-invalid={Boolean(errors.dayOfWeek)}
+                  aria-describedby="schedule-day-error"
+                >
+                  <SelectValue placeholder="Select a day" />
+                </SelectTrigger>
+                <SelectContent>
+                  {DAY_LABELS.map((label, index) => (
+                    <SelectItem key={label} value={String(index)}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FieldError id="schedule-day-error" message={errors.dayOfWeek} />
+            </div>
+
+            {/* Hour */}
+            <div className="space-y-1.5">
+              <Label htmlFor="schedule-hour" className={cn(poppins_500.className, "text-ink")}>
+                Hour
+              </Label>
+              <Select
+                value={String(config.schedule.hour)}
+                onValueChange={(value) => setSchedule({ hour: Number(value) })}
+              >
+                <SelectTrigger
+                  id="schedule-hour"
+                  className="w-full"
+                  aria-invalid={Boolean(errors.hour)}
+                  aria-describedby="schedule-hour-error"
+                >
+                  <SelectValue placeholder="00" />
+                </SelectTrigger>
+                <SelectContent>
+                  {HOURS.map((h) => (
+                    <SelectItem key={h} value={String(h)}>
+                      {pad2(h)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FieldError id="schedule-hour-error" message={errors.hour} />
+            </div>
+
+            {/* Minute */}
+            <div className="space-y-1.5">
+              <Label htmlFor="schedule-minute" className={cn(poppins_500.className, "text-ink")}>
+                Minute
+              </Label>
+              <Select
+                value={String(config.schedule.minute)}
+                onValueChange={(value) => setSchedule({ minute: Number(value) })}
+              >
+                <SelectTrigger
+                  id="schedule-minute"
+                  className="w-full"
+                  aria-invalid={Boolean(errors.minute)}
+                  aria-describedby="schedule-minute-error"
+                >
+                  <SelectValue placeholder="00" />
+                </SelectTrigger>
+                <SelectContent>
+                  {ALLOWED_MINUTES.map((m) => (
+                    <SelectItem key={m} value={String(m)}>
+                      {pad2(m)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FieldError id="schedule-minute-error" message={errors.minute} />
+            </div>
+
+            {/* Timezone */}
+            <div className="space-y-1.5">
+              <Label htmlFor="schedule-tz" className={cn(poppins_500.className, "text-ink")}>
+                Timezone
+              </Label>
+              <Select
+                value={config.schedule.timezone}
+                onValueChange={(value) => setSchedule({ timezone: value })}
+              >
+                <SelectTrigger
+                  id="schedule-tz"
+                  className="w-full"
+                  aria-invalid={Boolean(errors.timezone)}
+                  aria-describedby="schedule-tz-error"
+                >
+                  <SelectValue placeholder="Select a timezone" />
+                </SelectTrigger>
+                <SelectContent>
+                  {TIMEZONES.map((tz) => (
+                    <SelectItem key={tz} value={tz}>
+                      {tz}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FieldError id="schedule-tz-error" message={errors.timezone} />
+            </div>
+          </div>
+
+          {/* Read-only preview: cron string + human sentence */}
+          <div className="flex flex-wrap items-center gap-3 rounded-xl border border-accent/10 bg-surface px-4 py-3">
+            <span className={cn(poppins_500.className, "text-sm text-ink")}>
+              {humanSchedule(config.schedule)}
+            </span>
+            <Badge
+              variant="outline"
+              className={cn(
+                poppins_500.className,
+                "rounded-full border-secondary/30 bg-secondary/10 text-secondary"
+              )}
+            >
+              cron: {cronPreview}
+            </Badge>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* (c) Recipients */}
+      <Card className="rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
+        <CardHeader>
+          <CardTitle
+            className={cn(poppins_600.className, "flex items-center gap-2 text-ink")}
+          >
+            <Mail className="h-5 w-5 text-secondary" />
+            Recipients
+          </CardTitle>
+          <CardDescription className={cn(poppins_400.className, "text-ink-muted")}>
+            Admin email addresses that receive every scheduled digest.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="recipient-email" className={cn(poppins_500.className, "text-ink")}>
+              Add recipient
+            </Label>
+            <div className="flex items-start gap-2">
+              <div className="flex-1 space-y-1.5">
+                <Input
+                  id="recipient-email"
+                  type="email"
+                  inputMode="email"
+                  autoComplete="off"
+                  placeholder="admin@deenbridge.org"
+                  value={emailDraft}
+                  onChange={(event) => setEmailDraft(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      handleAddRecipient();
+                    }
+                  }}
+                  aria-invalid={Boolean(draftEmailError)}
+                  aria-describedby="recipient-email-error"
+                />
+                <FieldError id="recipient-email-error" message={draftEmailError} />
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                className="rounded-full"
+                onClick={handleAddRecipient}
+                disabled={!draftEmail || Boolean(draftEmailError)}
+              >
+                <Plus className="mr-1 h-4 w-4" />
+                Add
+              </Button>
+            </div>
+          </div>
+
+          {config.recipients.length === 0 ? (
+            <p className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+              No recipients yet. Add at least one while a digest is enabled.
+            </p>
+          ) : (
+            <ul className="flex flex-wrap gap-2">
+              {config.recipients.map((email) => (
+                <li key={email}>
+                  <span
+                    className={cn(
+                      poppins_500.className,
+                      "inline-flex items-center gap-1.5 rounded-full border border-accent/15 bg-surface px-3 py-1 text-sm text-ink"
+                    )}
+                  >
+                    {email}
+                    <button
+                      type="button"
+                      onClick={() => removeRecipient(email)}
+                      aria-label={`Remove ${email}`}
+                      className="rounded-full p-0.5 text-ink-muted transition-colors hover:bg-destructive/10 hover:text-destructive"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <FieldError id="recipients-error" message={errors.recipients} />
+        </CardContent>
+      </Card>
+
+      {/* Footer save (mirrors header action; disabled while invalid) */}
+      <div className="flex items-center justify-end gap-3">
+        {!isValid && (
+          <span className={cn(poppins_400.className, "text-xs text-destructive")}>
+            Fix the highlighted fields before saving.
+          </span>
+        )}
+        <Button
+          type="button"
+          className="rounded-full bg-accent text-white hover:bg-accent/90"
+          onClick={() => save()}
+          disabled={!isValid || isSaving}
+        >
+          <Save className="mr-1 h-4 w-4" />
+          {isSaving ? "Saving…" : "Save changes"}
+        </Button>
+      </div>
+    </PageShell>
+  );
+}
+
+export default function ScheduledDigestsPage() {
+  return (
+    <AdminTierGuard>
+      <DigestsContent />
+    </AdminTierGuard>
+  );
+}

--- a/hooks/useDigestConfig.js
+++ b/hooks/useDigestConfig.js
@@ -1,0 +1,193 @@
+"use client";
+/**
+ * useDigestConfig — data hook for the scheduled digests configuration page (#306).
+ * ---------------------------------------------------------------------------
+ * Loads the digest configuration via the stubbed service in
+ * `lib/actions/admin-digests` (same shape as `useFeatureFlags`/`useAdminTeam`:
+ * local state + effect + explicit refresh) and holds an **editable local draft**
+ * the admin mutates through the exposed helpers before an explicit `save`.
+ *
+ * **Fails closed.** The config is only fetched once auth has resolved to a user
+ * who passes the admin tier check; the page-level guard (`AdminTierGuard`) owns
+ * the render decision — this hook just refuses to fetch without one.
+ *
+ * `save` runs `validateDigestConfig` first and blocks + toasts on invalid input
+ * so a malformed cron-ish selection never reaches the (stubbed) backend.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import useAuth from "@/hooks/useAuth";
+import { canManageTeam } from "@/lib/auth/admin-tiers";
+import {
+  getDigestConfig,
+  updateDigestConfig,
+  validateDigestConfig,
+} from "@/lib/actions/admin-digests";
+
+export default function useDigestConfig() {
+  const { user, loading: authLoading } = useAuth();
+
+  const [config, setConfig] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { config: loaded } = await getDigestConfig();
+      setConfig(loaded);
+    } catch (err) {
+      setError(err?.message || "Failed to load digest configuration");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return;
+    if (!user || !canManageTeam(user)) {
+      setIsLoading(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const { config: loaded } = await getDigestConfig();
+        if (!cancelled) setConfig(loaded);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err?.message || "Failed to load digest configuration");
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading]);
+
+  /**
+   * Toggle one digest type on/off in the local draft.
+   * @param {"moderation"|"revenue"|"signups"} type
+   */
+  const toggleDigest = useCallback((type) => {
+    setConfig((prev) => {
+      if (!prev) return prev;
+      const current = Boolean(prev.digests?.[type]?.enabled);
+      return {
+        ...prev,
+        digests: {
+          ...prev.digests,
+          [type]: { ...prev.digests?.[type], enabled: !current },
+        },
+      };
+    });
+  }, []);
+
+  /**
+   * Patch the delivery schedule in the local draft (merges the given fields).
+   * @param {Partial<{dayOfWeek: number, hour: number, minute: number, timezone: string}>} patch
+   */
+  const setSchedule = useCallback((patch) => {
+    setConfig((prev) =>
+      prev ? { ...prev, schedule: { ...prev.schedule, ...patch } } : prev
+    );
+  }, []);
+
+  /**
+   * Add a recipient email to the local draft. No-ops on empty/duplicate.
+   * @param {string} email
+   * @returns {boolean} whether the email was added
+   */
+  const addRecipient = useCallback((email) => {
+    const next = String(email || "").trim();
+    if (!next) return false;
+    let added = false;
+    setConfig((prev) => {
+      if (!prev) return prev;
+      const exists = prev.recipients.some(
+        (r) => r.toLowerCase() === next.toLowerCase()
+      );
+      if (exists) return prev;
+      added = true;
+      return { ...prev, recipients: [...prev.recipients, next] };
+    });
+    return added;
+  }, []);
+
+  /**
+   * Remove a recipient email from the local draft.
+   * @param {string} email
+   */
+  const removeRecipient = useCallback((email) => {
+    setConfig((prev) =>
+      prev
+        ? {
+            ...prev,
+            recipients: prev.recipients.filter(
+              (r) => r.toLowerCase() !== String(email || "").toLowerCase()
+            ),
+          }
+        : prev
+    );
+  }, []);
+
+  const { errors, warning, isValid } = useMemo(() => {
+    if (!config) return { errors: {}, warning: null, isValid: false };
+    const result = validateDigestConfig(config);
+    return {
+      errors: result.errors,
+      warning: result.warning,
+      isValid: result.valid,
+    };
+  }, [config]);
+
+  /**
+   * Validate then persist the draft. Blocks + toasts on invalid input; surfaces
+   * success/failure via sonner. Resolves `true` on success, `false` otherwise.
+   */
+  const save = useCallback(async () => {
+    if (!config) return false;
+    const { valid, errors: validationErrors } = validateDigestConfig(config);
+    if (!valid) {
+      toast.error(
+        Object.values(validationErrors)[0] || "Fix the highlighted fields first"
+      );
+      return false;
+    }
+    setIsSaving(true);
+    try {
+      const { config: saved } = await updateDigestConfig(config);
+      setConfig(saved);
+      toast.success("Digest schedule saved");
+      return true;
+    } catch (err) {
+      toast.error(err?.message || "Couldn't save the digest schedule");
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  }, [config]);
+
+  return {
+    config,
+    setConfig,
+    toggleDigest,
+    setSchedule,
+    addRecipient,
+    removeRecipient,
+    errors,
+    warning,
+    isValid,
+    isLoading,
+    isSaving,
+    error,
+    save,
+    refresh,
+  };
+}

--- a/lib/actions/admin-digests.js
+++ b/lib/actions/admin-digests.js
@@ -1,0 +1,273 @@
+/**
+ * Scheduled report digests service — read/write the recurring digest-email
+ * configuration and validate a cron-like delivery schedule (#306).
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Every network function here resolves with mocked data so the
+ * digests configuration page (#306) can be built and reviewed before the
+ * backend endpoints exist. Swap the mock bodies for `axiosInstance` calls
+ * (see `lib/config/axios.config.js`) when the backend lands.
+ *
+ * Frontend owns the *configuration UX* only — the backend runs the schedule
+ * and actually sends the emails. This module additionally exports two **pure**
+ * helpers (`scheduleToCron`, `validateDigestConfig`) that are the deliverable
+ * "client-side cron-ish validation": the UI previews and validates the
+ * selection before it is ever submitted.
+ *
+ * Config shape owned by the backend:
+ *
+ *   {
+ *     digests: {
+ *       moderation: { enabled: boolean }, // content-moderation summary
+ *       revenue:    { enabled: boolean }, // revenue / payouts summary
+ *       signups:    { enabled: boolean }, // new-user signups summary
+ *     },
+ *     schedule: {
+ *       dayOfWeek: number,   // 0-6, 0 = Sunday … 6 = Saturday
+ *       hour: number,        // 0-23 (24h clock, in `timezone`)
+ *       minute: number,      // one of 0 | 15 | 30 | 45
+ *       timezone: string,    // IANA tz, e.g. "UTC", "America/New_York"
+ *     },
+ *     recipients: string[],  // admin email addresses that receive the digests
+ *   }
+ */
+
+const MOCK_DELAY_MS = 400;
+
+/** The three digest types this feature manages, in display order. */
+export const DIGEST_TYPES = Object.freeze(["moderation", "revenue", "signups"]);
+
+/** Minutes the schedule picker allows — quarter-hour granularity. */
+export const ALLOWED_MINUTES = Object.freeze([0, 15, 30, 45]);
+
+/** Sunday-first day labels, indexed by `schedule.dayOfWeek` (0-6). */
+export const DAY_LABELS = Object.freeze([
+  "Sunday",
+  "Monday",
+  "Tuesday",
+  "Wednesday",
+  "Thursday",
+  "Friday",
+  "Saturday",
+]);
+
+/** A small, sensible timezone allow-list for the read-only-ish tz select. */
+export const TIMEZONES = Object.freeze([
+  "UTC",
+  "America/New_York",
+  "America/Chicago",
+  "America/Denver",
+  "America/Los_Angeles",
+  "Europe/London",
+  "Europe/Berlin",
+  "Africa/Lagos",
+  "Asia/Dubai",
+  "Asia/Karachi",
+  "Asia/Kuala_Lumpur",
+  "Asia/Jakarta",
+]);
+
+/**
+ * Reasonably strict email pattern. Deliberately not RFC-5322-exhaustive — it
+ * rejects the obviously-malformed addresses an admin would fat-finger while
+ * accepting the ordinary `local@domain.tld` shape.
+ */
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+/** In-memory store so the stubbed update mutation round-trips in dev. */
+let mockConfig = null;
+
+function withMockDelay(value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_DELAY_MS));
+}
+
+function seedConfig() {
+  return {
+    digests: {
+      moderation: { enabled: true },
+      revenue: { enabled: true },
+      signups: { enabled: false },
+    },
+    schedule: {
+      dayOfWeek: 1, // Monday
+      hour: 9,
+      minute: 0,
+      timezone: "UTC",
+    },
+    recipients: ["admin@deenbridge.org", "ops@deenbridge.org"],
+  };
+}
+
+/** Deep-ish clone of the config so callers never mutate the mock store. */
+function cloneConfig(config) {
+  return {
+    digests: {
+      moderation: { enabled: Boolean(config?.digests?.moderation?.enabled) },
+      revenue: { enabled: Boolean(config?.digests?.revenue?.enabled) },
+      signups: { enabled: Boolean(config?.digests?.signups?.enabled) },
+    },
+    schedule: {
+      dayOfWeek: config?.schedule?.dayOfWeek,
+      hour: config?.schedule?.hour,
+      minute: config?.schedule?.minute,
+      timezone: config?.schedule?.timezone,
+    },
+    recipients: Array.isArray(config?.recipients) ? [...config.recipients] : [],
+  };
+}
+
+function getMockConfig() {
+  if (!mockConfig) mockConfig = seedConfig();
+  return mockConfig;
+}
+
+/**
+ * Convert a delivery `schedule` into a 5-field cron expression. Digests fire on
+ * a specific minute/hour of a single weekday every week, so day-of-month and
+ * month are always wildcards: `"minute hour * * dayOfWeek"`.
+ *
+ * Pure and total: out-of-range or missing fields are emitted verbatim (or as
+ * `*`) rather than throwing — validation is `validateDigestConfig`'s job, and
+ * the preview should still render something for a half-built selection.
+ *
+ * @param {{dayOfWeek?: number, hour?: number, minute?: number}} schedule
+ * @returns {string} e.g. `"0 9 * * 1"` (Mondays at 09:00)
+ */
+export function scheduleToCron(schedule = {}) {
+  const field = (value) =>
+    Number.isInteger(value) ? String(value) : "*";
+  const minute = field(schedule.minute);
+  const hour = field(schedule.hour);
+  const dow = field(schedule.dayOfWeek);
+  return `${minute} ${hour} * * ${dow}`;
+}
+
+/**
+ * Validate a digest configuration before submit — the "cron-ish" client-side
+ * check. Returns a flat map of field → message plus a `valid` boolean.
+ *
+ * Rules:
+ *   - `dayOfWeek` is an integer 0-6.
+ *   - `hour` is an integer 0-23.
+ *   - `minute` is one of {0, 15, 30, 45}.
+ *   - `timezone` is a non-empty string.
+ *   - Every recipient is a well-formed email; no duplicates.
+ *   - If **any** digest is enabled there must be at least one recipient.
+ *   - All digests off is *allowed* but surfaces a non-blocking `warning`
+ *     (nothing will be sent) — it does not flip `valid` to false.
+ *
+ * @param {object} config config in the shape documented at the top of the file
+ * @returns {{valid: boolean, errors: Record<string, string>, warning: string|null}}
+ */
+export function validateDigestConfig(config) {
+  const errors = {};
+  let warning = null;
+
+  const digests = config?.digests || {};
+  const anyEnabled = DIGEST_TYPES.some((type) => digests?.[type]?.enabled);
+  if (!anyEnabled) {
+    warning =
+      "All digests are off — no scheduled emails will be sent until you enable one.";
+  }
+
+  const schedule = config?.schedule || {};
+
+  if (
+    !Number.isInteger(schedule.dayOfWeek) ||
+    schedule.dayOfWeek < 0 ||
+    schedule.dayOfWeek > 6
+  ) {
+    errors.dayOfWeek = "Pick a day of the week.";
+  }
+
+  if (
+    !Number.isInteger(schedule.hour) ||
+    schedule.hour < 0 ||
+    schedule.hour > 23
+  ) {
+    errors.hour = "Hour must be between 00 and 23.";
+  }
+
+  if (!ALLOWED_MINUTES.includes(schedule.minute)) {
+    errors.minute = "Minute must be 00, 15, 30, or 45.";
+  }
+
+  if (typeof schedule.timezone !== "string" || schedule.timezone.trim() === "") {
+    errors.timezone = "Select a timezone.";
+  }
+
+  const recipients = Array.isArray(config?.recipients) ? config.recipients : [];
+  const seen = new Set();
+  const bad = [];
+  let hasDuplicate = false;
+  recipients.forEach((raw) => {
+    const email = String(raw || "").trim().toLowerCase();
+    if (!EMAIL_RE.test(email)) {
+      bad.push(raw);
+      return;
+    }
+    if (seen.has(email)) hasDuplicate = true;
+    seen.add(email);
+  });
+  if (bad.length > 0) {
+    errors.recipients = `Fix invalid email${bad.length > 1 ? "s" : ""}: ${bad.join(
+      ", "
+    )}.`;
+  } else if (hasDuplicate) {
+    errors.recipients = "Remove duplicate recipients.";
+  } else if (anyEnabled && recipients.length === 0) {
+    errors.recipients = "Add at least one recipient while a digest is enabled.";
+  }
+
+  return { valid: Object.keys(errors).length === 0, errors, warning };
+}
+
+/**
+ * Whether a single email string is well-formed. Exposed so the recipient input
+ * can validate inline without pulling in the whole config validator.
+ *
+ * @param {string} email
+ * @returns {boolean}
+ */
+export function isValidEmail(email) {
+  return EMAIL_RE.test(String(email || "").trim().toLowerCase());
+}
+
+/**
+ * Read the current digest configuration.
+ *
+ * TODO(backend): GET /api/admin/digests
+ *   - Auth: requires an admin session token (server-side tier check).
+ *   - 200 → { config: DigestConfig } using the shape above.
+ *   - 403 for non-admins.
+ *
+ * @returns {Promise<{config: object}>}
+ */
+export async function getDigestConfig() {
+  // TODO(backend): return axiosInstance.get("/api/admin/digests").then((res) => res.data);
+  return withMockDelay({ config: cloneConfig(getMockConfig()) });
+}
+
+/**
+ * Persist a new digest configuration (full replace, PUT semantics).
+ *
+ * TODO(backend): PUT /api/admin/digests
+ *   - Auth: admin only.
+ *   - Payload: DigestConfig (the full config object).
+ *   - 200 → { config: DigestConfig } echoing the stored value.
+ *   - 422 if the schedule / recipients fail server-side validation.
+ *
+ * @param {object} config the full config to store
+ * @returns {Promise<{config: object}>}
+ */
+export async function updateDigestConfig(config) {
+  // TODO(backend):
+  //   return axiosInstance.put("/api/admin/digests", config).then((res) => res.data);
+  const { valid, errors } = validateDigestConfig(config);
+  if (!valid) {
+    await withMockDelay(null);
+    const first = Object.values(errors)[0] || "Invalid digest configuration";
+    throw new Error(first);
+  }
+  mockConfig = cloneConfig(config);
+  return withMockDelay({ config: cloneConfig(mockConfig) });
+}


### PR DESCRIPTION
Closes #306

## Summary
An admin configuration UI for recurring digest emails — the frontend owns the configuration UX (the backend sends the emails). Follows the stubbed-service → hook → `AdminTierGuard` page pattern.

## What's included
- **`lib/actions/admin-digests.js`** — stubbed `getDigestConfig()`/`updateDigestConfig()` (`TODO(backend)` GET/PUT `/api/admin/digests`) plus pure `scheduleToCron()` and `validateDigestConfig()` (dayOfWeek 0–6, hour 0–23, minute ∈ {0,15,30,45}, timezone, well-formed/unique recipient emails, ≥1 recipient when any digest is enabled, non-blocking all-off warning).
- **`hooks/useDigestConfig.js`** — editable draft; `toggleDigest`, `setSchedule`, add/remove recipient, validate-before-save with `sonner` toasts.
- **`app/[locale]/dashboard/admin/settings/digests/page.jsx`** — `AdminTierGuard`-wrapped: three digest toggles (moderation/revenue/signups), a day/hour/minute/timezone schedule picker with a live **cron + human-sentence preview**, recipient management with inline validation and removable chips, and a Save button disabled while invalid.

## Acceptance criteria
Toggles for all three digest types ✓ · day/time picker ✓ · recipient management (editable admin emails) ✓ · client-side schedule validation ✓ · cron-ish selection validated before submit ✓

## CI note
Rebased on current `dev`; **builds green** locally (`npm run build`), and `npm run lint` is clean for all added files. The red **Run component tests** (vitest), **Lighthouse CI**, and **a11y** checks are **pre-existing failures on `dev` itself** (verified on a clean `dev` checkout: `useAdminTeam` vitest timeouts, a `next/font/google` mock gap, and 4 `label-has-associated-control` errors in the unrelated `app/[locale]/admin/audit-logs` + `reconciliation` pages) — this PR only adds new files and does not touch those. Happy to help fix the shared harness separately.