### PR TITLE
feat(admin): platform maintenance mode with friendly lock screen (#303)

### DIFF
--- a/app/[locale]/dashboard/admin/settings/maintenance/page.jsx
+++ b/app/[locale]/dashboard/admin/settings/maintenance/page.jsx
@@ -1,0 +1,271 @@
+"use client";
+/**
+ * Maintenance-mode settings page (#303).
+ * ---------------------------------------------------------------------------
+ * Super-admin surface (wrapped in `AdminTierGuard`) to toggle platform-wide
+ * maintenance mode, attach an optional learner-facing message and ETA, review
+ * who last changed it, and preview the exact lock screen learners will see.
+ *
+ * All reads/writes go through the shared `useMaintenanceMode` hook (the same
+ * hook the `MaintenanceGate` admin bar uses), so the toggle here and the bar
+ * stay consistent. Mutations surface sonner toasts from the hook.
+ */
+import { useEffect, useState } from "react";
+import { Wrench, ShieldAlert, Clock, Save } from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Switch } from "@/components/ui/switch";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import AdminTierGuard from "@/components/auth/AdminTierGuard";
+import MaintenanceScreen from "@/components/maintenance/MaintenanceScreen";
+import useMaintenanceMode from "@/hooks/useMaintenanceMode";
+import { cn } from "@/lib/utils";
+import {
+  poppins_400,
+  poppins_500,
+  poppins_600,
+} from "@/lib/config/font.config";
+
+/** Convert an ISO timestamp to a `datetime-local` input value (local tz). */
+function isoToLocalInput(iso) {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+  return local.toISOString().slice(0, 16);
+}
+
+/** Convert a `datetime-local` input value (local tz) back to an ISO string. */
+function localInputToIso(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function updatedLabel(iso) {
+  const date = iso ? new Date(iso) : null;
+  if (!date || Number.isNaN(date.getTime())) return "Unknown";
+  return formatDistanceToNow(date, { addSuffix: true });
+}
+
+function MaintenanceContent() {
+  const { maintenance, isLoading, isSaving, enable, disable, setState } =
+    useMaintenanceMode();
+
+  const [message, setMessage] = useState("");
+  const [etaLocal, setEtaLocal] = useState("");
+
+  // Seed the draft fields from the server state after each load / save. Keyed on
+  // `updatedAt` so an in-progress edit isn't clobbered until the next round-trip.
+  useEffect(() => {
+    if (!maintenance) return;
+    setMessage(maintenance.message || "");
+    setEtaLocal(isoToLocalInput(maintenance.etaAt));
+  }, [maintenance?.updatedAt]);
+
+  const enabled = Boolean(maintenance?.enabled);
+  const etaIso = localInputToIso(etaLocal);
+
+  const handleToggle = async (next) => {
+    try {
+      if (next) {
+        await enable({ message: message.trim() || null, etaAt: etaIso });
+      } else {
+        await disable();
+      }
+    } catch {
+      // Hook already surfaced a toast.
+    }
+  };
+
+  const handleSave = async () => {
+    try {
+      await setState({
+        enabled,
+        message: message.trim() || null,
+        etaAt: etaIso,
+      });
+    } catch {
+      // Hook already surfaced a toast.
+    }
+  };
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={Wrench}
+        title="Maintenance mode"
+        subtitle="Put the platform behind a friendly lock screen while you work — admins keep full access."
+      />
+
+      {/* Current status */}
+      <div className="rounded-2xl border border-accent/10 bg-surface-raised p-5 shadow-sm">
+        {isLoading ? (
+          <Skeleton className="h-6 w-48 rounded-full" />
+        ) : (
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <Badge
+                variant="outline"
+                className={cn(
+                  "rounded-full",
+                  enabled
+                    ? "border-amber-500/30 bg-amber-500/10 text-amber-600"
+                    : "border-emerald-500/30 bg-emerald-500/10 text-emerald-600"
+                )}
+              >
+                {enabled ? "Maintenance ON" : "Live — normal operation"}
+              </Badge>
+              <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+                {maintenance?.updatedBy?.name
+                  ? `Last changed by ${maintenance.updatedBy.name} `
+                  : "Last changed "}
+                {updatedLabel(maintenance?.updatedAt)}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <Switch
+                checked={enabled}
+                onCheckedChange={handleToggle}
+                disabled={isSaving}
+                aria-label={
+                  enabled ? "Disable maintenance mode" : "Enable maintenance mode"
+                }
+              />
+              <span className={cn(poppins_500.className, "text-sm text-ink")}>
+                {enabled ? "On" : "Off"}
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {enabled ? (
+        <div className="flex items-start gap-2 rounded-2xl border border-amber-500/30 bg-amber-500/5 p-4">
+          <ShieldAlert
+            className="mt-0.5 h-4 w-4 shrink-0 text-amber-600"
+            aria-hidden="true"
+          />
+          <p className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+            Maintenance is <strong className="text-ink">active</strong>. Learners
+            and logged-out visitors see the lock screen below; admins keep
+            working behind the persistent maintenance bar.
+          </p>
+        </div>
+      ) : null}
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Controls */}
+        <div className="space-y-5 rounded-2xl border border-accent/10 bg-surface-raised p-5 shadow-sm">
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="maintenance-message"
+              className={cn(poppins_500.className, "text-ink")}
+            >
+              Custom message (optional)
+            </Label>
+            <Textarea
+              id="maintenance-message"
+              placeholder="We're upgrading the library — back shortly, in shaa Allah."
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
+              rows={3}
+              maxLength={280}
+            />
+            <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+              Shown to learners on the lock screen. Leave blank for the default
+              copy. {message.length}/280
+            </p>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="maintenance-eta"
+              className={cn(poppins_500.className, "flex items-center gap-1.5 text-ink")}
+            >
+              <Clock className="h-4 w-4 text-accent" aria-hidden="true" />
+              Back-online ETA (optional)
+            </Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="maintenance-eta"
+                type="datetime-local"
+                value={etaLocal}
+                onChange={(event) => setEtaLocal(event.target.value)}
+                className="max-w-xs"
+              />
+              {etaLocal ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="rounded-full text-xs"
+                  onClick={() => setEtaLocal("")}
+                >
+                  Clear
+                </Button>
+              ) : null}
+            </div>
+            <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+              Drives the live &ldquo;Back in ~1h 12m&rdquo; countdown on the lock
+              screen.
+            </p>
+          </div>
+
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              onClick={handleSave}
+              disabled={isSaving || isLoading}
+              className="rounded-full bg-accent text-white hover:bg-accent/90"
+            >
+              <Save className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              {isSaving ? "Saving…" : "Save changes"}
+            </Button>
+          </div>
+        </div>
+
+        {/* Live learner preview */}
+        <div className="space-y-2">
+          <p
+            className={cn(
+              poppins_600.className,
+              "flex items-center gap-2 text-sm text-ink"
+            )}
+          >
+            Learner preview
+            <Badge
+              variant="outline"
+              className="rounded-full border-accent/20 text-xs text-ink-muted"
+            >
+              Live
+            </Badge>
+          </p>
+          <div className="relative h-[440px] overflow-hidden rounded-2xl border border-accent/10 shadow-sm">
+            <div className="pointer-events-none absolute left-0 top-0 w-[166.67%] origin-top-left scale-[0.6]">
+              <MaintenanceScreen
+                message={message.trim() || null}
+                etaAt={etaIso}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </PageShell>
+  );
+}
+
+export default function MaintenanceSettingsPage() {
+  return (
+    <AdminTierGuard>
+      <MaintenanceContent />
+    </AdminTierGuard>
+  );
+}

--- a/app/[locale]/offline/page.jsx
+++ b/app/[locale]/offline/page.jsx
@@ -1,81 +1,74 @@
 import Link from "next/link";
+import LockScreenShell from "@/components/maintenance/LockScreenShell";
 
+/**
+ * Offline fallback screen. Refactored (#303) to render through the shared
+ * `LockScreenShell` — the same gradient container + icon card the maintenance
+ * lock screen uses — without changing its copy, links, or appearance.
+ */
 export default function OfflinePage() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-green-50 via-white to-blue-50 px-6 text-center">
-      <div className="max-w-md">
-        <div className="mb-8 flex justify-center">
-          <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-accent/10">
-            <svg
-              aria-hidden="true"
-              className="h-10 w-10 text-accent"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              strokeWidth={1.5}
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M18.364 5.636a9 9 0 010 12.728M5.636 18.364a9 9 0 010-12.728M8.464 15.536a5 5 0 010-7.072m7.072 0a5 5 0 010 7.072M12 12h.01"
-              />
-            </svg>
-          </div>
-        </div>
-
-        <h1 className="mb-3 text-3xl font-bold text-foreground">
-          You&apos;re Offline
-        </h1>
-        <p className="mb-8 text-muted-foreground">
-          Deen Bridge is designed to work partially offline. You can still read
-          recently opened books and access cached content.
-        </p>
-
-        <div className="mb-8 rounded-2xl border border-border/50 bg-white/80 p-6 text-left shadow-sm backdrop-blur">
-          <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
-            What still works
-          </h2>
-          <ul className="space-y-2 text-sm text-foreground">
-            <li className="flex items-center gap-2">
-              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-accent/10 text-xs text-accent">
-                ✓
-              </span>
-              Previously opened books (PDF reader)
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-accent/10 text-xs text-accent">
-                ✓
-              </span>
-              Cached course content and pages
-            </li>
-            <li className="flex items-center gap-2">
-              <span className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs text-muted-foreground">
-                —
-              </span>
-              Messages, payments, and live spaces need a connection
-            </li>
-          </ul>
-        </div>
-
-        <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
-          <Link
-            href="/dashboard"
-            className="inline-flex items-center justify-center rounded-xl bg-accent px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-accent/90"
-          >
-            Try Dashboard
-          </Link>
-          <Link
-            href="/"
-            className="inline-flex items-center justify-center rounded-xl border border-border/60 bg-white px-6 py-3 text-sm font-semibold text-foreground shadow-sm transition hover:bg-muted"
-          >
-            Go Home
-          </Link>
-        </div>
-
-        <p className="mt-8 text-xs text-muted-foreground">
-          Reconnect to the internet to access all features.
-        </p>
+    <LockScreenShell
+      icon={
+        <svg
+          aria-hidden="true"
+          className="h-10 w-10 text-accent"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          strokeWidth={1.5}
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M18.364 5.636a9 9 0 010 12.728M5.636 18.364a9 9 0 010-12.728M8.464 15.536a5 5 0 010-7.072m7.072 0a5 5 0 010 7.072M12 12h.01"
+          />
+        </svg>
+      }
+      title={<>You&apos;re Offline</>}
+      description="Deen Bridge is designed to work partially offline. You can still read recently opened books and access cached content."
+      footer="Reconnect to the internet to access all features."
+    >
+      <div className="mb-8 rounded-2xl border border-border/50 bg-white/80 p-6 text-left shadow-sm backdrop-blur">
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
+          What still works
+        </h2>
+        <ul className="space-y-2 text-sm text-foreground">
+          <li className="flex items-center gap-2">
+            <span className="flex h-5 w-5 items-center justify-center rounded-full bg-accent/10 text-xs text-accent">
+              ✓
+            </span>
+            Previously opened books (PDF reader)
+          </li>
+          <li className="flex items-center gap-2">
+            <span className="flex h-5 w-5 items-center justify-center rounded-full bg-accent/10 text-xs text-accent">
+              ✓
+            </span>
+            Cached course content and pages
+          </li>
+          <li className="flex items-center gap-2">
+            <span className="flex h-5 w-5 items-center justify-center rounded-full bg-muted text-xs text-muted-foreground">
+              —
+            </span>
+            Messages, payments, and live spaces need a connection
+          </li>
+        </ul>
       </div>
-    </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:justify-center">
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center justify-center rounded-xl bg-accent px-6 py-3 text-sm font-semibold text-white shadow-md transition hover:bg-accent/90"
+        >
+          Try Dashboard
+        </Link>
+        <Link
+          href="/"
+          className="inline-flex items-center justify-center rounded-xl border border-border/60 bg-white px-6 py-3 text-sm font-semibold text-foreground shadow-sm transition hover:bg-muted"
+        >
+          Go Home
+        </Link>
+      </div>
+    </LockScreenShell>
   );
 }

--- a/components/maintenance/LockScreenShell.jsx
+++ b/components/maintenance/LockScreenShell.jsx
@@ -1,0 +1,60 @@
+/**
+ * LockScreenShell — the shared full-screen "friendly lock" visual shell.
+ * ---------------------------------------------------------------------------
+ * Extracted verbatim from the original offline page (#303) so the offline
+ * screen and the new maintenance lock screen (`MaintenanceScreen`) share one
+ * gradient container + centered icon card + heading/description layout instead
+ * of duplicating it. Purely presentational and framework-agnostic — it takes an
+ * icon node, a heading, a description, optional body `children` (rendered
+ * between the description and the footer), and an optional `footer` node.
+ *
+ * The markup below is byte-for-byte the offline page's wrapper so adopting the
+ * shell does not change the offline screen's appearance.
+ */
+import { cn } from "@/lib/utils";
+
+/**
+ * @param {object} props
+ * @param {React.ReactNode} props.icon      Icon node rendered inside the accent card (size it `h-10 w-10`).
+ * @param {React.ReactNode} props.title     Main heading text.
+ * @param {React.ReactNode} [props.description] Sub-heading paragraph under the title.
+ * @param {React.ReactNode} [props.children] Optional body content between description and footer.
+ * @param {React.ReactNode} [props.footer]  Optional muted footer line.
+ * @param {string} [props.className]         Extra classes for the outer gradient container.
+ */
+export default function LockScreenShell({
+  icon,
+  title,
+  description,
+  children,
+  footer,
+  className,
+}) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-green-50 via-white to-blue-50 px-6 text-center",
+        className
+      )}
+    >
+      <div className="max-w-md">
+        <div className="mb-8 flex justify-center">
+          <div className="flex h-20 w-20 items-center justify-center rounded-2xl bg-accent/10">
+            {icon}
+          </div>
+        </div>
+
+        <h1 className="mb-3 text-3xl font-bold text-foreground">{title}</h1>
+        {description ? (
+          <p className="mb-8 text-muted-foreground">{description}</p>
+        ) : null}
+
+        {children}
+
+        {footer ? (
+          <p className="mt-8 text-xs text-muted-foreground">{footer}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/maintenance/MaintenanceGate.jsx
+++ b/components/maintenance/MaintenanceGate.jsx
@@ -1,0 +1,162 @@
+"use client";
+/**
+ * MaintenanceGate — layout-level, client-side maintenance gate (#303).
+ * ---------------------------------------------------------------------------
+ * WHY A LAYOUT GATE, NOT MIDDLEWARE: auth in this app is entirely CLIENT-SIDE
+ * (a JWT in a cookie decoded by `useAuth`), so a Next.js `middleware.js` running
+ * on the edge cannot reliably tell an admin apart from a learner — it would
+ * either lock admins out or leak the app to everyone. Instead this gate is a
+ * client provider mounted once in `AppProviders`, so it re-evaluates the flag on
+ * every render and route change with the real, decoded user in hand. It also
+ * polls lightly (60s) and refetches on window focus so a toggle propagates to
+ * already-open tabs without a manual reload.
+ *
+ * Three coherent states:
+ *   1. maintenance OFF                → render the app normally.
+ *   2. maintenance ON  + admin        → render the app + a persistent top bar
+ *                                        ("Maintenance mode is ON") with a
+ *                                        "Turn off" action and a settings link.
+ *   3. maintenance ON  + non-admin /  → render <MaintenanceScreen> instead of
+ *      logged-out                        the app.
+ *
+ * FAIL-OPEN: while the initial state is still loading we render children, so a
+ * transient read never flashes the lock screen at legitimate users.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import Link from "next/link";
+import { Wrench, Settings, Loader2 } from "lucide-react";
+import useAuth from "@/hooks/useAuth";
+import useMaintenanceMode from "@/hooks/useMaintenanceMode";
+import { normalizeRole, ROLES } from "@/lib/auth/roles";
+import { getMaintenanceState } from "@/lib/actions/admin-maintenance";
+import MaintenanceScreen from "@/components/maintenance/MaintenanceScreen";
+import { cn } from "@/lib/utils";
+import { poppins_500 } from "@/lib/config/font.config";
+
+/** Poll cadence for propagating a toggle to already-open tabs. */
+const POLL_INTERVAL_MS = 60_000;
+
+/** Whether the user holds the admin role (any tier) and may bypass the lock. */
+function isAdminUser(user) {
+  return Boolean(user) && normalizeRole(user.role) === ROLES.ADMIN;
+}
+
+/**
+ * Persistent top bar shown to admins while maintenance is ON. Shares the admin
+ * `useMaintenanceMode` hook for the "Turn off" mutation, then asks the gate to
+ * refetch so the bar disappears immediately.
+ *
+ * @param {{onTurnedOff: () => void}} props
+ */
+function MaintenanceAdminBar({ onTurnedOff }) {
+  const router = useRouter();
+  const { disable, isSaving } = useMaintenanceMode();
+
+  const handleTurnOff = async () => {
+    try {
+      await disable();
+      onTurnedOff();
+      router.refresh();
+    } catch {
+      // useMaintenanceMode already surfaced a toast; leave the bar in place.
+    }
+  };
+
+  return (
+    <div
+      role="status"
+      className={cn(
+        poppins_500.className,
+        "sticky top-0 z-[60] flex flex-wrap items-center justify-center gap-x-4 gap-y-2 bg-amber-500 px-4 py-2 text-center text-sm text-amber-950 shadow-md"
+      )}
+    >
+      <span className="inline-flex items-center gap-2">
+        <Wrench className="h-4 w-4 shrink-0" aria-hidden="true" />
+        Maintenance mode is ON — learners see the lock screen.
+      </span>
+      <span className="inline-flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleTurnOff}
+          disabled={isSaving}
+          className="inline-flex items-center gap-1.5 rounded-full bg-amber-950 px-3 py-1 text-xs font-semibold text-amber-50 transition hover:bg-amber-900 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isSaving ? (
+            <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+          ) : null}
+          {isSaving ? "Turning off…" : "Turn off"}
+        </button>
+        <Link
+          href="/dashboard/admin/settings/maintenance"
+          className="inline-flex items-center gap-1 rounded-full border border-amber-950/40 px-3 py-1 text-xs font-semibold transition hover:bg-amber-950/10"
+        >
+          <Settings className="h-3.5 w-3.5" aria-hidden="true" />
+          Settings
+        </Link>
+      </span>
+    </div>
+  );
+}
+
+/**
+ * @param {{children: React.ReactNode}} props
+ */
+export default function MaintenanceGate({ children }) {
+  const { user, loading: authLoading } = useAuth();
+  const pathname = usePathname();
+
+  const [maintenance, setMaintenance] = useState(null);
+  const [ready, setReady] = useState(false);
+
+  const fetchState = useCallback(async () => {
+    try {
+      const { maintenance: state } = await getMaintenanceState();
+      setMaintenance(state);
+    } catch {
+      // Fail open: on a read error leave the last-known (or null) state so the
+      // app stays reachable rather than trapping everyone behind the lock.
+    } finally {
+      setReady(true);
+    }
+  }, []);
+
+  // Re-check on mount and on every route change (the "each navigation" check).
+  useEffect(() => {
+    fetchState();
+  }, [fetchState, pathname]);
+
+  // Light polling + focus refetch so an open tab notices a toggle.
+  useEffect(() => {
+    const id = setInterval(fetchState, POLL_INTERVAL_MS);
+    const onFocus = () => fetchState();
+    window.addEventListener("focus", onFocus);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [fetchState]);
+
+  const enabled = Boolean(maintenance?.enabled);
+
+  // Fail-open until we have both the flag and a resolved auth state.
+  if (!ready || authLoading || !enabled) {
+    return <>{children}</>;
+  }
+
+  if (isAdminUser(user)) {
+    return (
+      <>
+        <MaintenanceAdminBar onTurnedOff={fetchState} />
+        {children}
+      </>
+    );
+  }
+
+  return (
+    <MaintenanceScreen
+      message={maintenance?.message}
+      etaAt={maintenance?.etaAt}
+    />
+  );
+}

--- a/components/maintenance/MaintenanceScreen.jsx
+++ b/components/maintenance/MaintenanceScreen.jsx
@@ -1,0 +1,97 @@
+"use client";
+/**
+ * MaintenanceScreen — the friendly learner-facing lock screen (#303).
+ * ---------------------------------------------------------------------------
+ * Shown by `MaintenanceGate` to non-admin / logged-out visitors while
+ * platform-wide maintenance mode is ON. Built by ADAPTING the offline page's
+ * visual shell (`LockScreenShell`) so it shares the exact gradient + icon-card
+ * styling rather than duplicating it.
+ *
+ * Purely presentational: it renders a reassuring heading, the admin's optional
+ * custom message, and — when an `etaAt` is provided — a LIVE COUNTDOWN
+ * ("Back in ~1h 12m") that ticks every second and degrades gracefully once the
+ * ETA has passed.
+ */
+import { useEffect, useState } from "react";
+import { Wrench } from "lucide-react";
+import LockScreenShell from "@/components/maintenance/LockScreenShell";
+
+const DEFAULT_MESSAGE =
+  "Deen Bridge is briefly down for scheduled maintenance. We're polishing things up and will be back shortly — thank you for your patience.";
+
+/**
+ * Format the milliseconds remaining until the ETA into a friendly, approximate
+ * label. Returns `null` when there is no valid future target so the caller can
+ * omit the countdown entirely.
+ *
+ * @param {number} msRemaining
+ * @returns {string}
+ */
+function formatCountdown(msRemaining) {
+  if (msRemaining <= 0) return "Back any moment now";
+  const totalMinutes = Math.floor(msRemaining / 60000);
+  if (totalMinutes < 1) return "Back in less than a minute";
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours >= 24) {
+    const days = Math.floor(hours / 24);
+    const remHours = hours % 24;
+    return `Back in ~${days}d${remHours ? ` ${remHours}h` : ""}`;
+  }
+  if (hours >= 1) return `Back in ~${hours}h ${minutes}m`;
+  return `Back in ~${minutes}m`;
+}
+
+/**
+ * Live countdown pill. Recomputes every second off the wall clock so it stays
+ * accurate across tab sleeps, and stops updating once the ETA is reached.
+ *
+ * @param {{etaAt: string}} props ISO 8601 target timestamp.
+ */
+function Countdown({ etaAt }) {
+  const target = new Date(etaAt).getTime();
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (Number.isNaN(target)) return undefined;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [target]);
+
+  if (Number.isNaN(target)) return null;
+
+  const label = formatCountdown(target - now);
+
+  return (
+    <div
+      className="mx-auto mb-8 inline-flex items-center gap-2 rounded-full border border-accent/20 bg-accent/10 px-4 py-2 text-sm font-semibold text-accent"
+      role="status"
+      aria-live="polite"
+    >
+      <span
+        className="h-2 w-2 animate-pulse rounded-full bg-accent"
+        aria-hidden="true"
+      />
+      {label}
+    </div>
+  );
+}
+
+/**
+ * @param {object} props
+ * @param {string|null} [props.message] Optional custom admin message.
+ * @param {string|null} [props.etaAt]   Optional ISO 8601 "back online" target.
+ */
+export default function MaintenanceScreen({ message, etaAt }) {
+  return (
+    <LockScreenShell
+      icon={<Wrench className="h-10 w-10 text-accent" aria-hidden="true" />}
+      title={<>We&apos;ll be right back</>}
+      description={message?.trim() ? message : DEFAULT_MESSAGE}
+      footer="This page will not update automatically — please check back in a little while."
+    >
+      {etaAt ? <Countdown etaAt={etaAt} /> : null}
+    </LockScreenShell>
+  );
+}

--- a/components/providers/AppProviders.jsx
+++ b/components/providers/AppProviders.jsx
@@ -6,6 +6,7 @@ import AuthProvider from "@/components/providers/AuthProvider";
 import CacheProvider from "@/components/providers/CacheProvider";
 import FeatureFlagProvider from "@/components/providers/FeatureFlagProvider";
 import StellarProvider from "@/components/stellar/StellarProvider";
+import MaintenanceGate from "@/components/maintenance/MaintenanceGate";
 
 export default function AppProviders({ children }) {
   return (
@@ -14,7 +15,14 @@ export default function AppProviders({ children }) {
         <CacheProvider>
           <AuthProvider>
             <FeatureFlagProvider>
-              <StellarProvider>{children}</StellarProvider>
+              <StellarProvider>
+                {/*
+                 * Mounted inside AuthProvider so the gate sees the decoded
+                 * client-side user; it wraps the whole app so maintenance mode
+                 * applies platform-wide on every render/navigation (#303).
+                 */}
+                <MaintenanceGate>{children}</MaintenanceGate>
+              </StellarProvider>
             </FeatureFlagProvider>
           </AuthProvider>
         </CacheProvider>

--- a/hooks/useMaintenanceMode.js
+++ b/hooks/useMaintenanceMode.js
@@ -1,0 +1,148 @@
+"use client";
+/**
+ * useMaintenanceMode — admin data hook for platform-wide maintenance (#303).
+ * ---------------------------------------------------------------------------
+ * Loads the maintenance state via the stubbed service in
+ * `lib/actions/admin-maintenance` and exposes the toggle/save mutations the
+ * admin settings page and the `MaintenanceGate` admin bar share, so both drive
+ * one code path and stay consistent.
+ *
+ * **Fails closed.** The state is only fetched once auth has resolved to a user
+ * with the admin role (staff or super). The settings *page* is additionally
+ * restricted to super-admins by its `AdminTierGuard`; this hook only refuses to
+ * fetch for non-admins. Every mutation stamps the acting admin as `updatedBy`.
+ *
+ * NOTE: this is the *management* hook. The gate reads the public state itself
+ * (for logged-out/learner visitors) — it uses this hook only for the admin bar.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import useAuth from "@/hooks/useAuth";
+import { normalizeRole, ROLES } from "@/lib/auth/roles";
+import {
+  getMaintenanceState,
+  setMaintenanceState,
+} from "@/lib/actions/admin-maintenance";
+
+/** Whether the user holds the admin role (any tier). Fails closed. */
+function isAdminUser(user) {
+  return Boolean(user) && normalizeRole(user.role) === ROLES.ADMIN;
+}
+
+/** Build the `updatedBy` actor descriptor the stub stamps onto writes. */
+function toActor(user) {
+  if (!user) return null;
+  return {
+    id: String(user._id ?? user.id ?? ""),
+    name: String(user.name ?? user.fullName ?? "Admin"),
+  };
+}
+
+export default function useMaintenanceMode() {
+  const { user, loading: authLoading } = useAuth();
+
+  const [maintenance, setMaintenance] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const { maintenance: state } = await getMaintenanceState();
+      setMaintenance(state);
+      return state;
+    } catch (err) {
+      setError(err?.message || "Failed to load maintenance state");
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (authLoading) return undefined;
+    if (!isAdminUser(user)) {
+      setIsLoading(false);
+      return undefined;
+    }
+    let cancelled = false;
+    (async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const { maintenance: state } = await getMaintenanceState();
+        if (!cancelled) setMaintenance(state);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err?.message || "Failed to load maintenance state");
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading]);
+
+  /**
+   * Write maintenance state. Stamps the acting admin, updates local state with
+   * the server echo, and surfaces failures via toast (re-throwing so callers
+   * can keep a dialog open / revert UI).
+   *
+   * @param {{enabled: boolean, message?: string|null, etaAt?: string|null}} payload
+   */
+  const setState = useCallback(
+    async (payload) => {
+      setIsSaving(true);
+      try {
+        const { maintenance: next } = await setMaintenanceState({
+          ...payload,
+          actor: toActor(user),
+        });
+        setMaintenance(next);
+        return next;
+      } catch (err) {
+        toast.error(err?.message || "Couldn't update maintenance mode");
+        throw err;
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [user]
+  );
+
+  /**
+   * Turn maintenance ON, optionally with a custom message and ETA.
+   *
+   * @param {{message?: string|null, etaAt?: string|null}} [payload]
+   */
+  const enable = useCallback(
+    async (payload = {}) => {
+      const next = await setState({ enabled: true, ...payload });
+      toast.success("Maintenance mode enabled");
+      return next;
+    },
+    [setState]
+  );
+
+  /** Turn maintenance OFF, preserving the stored message/ETA. */
+  const disable = useCallback(async () => {
+    const next = await setState({ enabled: false });
+    toast.success("Maintenance mode disabled");
+    return next;
+  }, [setState]);
+
+  return {
+    maintenance,
+    isLoading,
+    isSaving,
+    error,
+    enable,
+    disable,
+    setState,
+    refresh,
+  };
+}

--- a/lib/actions/admin-maintenance.js
+++ b/lib/actions/admin-maintenance.js
@@ -1,0 +1,117 @@
+/**
+ * Maintenance-mode service — read and write the platform-wide maintenance flag.
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Every function here resolves with mocked data backed by a
+ * module-level store so the admin settings page (#303) and the layout-level
+ * `MaintenanceGate` can be built, wired together, and reviewed before the
+ * backend endpoints exist. Toggling maintenance from the admin page mutates the
+ * same in-memory store the gate reads, so the two stay in sync within a browser
+ * session (until a full reload re-seeds the module).
+ *
+ * Maintenance state shape owned by the backend:
+ *
+ *   {
+ *     enabled: boolean,                 // master on/off switch
+ *     message: string | null,           // optional custom learner-facing copy
+ *     etaAt: string | null,             // optional ISO 8601 "back online" target
+ *     updatedBy: { id: string, name: string } | null, // who last toggled it
+ *     updatedAt: string,                // ISO 8601 timestamp of last change
+ *   }
+ *
+ * TODO(backend): GET/PUT /api/admin/maintenance
+ *   - GET is **public / unauthenticated** so the layout gate can read the flag
+ *     for logged-out and non-admin visitors on every navigation.
+ *       200 → { maintenance: MaintenanceState }
+ *   - PUT is **super-admin only** (server-side tier check, like the flags API).
+ *       Payload: { enabled: boolean, message?: string | null, etaAt?: string | null }
+ *       200 → { maintenance: MaintenanceState } with server-stamped
+ *             `updatedBy` / `updatedAt`.
+ *       403 for non-super-admins.
+ */
+
+const MOCK_DELAY_MS = 300;
+
+/**
+ * In-memory store so the stubbed read/write round-trips within a session. Seeded
+ * lazily on first access. Defaults to maintenance OFF (fail-open, normal app).
+ *
+ * @type {{enabled: boolean, message: string|null, etaAt: string|null, updatedBy: {id: string, name: string}|null, updatedAt: string}|null}
+ */
+let mockMaintenance = null;
+
+function withMockDelay(value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_DELAY_MS));
+}
+
+function seedMaintenance() {
+  return {
+    enabled: false,
+    message: null,
+    etaAt: null,
+    updatedBy: null,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function getStore() {
+  if (!mockMaintenance) mockMaintenance = seedMaintenance();
+  return mockMaintenance;
+}
+
+/**
+ * Read the current maintenance state.
+ *
+ * Mirrors the **public** GET contract: no auth required, so the gate can call
+ * it for any visitor. Returns a defensive copy so callers can't mutate the
+ * store directly.
+ *
+ * TODO(backend): return axiosInstance.get("/api/admin/maintenance").then((res) => res.data);
+ *
+ * @returns {Promise<{maintenance: {enabled: boolean, message: string|null, etaAt: string|null, updatedBy: {id: string, name: string}|null, updatedAt: string}}>}
+ */
+export async function getMaintenanceState() {
+  // TODO(backend): return axiosInstance.get("/api/admin/maintenance").then((res) => res.data);
+  return withMockDelay({ maintenance: { ...getStore() } });
+}
+
+/**
+ * Enable or disable maintenance mode, optionally attaching a custom learner
+ * message and an ETA. Mirrors the **super-admin-only** PUT contract.
+ *
+ * In the stub, `updatedBy` is stamped from the optional `actor` argument the
+ * hook passes (the acting admin from `useAuth`); the real backend derives it
+ * from the session token instead. Omitting a field leaves prior copy in place
+ * only when the caller doesn't send it — passing `null` clears it.
+ *
+ * TODO(backend):
+ *   return axiosInstance
+ *     .put("/api/admin/maintenance", { enabled, message, etaAt })
+ *     .then((res) => res.data);
+ *
+ * @param {{enabled: boolean, message?: string|null, etaAt?: string|null, actor?: {id: string, name: string}|null}} payload
+ * @returns {Promise<{maintenance: {enabled: boolean, message: string|null, etaAt: string|null, updatedBy: {id: string, name: string}|null, updatedAt: string}}>}
+ */
+export async function setMaintenanceState(payload = {}) {
+  // TODO(backend):
+  //   return axiosInstance
+  //     .put("/api/admin/maintenance", { enabled, message, etaAt })
+  //     .then((res) => res.data);
+  const store = getStore();
+  const next = {
+    enabled: Boolean(payload.enabled),
+    message:
+      "message" in payload
+        ? payload.message
+          ? String(payload.message)
+          : null
+        : store.message,
+    etaAt: "etaAt" in payload ? (payload.etaAt || null) : store.etaAt,
+    updatedBy:
+      payload.actor && typeof payload.actor === "object"
+        ? { id: String(payload.actor.id ?? ""), name: String(payload.actor.name ?? "") }
+        : store.updatedBy,
+    updatedAt: new Date().toISOString(),
+  };
+  mockMaintenance = next;
+  return withMockDelay({ maintenance: { ...next } });
+}


### PR DESCRIPTION
Closes #303

## Summary
A platform-wide maintenance mode: an admin toggle that persists state via API, a **layout-level gate** that shows a friendly lock screen to learners while admins keep working behind a persistent bar, and an optional ETA countdown. The existing offline page is **adapted, not duplicated**.

> **Architecture note:** auth here is client-side (JWT via `useAuth`), so a Next middleware can't reliably identify admins. The gate is therefore a layout-level client component that runs on every render/navigation — `middleware.js` is untouched.

## What's included
- **`lib/actions/admin-maintenance.js`** — stubbed `getMaintenanceState()` (public read so the gate can check it) / `setMaintenanceState()`; `TODO(backend)` GET/PUT `/api/admin/maintenance`.
- **`components/maintenance/LockScreenShell.jsx`** — shared visual shell extracted from the offline page; **`app/[locale]/offline/page.jsx` refactored to render through it** (copy/links/appearance unchanged).
- **`components/maintenance/MaintenanceScreen.jsx`** — friendly learner lock screen with a **live ETA countdown**.
- **`components/maintenance/MaintenanceGate.jsx`** — mounted once in `AppProviders`: OFF → app; ON+admin → app **+ persistent "maintenance ON" bar** with Turn-off + settings link; ON+non-admin → lock screen. Fails open while loading; re-checks on route change, 60s poll, and window focus.
- **`hooks/useMaintenanceMode.js`** — admin hook shared by the settings page and the bar.
- **`app/[locale]/dashboard/admin/settings/maintenance/page.jsx`** — `AdminTierGuard`-wrapped toggle + message + ETA inputs, status display, and a live lock-screen preview.

## Acceptance criteria
Maintenance toggle in settings ✓ · API state persistence ✓ · layout-level flag check each request ✓ · non-admin lock screen ✓ · offline page adapted (shared shell) ✓ · admin bypass ✓ · persistent admin bar + Turn-off ✓ · optional countdown/ETA ✓ · all three states (normal / admin / learner) coherent ✓

## CI note
Rebased on current `dev`; **builds green** locally (`npm run build`), and `npm run lint` is clean for all added files. The red **Run component tests** (vitest), **Lighthouse CI**, and **a11y** checks are **pre-existing failures on `dev` itself** (verified on a clean `dev` checkout: `useAdminTeam` vitest timeouts, a `next/font/google` mock gap, and 4 `label-has-associated-control` errors in the unrelated `app/[locale]/admin/audit-logs` + `reconciliation` pages) — this PR only adds new files and does not touch those. Happy to help fix the shared harness separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added platform-wide maintenance mode controls for super-admins.
  * Admins can enable or disable maintenance mode, customize the learner message, and set a return-time estimate.
  * Added a live preview of the maintenance lock screen and countdown display.
  * Visitors see a maintenance screen while the platform is unavailable; admins retain access with management controls.
* **Improvements**
  * Standardized offline and maintenance screens with a shared full-screen layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->