### PR TITLE
feat(admin): session security hardening for admin sessions (#337)

### DIFF
--- a/app/[locale]/(pages)/(auth)/login/page.jsx
+++ b/app/[locale]/(pages)/(auth)/login/page.jsx
@@ -1,10 +1,11 @@
 import LoginForm from '@/components/organisms/auth/login-form'
 import ForgetPassword from '@/components/organisms/auth/forget-password'
 import { GalleryVerticalEnd } from 'lucide-react'
-import React from 'react'
+import React, { Suspense } from 'react'
 import Image from "next/image"
 import Link from 'next/link'
 import { siteUrl, siteName } from "@/lib/config/site.config"
+import SessionEndedNotice from "@/components/auth/SessionEndedNotice"
 
 export const metadata = {
   title: { absolute: "Sign in | Deen Bridge" },
@@ -43,6 +44,9 @@ const page = () => {
         </div>
         <div className="flex flex-1 items-center justify-center">
           <div className="w-full max-w-xs">
+            <Suspense fallback={null}>
+              <SessionEndedNotice />
+            </Suspense>
             <LoginForm />
           </div>
         </div>

--- a/app/[locale]/dashboard/admin/settings/flags/page.jsx
+++ b/app/[locale]/dashboard/admin/settings/flags/page.jsx
@@ -60,7 +60,9 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import AdminTierGuard from "@/components/auth/AdminTierGuard";
+import ReauthPromptDialog from "@/components/auth/ReauthPromptDialog";
 import useFeatureFlags from "@/hooks/useFeatureFlags";
+import useReauth from "@/hooks/useReauth";
 import { cn } from "@/lib/utils";
 import {
   poppins_400,
@@ -275,7 +277,7 @@ function CreateFlagDialog({ open, onOpenChange, existingKeys, onCreate }) {
   );
 }
 
-function FlagRow({ flag, onToggle, onRolloutCommit }) {
+function FlagRow({ flag, onToggle, onRolloutCommit, ensureFreshSession }) {
   const [confirmOff, setConfirmOff] = useState(false);
   const [rolloutDraft, setRolloutDraft] = useState(String(flag.rolloutPercentage));
 
@@ -392,7 +394,15 @@ function FlagRow({ flag, onToggle, onRolloutCommit }) {
             <AlertDialogCancel className="rounded-full">Cancel</AlertDialogCancel>
             <AlertDialogAction
               className="rounded-full bg-destructive text-white hover:bg-destructive/90"
-              onClick={() => onToggle(flag.key, false)}
+              onClick={async () => {
+                // Sensitive action (#337): if the session is older than the
+                // configured re-auth age, require a password step-up before
+                // disabling a kill-switch flag. `ensureFreshSession` resolves
+                // instantly when the session is already fresh.
+                if (await ensureFreshSession()) {
+                  onToggle(flag.key, false);
+                }
+              }}
             >
               Turn off
             </AlertDialogAction>
@@ -429,6 +439,7 @@ function FlagsHeader() {
 function FeatureFlagsContent() {
   const { flags, isLoading, error, refresh, toggleFlag, setRollout, createFlag } =
     useFeatureFlags();
+  const { ensureFreshSession, reauthProps } = useReauth();
   const [createOpen, setCreateOpen] = useState(false);
 
   const existingKeys = useMemo(() => flags.map((flag) => flag.key), [flags]);
@@ -501,6 +512,7 @@ function FeatureFlagsContent() {
                   flag={flag}
                   onToggle={toggleFlag}
                   onRolloutCommit={setRollout}
+                  ensureFreshSession={ensureFreshSession}
                 />
               ))}
             </TableBody>
@@ -514,6 +526,9 @@ function FeatureFlagsContent() {
         existingKeys={existingKeys}
         onCreate={createFlag}
       />
+
+      {/* Step-up re-auth for sensitive flag changes (#337). */}
+      <ReauthPromptDialog {...reauthProps} />
     </PageShell>
   );
 }

--- a/app/[locale]/dashboard/admin/settings/session-security/page.jsx
+++ b/app/[locale]/dashboard/admin/settings/session-security/page.jsx
@@ -1,0 +1,281 @@
+"use client";
+/**
+ * Session-security settings page (#337).
+ * ---------------------------------------------------------------------------
+ * Super-admin surface (wrapped in `AdminTierGuard`) for editing the configurable
+ * admin session-hardening values that drive `AdminIdleGuard` and the re-auth
+ * prompt: the idle timeout, the warning lead time, and the re-auth age.
+ *
+ * Mirrors the feature-flags settings page: a `PageShell` + `PageHeader`, a
+ * `Skeleton` loading state, an `EmptyState` on load failure, and a validated
+ * form that saves through the stubbed `admin-session-config` service with
+ * `sonner` toasts. Validation is client-side (mirroring
+ * `validateSessionSecurityConfig`) with the submit button disabled until valid.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { Clock, KeyRound, ShieldCheck, TimerReset } from "lucide-react";
+import { toast } from "sonner";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
+import AdminTierGuard from "@/components/auth/AdminTierGuard";
+import {
+  getSessionSecurityConfig,
+  updateSessionSecurityConfig,
+  validateSessionSecurityConfig,
+  DEFAULT_SESSION_SECURITY_CONFIG,
+} from "@/lib/actions/admin-session-config";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+/** One field's controlled number input with an inline hint / error. */
+function ConfigField({
+  id,
+  icon: Icon,
+  label,
+  unit,
+  hint,
+  value,
+  error,
+  onChange,
+  min,
+  max,
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={id} className={cn(poppins_500.className, "text-ink")}>
+        <Icon className="h-4 w-4 text-secondary" aria-hidden="true" />
+        {label}
+      </Label>
+      <div className="flex items-center gap-2">
+        <Input
+          id={id}
+          type="number"
+          inputMode="numeric"
+          min={min}
+          max={max}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          aria-invalid={Boolean(error)}
+          aria-describedby={`${id}-hint`}
+          className="max-w-[8rem]"
+        />
+        <span className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+          {unit}
+        </span>
+      </div>
+      <p
+        id={`${id}-hint`}
+        className={cn(
+          poppins_400.className,
+          "text-xs",
+          error ? "text-destructive" : "text-ink-muted"
+        )}
+      >
+        {error || hint}
+      </p>
+    </div>
+  );
+}
+
+function SessionSecurityContent() {
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState(null);
+  const [isSaving, setIsSaving] = useState(false);
+
+  // Form fields are kept as strings so the inputs stay controlled while typing.
+  const [form, setForm] = useState({
+    idleTimeoutMinutes: "",
+    idleWarningSeconds: "",
+    reauthAfterMinutes: "",
+  });
+
+  const load = async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const cfg = await getSessionSecurityConfig();
+      setForm({
+        idleTimeoutMinutes: String(cfg.idleTimeoutMinutes),
+        idleWarningSeconds: String(cfg.idleWarningSeconds),
+        reauthAfterMinutes: String(cfg.reauthAfterMinutes),
+      });
+    } catch (err) {
+      setLoadError(err?.message || "Failed to load session-security settings");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const setField = (name) => (value) =>
+    setForm((prev) => ({ ...prev, [name]: value }));
+
+  // Parse to numbers and validate with the same rules the service enforces.
+  const numeric = useMemo(
+    () => ({
+      idleTimeoutMinutes: Number(form.idleTimeoutMinutes),
+      idleWarningSeconds: Number(form.idleWarningSeconds),
+      reauthAfterMinutes: Number(form.reauthAfterMinutes),
+    }),
+    [form]
+  );
+
+  const { valid, errors } = useMemo(
+    () => validateSessionSecurityConfig(numeric),
+    [numeric]
+  );
+
+  const handleReset = () => {
+    setForm({
+      idleTimeoutMinutes: String(
+        DEFAULT_SESSION_SECURITY_CONFIG.idleTimeoutMinutes
+      ),
+      idleWarningSeconds: String(
+        DEFAULT_SESSION_SECURITY_CONFIG.idleWarningSeconds
+      ),
+      reauthAfterMinutes: String(
+        DEFAULT_SESSION_SECURITY_CONFIG.reauthAfterMinutes
+      ),
+    });
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!valid || isSaving) return;
+    setIsSaving(true);
+    try {
+      const saved = await updateSessionSecurityConfig(numeric);
+      setForm({
+        idleTimeoutMinutes: String(saved.idleTimeoutMinutes),
+        idleWarningSeconds: String(saved.idleWarningSeconds),
+        reauthAfterMinutes: String(saved.reauthAfterMinutes),
+      });
+      toast.success("Session-security settings saved");
+    } catch (err) {
+      toast.error(err?.message || "Couldn't save settings");
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={ShieldCheck}
+        title="Session security"
+        subtitle="Tune idle-timeout and re-authentication rules for admin sessions"
+      />
+
+      {loadError ? (
+        <EmptyState
+          icon={ShieldCheck}
+          title="Failed to load"
+          description={loadError}
+          action={
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={load}
+            >
+              Try again
+            </Button>
+          }
+        />
+      ) : loading ? (
+        <div className="max-w-xl space-y-6 rounded-2xl border border-accent/10 bg-surface-raised p-6 shadow-sm">
+          {[...Array(3)].map((_, i) => (
+            <div key={i} className="space-y-2">
+              <Skeleton className="h-4 w-40 rounded-full" />
+              <Skeleton className="h-9 w-32 rounded-lg" />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <form
+          onSubmit={handleSubmit}
+          noValidate
+          className="max-w-xl space-y-6 rounded-2xl border border-accent/10 bg-surface-raised p-6 shadow-sm"
+        >
+          <ConfigField
+            id="idle-timeout-minutes"
+            icon={Clock}
+            label="Idle timeout"
+            unit="minutes"
+            hint="Sign admins out after this much inactivity."
+            value={form.idleTimeoutMinutes}
+            error={errors.idleTimeoutMinutes}
+            onChange={setField("idleTimeoutMinutes")}
+            min={1}
+            max={480}
+          />
+
+          <ConfigField
+            id="idle-warning-seconds"
+            icon={TimerReset}
+            label="Warning lead time"
+            unit="seconds"
+            hint="Show the countdown warning this long before the timeout."
+            value={form.idleWarningSeconds}
+            error={errors.idleWarningSeconds}
+            onChange={setField("idleWarningSeconds")}
+            min={5}
+            max={600}
+          />
+
+          <ConfigField
+            id="reauth-after-minutes"
+            icon={KeyRound}
+            label="Re-authentication age"
+            unit="minutes"
+            hint="Require a password re-entry for sensitive actions once the session is older than this."
+            value={form.reauthAfterMinutes}
+            error={errors.reauthAfterMinutes}
+            onChange={setField("reauthAfterMinutes")}
+            min={1}
+            max={1440}
+          />
+
+          <div className="flex items-center gap-2 pt-2">
+            <Button
+              type="submit"
+              className="rounded-full bg-accent text-white hover:bg-accent/90"
+              disabled={!valid || isSaving}
+            >
+              {isSaving ? "Saving…" : "Save changes"}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={handleReset}
+              disabled={isSaving}
+            >
+              Reset to defaults
+            </Button>
+          </div>
+          <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+            These rules apply to admin sessions only. The backend remains the
+            source of truth for session validity.
+          </p>
+        </form>
+      )}
+    </PageShell>
+  );
+}
+
+export default function SessionSecurityPage() {
+  return (
+    <AdminTierGuard>
+      <SessionSecurityContent />
+    </AdminTierGuard>
+  );
+}

--- a/components/auth/AdminIdleGuard.jsx
+++ b/components/auth/AdminIdleGuard.jsx
@@ -1,0 +1,161 @@
+"use client";
+/**
+ * AdminIdleGuard — idle-timeout warning + auto-logout for admin sessions (#337).
+ * ---------------------------------------------------------------------------
+ * Mounted **once** in `AppProviders`, this component is a deliberate no-op
+ * except when BOTH conditions hold:
+ *   1. the signed-in user is an admin (`normalizeRole(user.role) === ADMIN`), and
+ *   2. the user is currently on an admin surface (an `/admin` or
+ *      `/dashboard/admin` route).
+ *
+ * Admin sessions are held to a stricter standard than learner areas: after a
+ * configurable idle period an "you'll be signed out" warning counts down, and
+ * on timeout the user is signed out and bounced to the login page with a clear
+ * reason. Everywhere else it arms nothing, so the blast radius is contained.
+ *
+ * **Fail safe.** It never forces a logout while auth or the config are still
+ * loading, and it disarms the moment the user leaves an admin route or signs
+ * out — a non-admin visitor is never affected.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { LogOut, ShieldAlert } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import useAuth from "@/hooks/useAuth";
+import useIdleTimeout from "@/hooks/useIdleTimeout";
+import { ROLES, normalizeRole } from "@/lib/auth/roles";
+import {
+  getSessionSecurityConfig,
+  DEFAULT_SESSION_SECURITY_CONFIG,
+} from "@/lib/actions/admin-session-config";
+import {
+  loginUrlWithReason,
+  SESSION_IDLE,
+  clearReauthMarker,
+} from "@/lib/auth/session-status";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_600 } from "@/lib/config/font.config";
+
+/** Matches an admin surface: ".../admin" or ".../admin/..." (any locale prefix). */
+const ADMIN_ROUTE = /\/admin(\/|$)/;
+
+/** Format seconds as "m:ss" for the countdown, clamped at zero. */
+function formatCountdown(totalSeconds) {
+  const s = Math.max(0, Math.floor(totalSeconds || 0));
+  const minutes = Math.floor(s / 60);
+  const seconds = s % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+export default function AdminIdleGuard() {
+  const { user, loading, logout } = useAuth();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const [config, setConfig] = useState(null);
+
+  const isAdmin = useMemo(
+    () => Boolean(user) && normalizeRole(user.role) === ROLES.ADMIN,
+    [user]
+  );
+  const onAdminRoute = Boolean(pathname && ADMIN_ROUTE.test(pathname));
+
+  // Load the (stubbed) config once we know the user is an admin. Fail safe:
+  // fall back to defaults if the request fails so the guard still protects.
+  useEffect(() => {
+    if (!isAdmin) {
+      setConfig(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const cfg = await getSessionSecurityConfig();
+        if (!cancelled) setConfig(cfg);
+      } catch {
+        if (!cancelled) setConfig({ ...DEFAULT_SESSION_SECURITY_CONFIG });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isAdmin]);
+
+  // Only arm once everything needed is resolved — never mid-load.
+  const armed = !loading && isAdmin && onAdminRoute && Boolean(config);
+
+  const idleMs = (config?.idleTimeoutMinutes ?? 0) * 60_000;
+  const warnMs = (config?.idleWarningSeconds ?? 0) * 1000;
+
+  const handleTimeout = () => {
+    // Sign out, forget any step-up freshness, and explain why on the login page.
+    clearReauthMarker();
+    try {
+      logout();
+    } finally {
+      router.replace(loginUrlWithReason(SESSION_IDLE));
+    }
+  };
+
+  const { isIdleWarning, remainingSeconds, stayActive } = useIdleTimeout({
+    idleMs,
+    warnMs,
+    enabled: armed,
+    onTimeout: handleTimeout,
+  });
+
+  // Nothing to render unless we're armed and actively warning.
+  if (!armed || !isIdleWarning) return null;
+
+  return (
+    <AlertDialog open={isIdleWarning}>
+      <AlertDialogContent className="border border-destructive/20 bg-surface-raised">
+        <AlertDialogHeader>
+          <AlertDialogTitle
+            className={cn(poppins_600.className, "flex items-center gap-2 text-ink")}
+          >
+            <ShieldAlert className="h-5 w-5 text-destructive" aria-hidden="true" />
+            You&apos;ll be signed out soon
+          </AlertDialogTitle>
+          <AlertDialogDescription
+            className={cn(poppins_400.className, "text-ink-muted")}
+          >
+            For security, your admin session will end after inactivity. You&apos;ll
+            be signed out in{" "}
+            <span
+              className="font-mono font-semibold text-destructive"
+              aria-live="polite"
+            >
+              {formatCountdown(remainingSeconds)}
+            </span>
+            .
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            className="rounded-full"
+            onClick={handleTimeout}
+          >
+            <LogOut className="mr-1 h-4 w-4" aria-hidden="true" />
+            Sign out now
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className="rounded-full bg-accent text-white hover:bg-accent/90"
+            onClick={stayActive}
+          >
+            Stay signed in
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/components/auth/ReauthPromptDialog.jsx
+++ b/components/auth/ReauthPromptDialog.jsx
@@ -1,0 +1,138 @@
+"use client";
+/**
+ * ReauthPromptDialog — password step-up prompt for sensitive actions (#337).
+ * ---------------------------------------------------------------------------
+ * Presentational dialog driven by `useReauth`. It collects the current admin's
+ * password and calls `onConfirm(password)`; on success the parent hook closes it
+ * and lets the sensitive action proceed, on failure it surfaces the error inline
+ * and stays open so the admin can retry. Cancel/escape/close never proceed.
+ *
+ * Usage:
+ *   const { ensureFreshSession, reauthProps } = useReauth();
+ *   <ReauthPromptDialog {...reauthProps} />
+ */
+import { useEffect, useState } from "react";
+import { KeyRound, ShieldAlert } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+export default function ReauthPromptDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  title = "Confirm it's you",
+  description = "Your session has been active for a while. Re-enter your password to continue with this sensitive action.",
+}) {
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // Never carry a typed password or error across opens.
+  useEffect(() => {
+    if (!open) {
+      setPassword("");
+      setError(null);
+      setIsSubmitting(false);
+    }
+  }, [open]);
+
+  const canSubmit = password.trim().length > 0 && !isSubmitting;
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await onConfirm?.(password);
+      // Parent (useReauth) closes the dialog on success.
+    } catch (err) {
+      setError(err?.message || "Re-authentication failed. Please try again.");
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !isSubmitting && onOpenChange?.(next)}>
+      <DialogContent className="border border-accent/10 bg-surface-raised sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle
+            className={cn(poppins_600.className, "flex items-center gap-2 text-ink")}
+          >
+            <ShieldAlert className="h-5 w-5 text-secondary" aria-hidden="true" />
+            {title}
+          </DialogTitle>
+          <DialogDescription className={cn(poppins_400.className, "text-ink-muted")}>
+            {description}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4" noValidate>
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="reauth-password"
+              className={cn(poppins_500.className, "text-ink")}
+            >
+              Password
+            </Label>
+            <div className="relative">
+              <KeyRound
+                className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-muted"
+                aria-hidden="true"
+              />
+              <Input
+                id="reauth-password"
+                type="password"
+                className="pl-9"
+                placeholder="Your account password"
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                aria-invalid={Boolean(error)}
+                aria-describedby={error ? "reauth-error" : undefined}
+                autoComplete="current-password"
+              />
+            </div>
+            {error && (
+              <p
+                id="reauth-error"
+                className={cn(poppins_400.className, "text-xs text-destructive")}
+              >
+                {error}
+              </p>
+            )}
+          </div>
+
+          <DialogFooter className="gap-2 sm:gap-0">
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              disabled={isSubmitting}
+              onClick={() => onOpenChange?.(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              className="rounded-full bg-accent text-white hover:bg-accent/90"
+              disabled={!canSubmit}
+            >
+              {isSubmitting ? "Verifying…" : "Confirm"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/auth/SessionEndedNotice.jsx
+++ b/components/auth/SessionEndedNotice.jsx
@@ -1,0 +1,47 @@
+"use client";
+/**
+ * SessionEndedNotice — "expired vs revoked vs idle" banner on the login page.
+ * ---------------------------------------------------------------------------
+ * Reads the `?reason=` query param (set when the app bounces to login) and shows
+ * a clear, reason-specific message so the user understands *why* they're back at
+ * the sign-in screen. Renders nothing when there is no recognised reason.
+ *
+ * Copy and the destructive/default styling come from `lib/auth/session-status`
+ * so the reasons stay consistent wherever they're surfaced. Because it reads
+ * search params, mount it inside a `<Suspense>` boundary (Next.js 15).
+ */
+import { useSearchParams } from "next/navigation";
+import { AlertTriangle, Clock, ShieldAlert } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  reasonMessage,
+  SESSION_END_REASONS,
+} from "@/lib/auth/session-status";
+import { cn } from "@/lib/utils";
+
+const REASON_ICON = {
+  [SESSION_END_REASONS.SESSION_EXPIRED]: Clock,
+  [SESSION_END_REASONS.SESSION_REVOKED]: ShieldAlert,
+  [SESSION_END_REASONS.SESSION_IDLE]: AlertTriangle,
+};
+
+export default function SessionEndedNotice() {
+  const searchParams = useSearchParams();
+  const reason = searchParams.get("reason");
+  const copy = reasonMessage(reason);
+
+  if (!copy) return null;
+
+  const Icon = REASON_ICON[reason?.trim().toLowerCase()] || ShieldAlert;
+
+  return (
+    <Alert
+      variant={copy.variant}
+      className={cn("mb-4", copy.variant === "default" && "border-accent/20")}
+    >
+      <Icon className="h-4 w-4" aria-hidden="true" />
+      <AlertTitle>{copy.title}</AlertTitle>
+      <AlertDescription>{copy.message}</AlertDescription>
+    </Alert>
+  );
+}

--- a/components/providers/AppProviders.jsx
+++ b/components/providers/AppProviders.jsx
@@ -6,6 +6,7 @@ import AuthProvider from "@/components/providers/AuthProvider";
 import CacheProvider from "@/components/providers/CacheProvider";
 import FeatureFlagProvider from "@/components/providers/FeatureFlagProvider";
 import StellarProvider from "@/components/stellar/StellarProvider";
+import AdminIdleGuard from "@/components/auth/AdminIdleGuard";
 
 export default function AppProviders({ children }) {
   return (
@@ -14,7 +15,12 @@ export default function AppProviders({ children }) {
         <CacheProvider>
           <AuthProvider>
             <FeatureFlagProvider>
-              <StellarProvider>{children}</StellarProvider>
+              <StellarProvider>
+                {/* Idle-timeout auto-logout for admin sessions (#337).
+                    Self-noops for non-admins and non-admin routes. */}
+                <AdminIdleGuard />
+                {children}
+              </StellarProvider>
             </FeatureFlagProvider>
           </AuthProvider>
         </CacheProvider>

--- a/hooks/useIdleTimeout.js
+++ b/hooks/useIdleTimeout.js
@@ -1,0 +1,163 @@
+"use client";
+/**
+ * useIdleTimeout — reusable inactivity timer for session hardening (#337).
+ * ---------------------------------------------------------------------------
+ * Tracks user activity (mousemove / keydown / click / scroll / touch /
+ * visibility) and fires two callbacks:
+ *   - `onWarn`    after `idleMs - warnMs` of inactivity (show a warning), and
+ *   - `onTimeout` at `idleMs` of inactivity (auto-logout).
+ *
+ * It exposes `{ isIdleWarning, remainingSeconds, reset, stayActive }` so a UI
+ * can render a live countdown and let the user cancel.
+ *
+ * Robustness
+ * ----------
+ *   - Activity handlers are throttled so a moving mouse doesn't reset timers on
+ *     every pixel.
+ *   - All timers/intervals/listeners are cleaned up on unmount, on `enabled`
+ *     flipping off, and whenever the timing inputs change.
+ *   - Callbacks are held in refs so changing an inline `onWarn`/`onTimeout` does
+ *     not tear down and re-arm the listeners.
+ *   - Fully guarded for SSR (no `window`) and post-unmount state updates.
+ *
+ * @param {Object} options
+ * @param {number} options.idleMs   total inactivity before timeout (ms)
+ * @param {number} options.warnMs   how long before timeout to warn (ms)
+ * @param {boolean} [options.enabled=true] arm the timer only when true
+ * @param {() => void} [options.onWarn]     fired once when the warning begins
+ * @param {() => void} [options.onTimeout]  fired once when the timeout elapses
+ * @param {number} [options.throttleMs=750] min gap between activity resets
+ * @returns {{isIdleWarning: boolean, remainingSeconds: number, reset: () => void, stayActive: () => void}}
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const ACTIVITY_EVENTS = [
+  "mousemove",
+  "mousedown",
+  "keydown",
+  "click",
+  "scroll",
+  "touchstart",
+  "wheel",
+];
+
+export default function useIdleTimeout({
+  idleMs,
+  warnMs,
+  enabled = true,
+  onWarn,
+  onTimeout,
+  throttleMs = 750,
+} = {}) {
+  const [isIdleWarning, setIsIdleWarning] = useState(false);
+  const [remainingSeconds, setRemainingSeconds] = useState(
+    Math.ceil((warnMs || 0) / 1000)
+  );
+
+  // Keep callbacks in refs so their identity doesn't re-arm the effect.
+  const onWarnRef = useRef(onWarn);
+  const onTimeoutRef = useRef(onTimeout);
+  useEffect(() => {
+    onWarnRef.current = onWarn;
+  }, [onWarn]);
+  useEffect(() => {
+    onTimeoutRef.current = onTimeout;
+  }, [onTimeout]);
+
+  const mountedRef = useRef(false);
+  const warnTimerRef = useRef(null);
+  const idleTimerRef = useRef(null);
+  const countdownRef = useRef(null);
+  const lastActivityRef = useRef(0);
+
+  const clearTimers = useCallback(() => {
+    if (warnTimerRef.current) clearTimeout(warnTimerRef.current);
+    if (idleTimerRef.current) clearTimeout(idleTimerRef.current);
+    if (countdownRef.current) clearInterval(countdownRef.current);
+    warnTimerRef.current = null;
+    idleTimerRef.current = null;
+    countdownRef.current = null;
+  }, []);
+
+  // `reset` is exposed and also used internally on activity. It re-arms the
+  // warn/idle timers from "now". Guarded so it no-ops while disabled.
+  const reset = useCallback(() => {
+    if (!enabled || !Number.isFinite(idleMs) || idleMs <= 0) return;
+    clearTimers();
+    if (mountedRef.current) setIsIdleWarning(false);
+
+    const safeWarnMs = Math.min(Math.max(0, warnMs || 0), idleMs);
+    const warnAt = Math.max(0, idleMs - safeWarnMs);
+
+    warnTimerRef.current = setTimeout(() => {
+      if (!mountedRef.current) return;
+      setIsIdleWarning(true);
+      setRemainingSeconds(Math.ceil(safeWarnMs / 1000));
+      onWarnRef.current?.();
+
+      // Live countdown for the UI while the warning is showing.
+      countdownRef.current = setInterval(() => {
+        if (!mountedRef.current) return;
+        setRemainingSeconds((prev) => (prev > 0 ? prev - 1 : 0));
+      }, 1000);
+    }, warnAt);
+
+    idleTimerRef.current = setTimeout(() => {
+      if (countdownRef.current) clearInterval(countdownRef.current);
+      countdownRef.current = null;
+      if (!mountedRef.current) return;
+      setRemainingSeconds(0);
+      onTimeoutRef.current?.();
+    }, idleMs);
+  }, [enabled, idleMs, warnMs, clearTimers]);
+
+  // `stayActive` is the explicit user-driven reset (e.g. "Stay signed in").
+  const stayActive = useCallback(() => {
+    lastActivityRef.current = Date.now();
+    reset();
+  }, [reset]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    if (!enabled || typeof window === "undefined") {
+      clearTimers();
+      setIsIdleWarning(false);
+      return () => {
+        mountedRef.current = false;
+        clearTimers();
+      };
+    }
+
+    const handleActivity = () => {
+      const now = Date.now();
+      if (now - lastActivityRef.current < throttleMs) return;
+      lastActivityRef.current = now;
+      reset();
+    };
+
+    const handleVisibility = () => {
+      // Returning to the tab counts as activity; leaving it does not.
+      if (document.visibilityState === "visible") handleActivity();
+    };
+
+    ACTIVITY_EVENTS.forEach((evt) =>
+      window.addEventListener(evt, handleActivity, { passive: true })
+    );
+    document.addEventListener("visibilitychange", handleVisibility);
+
+    // Arm immediately.
+    lastActivityRef.current = Date.now();
+    reset();
+
+    return () => {
+      mountedRef.current = false;
+      ACTIVITY_EVENTS.forEach((evt) =>
+        window.removeEventListener(evt, handleActivity)
+      );
+      document.removeEventListener("visibilitychange", handleVisibility);
+      clearTimers();
+    };
+  }, [enabled, throttleMs, reset, clearTimers]);
+
+  return { isIdleWarning, remainingSeconds, reset, stayActive };
+}

--- a/hooks/useReauth.js
+++ b/hooks/useReauth.js
@@ -1,0 +1,111 @@
+"use client";
+/**
+ * useReauth — step-up re-authentication gate for sensitive admin actions (#337).
+ * ---------------------------------------------------------------------------
+ * When a session is older than the configured `reauthAfterMinutes`, sensitive
+ * mutations should require the admin to re-confirm their password first. This
+ * hook exposes:
+ *
+ *   const { ensureFreshSession, reauthProps } = useReauth();
+ *
+ * `ensureFreshSession()` returns a promise that resolves `true` when the caller
+ * may proceed and `false` when the admin cancelled. If the session is already
+ * fresh (or its age can't be determined) it resolves `true` immediately without
+ * prompting. Otherwise it opens the re-auth dialog and resolves once the admin
+ * succeeds or cancels. Spread `reauthProps` onto `<ReauthPromptDialog />`.
+ *
+ * Usage:
+ *   const { ensureFreshSession, reauthProps } = useReauth();
+ *   const onDangerousThing = async () => {
+ *     if (!(await ensureFreshSession())) return; // cancelled
+ *     await doDangerousThing();
+ *   };
+ *   return <><ReauthPromptDialog {...reauthProps} /></>;
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  getSessionSecurityConfig,
+  DEFAULT_SESSION_SECURITY_CONFIG,
+} from "@/lib/actions/admin-session-config";
+import { reauthenticate } from "@/lib/actions/auth/reauth";
+import { isSessionFresh, markReauthenticated } from "@/lib/auth/session-status";
+
+export default function useReauth() {
+  const [open, setOpen] = useState(false);
+
+  // Threshold used to decide freshness; starts at the safe default and is
+  // replaced once the stubbed config loads.
+  const reauthAfterRef = useRef(
+    DEFAULT_SESSION_SECURITY_CONFIG.reauthAfterMinutes
+  );
+  // Resolver for the promise handed back by `ensureFreshSession`.
+  const pendingRef = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const cfg = await getSessionSecurityConfig();
+        if (!cancelled && cfg?.reauthAfterMinutes != null) {
+          reauthAfterRef.current = cfg.reauthAfterMinutes;
+        }
+      } catch {
+        // Keep the default threshold on failure.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const settle = useCallback((result) => {
+    const resolve = pendingRef.current;
+    pendingRef.current = null;
+    if (resolve) resolve(result);
+  }, []);
+
+  /**
+   * Resolve `true` when the caller may proceed with the sensitive action.
+   * Prompts for re-auth only when the session is stale.
+   * @returns {Promise<boolean>}
+   */
+  const ensureFreshSession = useCallback(() => {
+    if (isSessionFresh(reauthAfterRef.current)) {
+      return Promise.resolve(true);
+    }
+    // If a prompt is somehow already open, cancel the previous waiter.
+    if (pendingRef.current) settle(false);
+    return new Promise((resolve) => {
+      pendingRef.current = resolve;
+      setOpen(true);
+    });
+  }, [settle]);
+
+  /**
+   * Verify the password. Throws on failure so the dialog can show the error and
+   * stay open; on success marks the session fresh and resolves the waiter.
+   * @param {string} password
+   */
+  const onConfirm = useCallback(
+    async (password) => {
+      await reauthenticate({ password });
+      markReauthenticated();
+      setOpen(false);
+      settle(true);
+    },
+    [settle]
+  );
+
+  const onOpenChange = useCallback(
+    (next) => {
+      setOpen(next);
+      if (!next) settle(false); // closing/cancelling → don't proceed
+    },
+    [settle]
+  );
+
+  return {
+    ensureFreshSession,
+    reauthProps: { open, onOpenChange, onConfirm },
+  };
+}

--- a/lib/actions/admin-session-config.js
+++ b/lib/actions/admin-session-config.js
@@ -1,0 +1,135 @@
+/**
+ * Admin session-security config service — configurable session hardening values.
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** These functions resolve with mocked data so the session-security
+ * settings editor (#337) can be built and reviewed before the backend endpoints
+ * exist. Swap the mock bodies for `axiosInstance` calls (see
+ * `lib/config/axios.config.js`) when the backend lands.
+ *
+ * Config shape owned by the backend:
+ *
+ *   {
+ *     idleTimeoutMinutes: number,  // auto-logout after this much inactivity
+ *     idleWarningSeconds: number,  // show the "you'll be signed out" warning this
+ *                                  //   many seconds *before* the timeout fires
+ *     reauthAfterMinutes: number,  // require re-auth for sensitive actions once
+ *                                  //   the session is older than this
+ *   }
+ */
+
+const MOCK_DELAY_MS = 300;
+
+/** Sane, security-minded defaults used until the backend responds. */
+export const DEFAULT_SESSION_SECURITY_CONFIG = Object.freeze({
+  idleTimeoutMinutes: 15,
+  idleWarningSeconds: 60,
+  reauthAfterMinutes: 30,
+});
+
+/** Validation bounds, exported so the settings editor can hint them inline. */
+export const SESSION_SECURITY_BOUNDS = Object.freeze({
+  idleTimeoutMinutes: Object.freeze({ min: 1, max: 480 }),
+  idleWarningSeconds: Object.freeze({ min: 5, max: 600 }),
+  reauthAfterMinutes: Object.freeze({ min: 1, max: 1440 }),
+});
+
+/** In-memory store so the stubbed update round-trips in dev. */
+let mockConfig = { ...DEFAULT_SESSION_SECURITY_CONFIG };
+
+function withMockDelay(value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_DELAY_MS));
+}
+
+function isIntegerInRange(value, { min, max }) {
+  return Number.isInteger(value) && value >= min && value <= max;
+}
+
+/**
+ * Pure validator for a session-security config. Returns a per-field error map
+ * plus a `valid` flag; never throws. Enforces integer bounds and the
+ * cross-field rule that the warning lead time must be shorter than the idle
+ * timeout (you can't warn for longer than the whole timeout window).
+ *
+ * @param {Partial<{idleTimeoutMinutes: number, idleWarningSeconds: number, reauthAfterMinutes: number}>} cfg
+ * @returns {{valid: boolean, errors: {idleTimeoutMinutes?: string, idleWarningSeconds?: string, reauthAfterMinutes?: string}}}
+ */
+export function validateSessionSecurityConfig(cfg) {
+  const errors = {};
+  const c = cfg || {};
+
+  const idleT = SESSION_SECURITY_BOUNDS.idleTimeoutMinutes;
+  const idleW = SESSION_SECURITY_BOUNDS.idleWarningSeconds;
+  const reauth = SESSION_SECURITY_BOUNDS.reauthAfterMinutes;
+
+  if (!isIntegerInRange(c.idleTimeoutMinutes, idleT)) {
+    errors.idleTimeoutMinutes = `Enter a whole number between ${idleT.min} and ${idleT.max} minutes.`;
+  }
+  if (!isIntegerInRange(c.idleWarningSeconds, idleW)) {
+    errors.idleWarningSeconds = `Enter a whole number between ${idleW.min} and ${idleW.max} seconds.`;
+  }
+  if (!isIntegerInRange(c.reauthAfterMinutes, reauth)) {
+    errors.reauthAfterMinutes = `Enter a whole number between ${reauth.min} and ${reauth.max} minutes.`;
+  }
+
+  // Cross-field: the warning must fit inside the idle window.
+  if (
+    !errors.idleTimeoutMinutes &&
+    !errors.idleWarningSeconds &&
+    c.idleWarningSeconds >= c.idleTimeoutMinutes * 60
+  ) {
+    errors.idleWarningSeconds =
+      "The warning lead time must be shorter than the idle timeout.";
+  }
+
+  return { valid: Object.keys(errors).length === 0, errors };
+}
+
+/**
+ * Fetch the current session-security config.
+ *
+ * TODO(backend): GET /api/admin/session-security
+ *   - Auth: requires an admin session token (server-side tier check).
+ *   - 200 → { config: { idleTimeoutMinutes, idleWarningSeconds, reauthAfterMinutes } }
+ *   - 403 for non-admins.
+ *
+ * @returns {Promise<{idleTimeoutMinutes: number, idleWarningSeconds: number, reauthAfterMinutes: number}>}
+ */
+export async function getSessionSecurityConfig() {
+  // TODO(backend):
+  //   return axiosInstance
+  //     .get("/api/admin/session-security")
+  //     .then((res) => res.data.config);
+  return withMockDelay({ ...mockConfig });
+}
+
+/**
+ * Persist an updated session-security config. Validates before "saving" and
+ * rejects an invalid payload the same way the backend's 422 would.
+ *
+ * TODO(backend): PUT /api/admin/session-security
+ *   - Auth: admin only.
+ *   - Payload: { idleTimeoutMinutes, idleWarningSeconds, reauthAfterMinutes }
+ *   - 200 → { config: Config }
+ *   - 422 with a per-field error map for out-of-range / cross-field violations.
+ *
+ * @param {{idleTimeoutMinutes: number, idleWarningSeconds: number, reauthAfterMinutes: number}} cfg
+ * @returns {Promise<{idleTimeoutMinutes: number, idleWarningSeconds: number, reauthAfterMinutes: number}>}
+ */
+export async function updateSessionSecurityConfig(cfg) {
+  // TODO(backend):
+  //   return axiosInstance
+  //     .put("/api/admin/session-security", cfg)
+  //     .then((res) => res.data.config);
+  const { valid, errors } = validateSessionSecurityConfig(cfg);
+  if (!valid) {
+    const err = new Error("Invalid session-security configuration.");
+    err.fieldErrors = errors;
+    throw err;
+  }
+  mockConfig = {
+    idleTimeoutMinutes: cfg.idleTimeoutMinutes,
+    idleWarningSeconds: cfg.idleWarningSeconds,
+    reauthAfterMinutes: cfg.reauthAfterMinutes,
+  };
+  return withMockDelay({ ...mockConfig });
+}

--- a/lib/actions/auth/reauth.js
+++ b/lib/actions/auth/reauth.js
@@ -1,0 +1,44 @@
+/**
+ * Re-authentication service — password step-up before sensitive admin actions.
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Resolves against the mocked contract so the re-auth prompt (#337)
+ * can be built and reviewed before the backend endpoint exists. Swap the body
+ * for the `axiosInstance` call when the backend lands.
+ */
+
+import axiosInstance from "@/lib/config/axios.config";
+
+const MOCK_DELAY_MS = 500;
+
+/**
+ * Verify the current user's password to prove a fresh, deliberate presence
+ * before a sensitive action proceeds.
+ *
+ * TODO(backend): POST /api/auth/reauth
+ *   - Auth: the current session token in the Authorization header.
+ *   - Payload: { password: string }
+ *   - 200 → { ok: true, reauthAt: string (ISO 8601) } — server records the
+ *     step-up so subsequent sensitive calls within a window are trusted.
+ *   - 401 → { ok: false } for a wrong password (rate-limited server-side).
+ *
+ * @param {{password: string}} payload
+ * @returns {Promise<{ok: true, reauthAt: string}>}
+ * @throws {Error} with a friendly message on an incorrect password.
+ */
+export async function reauthenticate({ password } = {}) {
+  // TODO(backend):
+  //   const res = await axiosInstance.post("/api/auth/reauth", { password });
+  //   return res.data;
+  void axiosInstance; // referenced so the real wiring is a one-line swap.
+
+  await new Promise((resolve) => setTimeout(resolve, MOCK_DELAY_MS));
+
+  // Stub: treat any non-empty password as correct so the flow is demoable.
+  if (!password || !String(password).trim()) {
+    const err = new Error("Incorrect password. Please try again.");
+    err.status = 401;
+    throw err;
+  }
+
+  return { ok: true, reauthAt: new Date().toISOString() };
+}

--- a/lib/auth/session-status.js
+++ b/lib/auth/session-status.js
@@ -1,0 +1,210 @@
+/**
+ * Session status — reason constants, JWT age helpers, and login messaging.
+ * ---------------------------------------------------------------------------
+ * Single source of truth for *why* a session ended and *how old* the current
+ * session is, shared by the admin idle guard (#337), the re-auth prompt, and
+ * the login-page "session ended" banner.
+ *
+ * This is **defense-in-depth / UX only** — exactly like `roles.js` and
+ * `admin-tiers.js`. The backend remains the real authority on session validity;
+ * everything here exists so the UI can enforce stricter admin session flows and
+ * explain to the user what happened.
+ *
+ * Design rules
+ * ------------
+ *   - **Pure where it can be.** `decodeJwt`, `getSessionAgeMs`, `reasonMessage`
+ *     read only their inputs (or the auth cookie) — no React, no fetching.
+ *   - **Fail safe.** When the session age can't be determined (no JWT, no `iat`,
+ *     malformed token) the age helpers return `null` and callers must treat
+ *     "unknown age" as *not stale enough to force a logout* — we never sign an
+ *     admin out on a guess.
+ */
+
+import Cookies from "js-cookie";
+
+/**
+ * Canonical reasons a session can end. Passed through the `?reason=` query param
+ * to the login page so the user gets a precise "expired" vs "revoked" message.
+ */
+export const SESSION_END_REASONS = Object.freeze({
+  /** Backend token lifetime elapsed (JWT `exp` passed). */
+  SESSION_EXPIRED: "expired",
+  /** An admin revoked this device/session server-side. */
+  SESSION_REVOKED: "revoked",
+  /** Client-side idle-timeout auto-logout (admin hardening, #337). */
+  SESSION_IDLE: "idle",
+});
+
+// Convenience named exports mirroring the spec's constant names.
+export const SESSION_EXPIRED = SESSION_END_REASONS.SESSION_EXPIRED;
+export const SESSION_REVOKED = SESSION_END_REASONS.SESSION_REVOKED;
+export const SESSION_IDLE = SESSION_END_REASONS.SESSION_IDLE;
+
+/**
+ * Human-facing copy for each end reason. `variant` maps onto the `Alert` UI
+ * component so revoked (a security event) reads more urgently than a benign
+ * expiry.
+ */
+const REASON_COPY = Object.freeze({
+  [SESSION_END_REASONS.SESSION_EXPIRED]: Object.freeze({
+    title: "Your session expired",
+    message: "For your security, please sign in again to continue.",
+    variant: "default",
+  }),
+  [SESSION_END_REASONS.SESSION_REVOKED]: Object.freeze({
+    title: "Your session was revoked",
+    message:
+      "This session was signed out from another device or by an administrator. Sign in again if this was you.",
+    variant: "destructive",
+  }),
+  [SESSION_END_REASONS.SESSION_IDLE]: Object.freeze({
+    title: "Signed out for inactivity",
+    message:
+      "You were signed out after a period of inactivity to protect your account. Please sign in again.",
+    variant: "default",
+  }),
+});
+
+/**
+ * Normalise an arbitrary `?reason=` value to a known {@link SESSION_END_REASONS}
+ * value, or `null` when it is missing/unrecognised.
+ *
+ * @param {unknown} reason
+ * @returns {string|null}
+ */
+export function normalizeReason(reason) {
+  if (typeof reason !== "string") return null;
+  const r = reason.trim().toLowerCase();
+  const values = Object.values(SESSION_END_REASONS);
+  return values.includes(r) ? r : null;
+}
+
+/**
+ * Resolve the friendly `{ title, message, variant }` copy for an end reason.
+ * Returns `null` for an unknown/missing reason so callers can render nothing.
+ *
+ * @param {unknown} reason
+ * @returns {{title: string, message: string, variant: ("default"|"destructive")}|null}
+ */
+export function reasonMessage(reason) {
+  const key = normalizeReason(reason);
+  return key ? REASON_COPY[key] : null;
+}
+
+/**
+ * Build a login URL carrying the end reason so the login page can explain what
+ * happened. Locale-agnostic (next-intl middleware adds the locale prefix).
+ *
+ * @param {string} reason a {@link SESSION_END_REASONS} value
+ * @returns {string} e.g. "/login?reason=idle"
+ */
+export function loginUrlWithReason(reason) {
+  const key = normalizeReason(reason);
+  return key ? `/login?reason=${key}` : "/login";
+}
+
+/**
+ * Decode a JWT payload without verifying its signature. **Never** a security
+ * check — signature verification is the backend's job; this only reads claims
+ * (`iat`, `exp`) the client uses for UX timing. Returns `null` on any malformed
+ * input.
+ *
+ * @param {unknown} token
+ * @returns {Record<string, any>|null}
+ */
+export function decodeJwt(token) {
+  if (typeof token !== "string") return null;
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    let base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    // Pad to a multiple of 4 for atob.
+    while (base64.length % 4) base64 += "=";
+    const json =
+      typeof atob === "function"
+        ? atob(base64)
+        : Buffer.from(base64, "base64").toString("binary");
+    // Handle UTF-8 payloads.
+    const decoded = decodeURIComponent(
+      Array.prototype.map
+        .call(json, (c) => "%" + ("00" + c.charCodeAt(0).toString(16)).slice(-2))
+        .join("")
+    );
+    return JSON.parse(decoded);
+  } catch {
+    return null;
+  }
+}
+
+/** Read the raw auth token cookie (browser only). */
+function readToken() {
+  try {
+    return Cookies.get("authToken") || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Module-level "session freshness anchor" bumped whenever the user completes a
+ * successful re-authentication (step-up). The stubbed re-auth doesn't mint a new
+ * JWT, so without this a re-auth wouldn't reset the perceived session age.
+ * @type {number|null} epoch ms
+ */
+let lastReauthAt = null;
+
+/** Record a successful re-authentication so the session reads as fresh again. */
+export function markReauthenticated(at = Date.now()) {
+  lastReauthAt = typeof at === "number" && Number.isFinite(at) ? at : Date.now();
+}
+
+/** Clear the re-auth anchor (e.g. on logout). */
+export function clearReauthMarker() {
+  lastReauthAt = null;
+}
+
+/**
+ * Resolve the effective start of the current session as epoch ms — the most
+ * recent of the JWT `iat` and the last successful re-auth. Returns `null` when
+ * it cannot be determined (no token / no `iat`), which callers treat as
+ * "unknown, don't force anything".
+ *
+ * @param {string} [token] optional explicit token (defaults to the cookie)
+ * @returns {number|null}
+ */
+export function getSessionStartedAt(token) {
+  const claims = decodeJwt(token ?? readToken());
+  const iatMs =
+    claims && typeof claims.iat === "number" ? claims.iat * 1000 : null;
+  if (iatMs == null && lastReauthAt == null) return null;
+  return Math.max(iatMs ?? 0, lastReauthAt ?? 0) || null;
+}
+
+/**
+ * Age of the current session in milliseconds, or `null` when undeterminable.
+ *
+ * @param {string} [token]
+ * @returns {number|null}
+ */
+export function getSessionAgeMs(token) {
+  const startedAt = getSessionStartedAt(token);
+  if (startedAt == null) return null;
+  return Math.max(0, Date.now() - startedAt);
+}
+
+/**
+ * Whether the session is "fresh enough" to skip a re-auth prompt for a
+ * sensitive action. **Fails safe as fresh** when the age is unknown so a broken
+ * or unusual token never hard-blocks admins from acting — the backend still
+ * enforces the real rule.
+ *
+ * @param {number} maxAgeMinutes reauth-after threshold
+ * @param {string} [token]
+ * @returns {boolean}
+ */
+export function isSessionFresh(maxAgeMinutes, token) {
+  const ageMs = getSessionAgeMs(token);
+  if (ageMs == null) return true; // unknown age → don't force re-auth
+  const maxMs = Math.max(0, Number(maxAgeMinutes) || 0) * 60_000;
+  return ageMs <= maxMs;
+}


### PR DESCRIPTION
Closes #337

## Summary
Stricter, admin-only session UX layered on top of the backend (which stays the source of truth for session validation): idle-timeout warning + auto-logout, a re-authentication prompt before sensitive actions on older sessions, clear "expired" vs "revoked" vs "idle" messaging, and admin-configurable timeout values.

## What's included
- **`lib/auth/session-status.js`** — reason constants, unverified JWT decode for UX-only session age, `isSessionFresh`, `reasonMessage`, `loginUrlWithReason`, re-auth freshness anchor. **Unknown age fails safe** (treated as fresh — never hard-blocks an admin on a guess).
- **`hooks/useIdleTimeout.js`** — throttled activity tracker with `onWarn`/`onTimeout`, full cleanup + SSR/unmount guards.
- **`components/auth/AdminIdleGuard.jsx`** — arms **only** for admins on `/admin` routes once config+auth are loaded (no forced logout while loading); countdown warning dialog + auto-logout to `/login?reason=idle`. Mounted once in `AppProviders`, self-noops elsewhere so blast radius is contained.
- **`hooks/useReauth.js` + `components/auth/ReauthPromptDialog.jsx`** — `ensureFreshSession()` step-up before sensitive actions when the session is older than the configured age; demoed on the flags kill-switch.
- **`components/auth/SessionEndedNotice.jsx`** — per-reason banner on the login page (reads `?reason=`; wrapped in `Suspense` for Next 15).
- **`lib/actions/admin-session-config.js`** (+ validation) and **`app/[locale]/dashboard/admin/settings/session-security/page.jsx`** — the configurable timeout values editor (`AdminTierGuard`).
- Stubbed `lib/actions/auth/reauth.js` (`TODO(backend): POST /api/auth/reauth`) and session-config API (`TODO(backend): GET/PUT /api/admin/session-security`).

## Acceptance criteria
Idle warning ✓ · auto-logout after configurable N min ✓ · timeout configurable via settings editor ✓ · re-auth before sensitive actions on old sessions ✓ · expired vs revoked messaging ✓ · stricter rules for /admin than learner areas ✓ · token semantics documented / backend remains source of truth ✓

## CI note
Rebased on current `dev`; **builds green** locally (`npm run build`), `npm run lint` clean for all added/edited files. The red **Run component tests** (vitest), **Lighthouse**, and **a11y** checks are **pre-existing on `dev` itself** (verified on a clean `dev` checkout: `useAdminTeam` vitest timeouts, a `next/font/google` mock gap, and 4 `label-has-associated-control` errors in the unrelated `app/[locale]/admin/audit-logs` + `reconciliation` pages) — this PR does not touch those files. Happy to help fix the shared harness separately.