### PR TITLE
feat(admin): emergency broadcast quick-action (#307)

### DIFF
--- a/app/[locale]/dashboard/admin/broadcast/emergency/page.jsx
+++ b/app/[locale]/dashboard/admin/broadcast/emergency/page.jsx
@@ -1,0 +1,471 @@
+"use client";
+/**
+ * Emergency broadcast quick-action (#307).
+ * ---------------------------------------------------------------------------
+ * Admin surface (wrapped in `AdminTierGuard`) to fire a one-click incident
+ * alert during an outage or security event. Optimized for SPEED — the whole
+ * flow is: tap a template → (optionally tweak title / ETA / affected areas) →
+ * type the confirmation phrase → Send. An IMMEDIATE send (no scheduling); the
+ * learner-side red `EmergencyBroadcastBanner` picks it up from the same session
+ * store.
+ *
+ * A typed confirmation phrase guards the destructive action, and the whole page
+ * carries a distinct red/destructive treatment so the admin always knows this
+ * is high-severity — visually distinct from the amber maintenance surface.
+ */
+import { useMemo, useState } from "react";
+import {
+  Siren,
+  AlertTriangle,
+  Clock,
+  Send,
+  ServerCrash,
+  ShieldAlert,
+  Check,
+} from "lucide-react";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import AdminTierGuard from "@/components/auth/AdminTierGuard";
+import useEmergencyBroadcast from "@/hooks/useEmergencyBroadcast";
+import {
+  INCIDENT_TEMPLATES,
+  AFFECTED_AREAS,
+  labelForAreas,
+} from "@/lib/actions/admin-emergency-broadcast";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+/** Phrase the admin must type verbatim to unlock the Send button. */
+const CONFIRM_PHRASE = "SEND EMERGENCY";
+
+/** Convert an ISO timestamp to a `datetime-local` input value (local tz). */
+function isoToLocalInput(iso) {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "";
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60000);
+  return local.toISOString().slice(0, 16);
+}
+
+/** Convert a `datetime-local` input value (local tz) back to an ISO string. */
+function localInputToIso(value) {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+const TEMPLATE_META = {
+  outage: { icon: ServerCrash },
+  security: { icon: ShieldAlert },
+};
+
+function EmergencyBroadcastContent() {
+  const { broadcast, isSending, send, clear } = useEmergencyBroadcast();
+
+  const [template, setTemplate] = useState(null);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [etaLocal, setEtaLocal] = useState("");
+  const [areas, setAreas] = useState([]);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+
+  /** Prefill the form from a fixed incident preset. */
+  const applyTemplate = (key) => {
+    const preset = INCIDENT_TEMPLATES[key];
+    if (!preset) return;
+    setTemplate(key);
+    setTitle(preset.title);
+    setBody(preset.body);
+    setAreas([...preset.defaultAffectedAreas]);
+  };
+
+  const toggleArea = (id) => {
+    setAreas((prev) =>
+      prev.includes(id) ? prev.filter((a) => a !== id) : [...prev, id]
+    );
+  };
+
+  const etaIso = localInputToIso(etaLocal);
+  const trimmedTitle = title.trim();
+  const canPrepare =
+    Boolean(template) && Boolean(trimmedTitle) && areas.length > 0;
+  const confirmMatches = confirmText.trim() === CONFIRM_PHRASE;
+
+  const previewAreas = useMemo(() => labelForAreas(areas), [areas]);
+
+  const handleSend = async () => {
+    if (!confirmMatches) return;
+    try {
+      await send({
+        template,
+        title: trimmedTitle,
+        body: body.trim(),
+        etaAt: etaIso,
+        affectedAreas: areas,
+      });
+      setConfirmOpen(false);
+      setConfirmText("");
+    } catch {
+      // Hook already surfaced a toast; keep the dialog open to retry.
+    }
+  };
+
+  const handleResolve = async () => {
+    try {
+      await clear();
+    } catch {
+      // Hook already surfaced a toast.
+    }
+  };
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={Siren}
+        title="Emergency broadcast"
+        subtitle="Fire a one-click incident alert to every learner. Immediate send — no scheduling."
+      />
+
+      {/* Active alert banner (admin view) */}
+      {broadcast ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-red-500/40 bg-red-500/10 p-4">
+          <div className="flex items-start gap-2">
+            <AlertTriangle
+              className="mt-0.5 h-5 w-5 shrink-0 text-red-600"
+              aria-hidden="true"
+            />
+            <div>
+              <p className={cn(poppins_600.className, "text-sm text-red-700")}>
+                Live emergency broadcast: {broadcast.title}
+              </p>
+              <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+                Learners are seeing the red banner now
+                {broadcast.affectedAreas?.length
+                  ? ` · ${labelForAreas(broadcast.affectedAreas).join(", ")}`
+                  : ""}
+                .
+              </p>
+            </div>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleResolve}
+            disabled={isSending}
+            className="rounded-full border-red-500/40 text-red-700 hover:bg-red-500/10"
+          >
+            <Check className="mr-1.5 h-4 w-4" aria-hidden="true" />
+            {isSending ? "Resolving…" : "Mark resolved"}
+          </Button>
+        </div>
+      ) : null}
+
+      {/* Step 1 — pick an incident template */}
+      <div className="space-y-3">
+        <p className={cn(poppins_600.className, "text-sm text-ink")}>
+          1. Choose an incident template
+        </p>
+        <div className="grid gap-3 sm:grid-cols-2">
+          {Object.values(INCIDENT_TEMPLATES).map((preset) => {
+            const Icon = TEMPLATE_META[preset.id]?.icon || AlertTriangle;
+            const selected = template === preset.id;
+            return (
+              <button
+                key={preset.id}
+                type="button"
+                onClick={() => applyTemplate(preset.id)}
+                aria-pressed={selected}
+                className={cn(
+                  "flex items-start gap-3 rounded-2xl border p-4 text-left transition",
+                  selected
+                    ? "border-red-500 bg-red-500/10 ring-2 ring-red-500/40"
+                    : "border-accent/10 bg-surface-raised hover:border-red-500/40 hover:bg-red-500/5"
+                )}
+              >
+                <span className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-red-500/15 text-red-600">
+                  <Icon className="h-5 w-5" aria-hidden="true" />
+                </span>
+                <span className="min-w-0">
+                  <span
+                    className={cn(
+                      poppins_600.className,
+                      "block text-sm text-ink"
+                    )}
+                  >
+                    {preset.label}
+                  </span>
+                  <span
+                    className={cn(
+                      poppins_400.className,
+                      "mt-0.5 block text-xs text-ink-muted line-clamp-2"
+                    )}
+                  >
+                    {preset.body}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Step 2 — edit + send */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="space-y-5 rounded-2xl border border-accent/10 bg-surface-raised p-5 shadow-sm">
+          <p className={cn(poppins_600.className, "text-sm text-ink")}>
+            2. Review and send
+          </p>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="emergency-title"
+              className={cn(poppins_500.className, "text-ink")}
+            >
+              Title
+            </Label>
+            <Input
+              id="emergency-title"
+              placeholder="Platform outage"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              maxLength={120}
+              disabled={!template}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="emergency-eta"
+              className={cn(
+                poppins_500.className,
+                "flex items-center gap-1.5 text-ink"
+              )}
+            >
+              <Clock className="h-4 w-4 text-red-600" aria-hidden="true" />
+              Estimated resolution ETA (optional)
+            </Label>
+            <div className="flex items-center gap-2">
+              <Input
+                id="emergency-eta"
+                type="datetime-local"
+                value={etaLocal}
+                onChange={(event) => setEtaLocal(event.target.value)}
+                className="max-w-xs"
+                disabled={!template}
+              />
+              {etaLocal ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="rounded-full text-xs"
+                  onClick={() => setEtaLocal("")}
+                >
+                  Clear
+                </Button>
+              ) : null}
+            </div>
+          </div>
+
+          <fieldset className="space-y-2" disabled={!template}>
+            <legend
+              className={cn(poppins_500.className, "mb-1 text-sm text-ink")}
+            >
+              Affected areas
+            </legend>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {AFFECTED_AREAS.map((area) => {
+                const checkboxId = `emergency-area-${area.id}`;
+                return (
+                  <div key={area.id} className="flex items-center gap-2">
+                    <Checkbox
+                      id={checkboxId}
+                      checked={areas.includes(area.id)}
+                      onCheckedChange={() => toggleArea(area.id)}
+                    />
+                    <Label
+                      htmlFor={checkboxId}
+                      className={cn(poppins_400.className, "text-sm text-ink")}
+                    >
+                      {area.label}
+                    </Label>
+                  </div>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={!canPrepare || isSending}
+              onClick={() => {
+                setConfirmText("");
+                setConfirmOpen(true);
+              }}
+              className="rounded-full"
+            >
+              <Send className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              Send emergency broadcast
+            </Button>
+          </div>
+          {!canPrepare ? (
+            <p className={cn(poppins_400.className, "text-right text-xs text-ink-muted")}>
+              Pick a template, keep a title, and select at least one area.
+            </p>
+          ) : null}
+        </div>
+
+        {/* Learner preview — mirrors the red banner */}
+        <div className="space-y-2">
+          <p
+            className={cn(
+              poppins_600.className,
+              "flex items-center gap-2 text-sm text-ink"
+            )}
+          >
+            Learner preview
+            <Badge
+              variant="outline"
+              className="rounded-full border-red-500/30 text-xs text-red-600"
+            >
+              Red alert
+            </Badge>
+          </p>
+          <div className="overflow-hidden rounded-2xl border border-red-800/40 bg-red-600 text-red-50 shadow-md">
+            <div className="flex items-start gap-3 px-4 py-3">
+              <AlertTriangle
+                className="mt-0.5 h-5 w-5 shrink-0 text-red-100"
+                aria-hidden="true"
+              />
+              <div className="min-w-0 flex-1 space-y-1">
+                <p className={cn(poppins_600.className, "text-sm leading-snug")}>
+                  {trimmedTitle || "Your alert title"}
+                </p>
+                {body.trim() ? (
+                  <p className="text-xs leading-snug text-red-100/90">
+                    {body.trim()}
+                  </p>
+                ) : null}
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-0.5">
+                  {etaLocal ? (
+                    <span
+                      className={cn(
+                        poppins_500.className,
+                        "inline-flex items-center gap-1 text-xs text-red-100"
+                      )}
+                    >
+                      <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+                      Est. resolved by{" "}
+                      {new Date(etaLocal).toLocaleString(undefined, {
+                        month: "short",
+                        day: "numeric",
+                        hour: "numeric",
+                        minute: "2-digit",
+                      })}
+                    </span>
+                  ) : null}
+                  {previewAreas.map((area) => (
+                    <span
+                      key={area}
+                      className={cn(
+                        poppins_500.className,
+                        "rounded-full border border-red-100/30 bg-red-700/40 px-2 py-0.5 text-[11px] leading-none"
+                      )}
+                    >
+                      {area}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+          <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+            This is exactly what learners see, app-wide, the moment you send.
+          </p>
+        </div>
+      </div>
+
+      {/* Typed-confirmation dialog */}
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="flex items-center gap-2 text-red-600">
+              <Siren className="h-5 w-5" aria-hidden="true" />
+              Send emergency broadcast now?
+            </DialogTitle>
+            <DialogDescription>
+              This sends <strong>immediately</strong> to every learner — there is
+              no scheduling and no draft. To confirm, type{" "}
+              <span className="font-semibold text-red-600">{CONFIRM_PHRASE}</span>{" "}
+              below.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-1.5">
+            <Label
+              htmlFor="emergency-confirm"
+              className={cn(poppins_500.className, "text-ink")}
+            >
+              Confirmation phrase
+            </Label>
+            <Input
+              id="emergency-confirm"
+              autoComplete="off"
+              placeholder={CONFIRM_PHRASE}
+              value={confirmText}
+              onChange={(event) => setConfirmText(event.target.value)}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={() => setConfirmOpen(false)}
+              disabled={isSending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              className="rounded-full"
+              disabled={!confirmMatches || isSending}
+              onClick={handleSend}
+            >
+              <Send className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              {isSending ? "Sending…" : "Send now"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PageShell>
+  );
+}
+
+export default function EmergencyBroadcastPage() {
+  return (
+    <AdminTierGuard>
+      <EmergencyBroadcastContent />
+    </AdminTierGuard>
+  );
+}

--- a/components/broadcast/EmergencyBroadcastBanner.jsx
+++ b/components/broadcast/EmergencyBroadcastBanner.jsx
@@ -1,0 +1,139 @@
+"use client";
+/**
+ * EmergencyBroadcastBanner — learner-facing red alert banner (#307).
+ * ---------------------------------------------------------------------------
+ * The learner-side surface of the emergency-broadcast quick-action. Mounted
+ * once in `AppProviders` so every visitor — logged-in learner, educator, or
+ * logged-out guest — sees an active incident alert app-wide, mirroring how
+ * `MaintenanceGate` is mounted.
+ *
+ * It reads the **public** active broadcast itself (like the maintenance gate
+ * reads its public flag) and polls lightly + refetches on window focus so a
+ * send propagates to already-open tabs without a manual reload. It renders
+ * NOTHING when there is no active broadcast or when the visitor has dismissed
+ * the current one, so it never crashes or intrudes for logged-out / non-admin
+ * users.
+ *
+ * Distinct RED (destructive) treatment marks this as high-severity, visually
+ * separating it from the amber maintenance bar.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { AlertTriangle, Clock, X } from "lucide-react";
+import {
+  getActiveEmergencyBroadcast,
+  labelForAreas,
+} from "@/lib/actions/admin-emergency-broadcast";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+/** Poll cadence for propagating a send to already-open tabs. */
+const POLL_INTERVAL_MS = 60_000;
+
+/** Format an ISO ETA into a short, human "resolved by" label. */
+function formatEta(iso) {
+  if (!iso) return null;
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export default function EmergencyBroadcastBanner() {
+  const [broadcast, setBroadcast] = useState(null);
+  const [dismissedId, setDismissedId] = useState(null);
+
+  const fetchActive = useCallback(async () => {
+    try {
+      const { broadcast: active } = await getActiveEmergencyBroadcast();
+      setBroadcast(active);
+    } catch {
+      // Fail silent: on a read error leave the last-known state so a transient
+      // hiccup never wrongly hides or shows the alert.
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchActive();
+    const id = setInterval(fetchActive, POLL_INTERVAL_MS);
+    const onFocus = () => fetchActive();
+    window.addEventListener("focus", onFocus);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener("focus", onFocus);
+    };
+  }, [fetchActive]);
+
+  // Nothing active, or the visitor already dismissed this exact alert.
+  if (!broadcast || broadcast.id === dismissedId) return null;
+
+  const etaLabel = formatEta(broadcast.etaAt);
+  const areas = labelForAreas(broadcast.affectedAreas);
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      className={cn(
+        poppins_400.className,
+        "relative z-[70] border-b border-red-800/40 bg-red-600 text-red-50 shadow-md"
+      )}
+    >
+      <div className="mx-auto flex max-w-6xl items-start gap-3 px-4 py-3">
+        <AlertTriangle
+          className="mt-0.5 h-5 w-5 shrink-0 text-red-100"
+          aria-hidden="true"
+        />
+        <div className="min-w-0 flex-1 space-y-1">
+          <p className={cn(poppins_600.className, "text-sm leading-snug")}>
+            {broadcast.title}
+          </p>
+          {broadcast.body ? (
+            <p className="text-xs leading-snug text-red-100/90">
+              {broadcast.body}
+            </p>
+          ) : null}
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 pt-0.5">
+            {etaLabel ? (
+              <span
+                className={cn(
+                  poppins_500.className,
+                  "inline-flex items-center gap-1 text-xs text-red-100"
+                )}
+              >
+                <Clock className="h-3.5 w-3.5" aria-hidden="true" />
+                Est. resolved by {etaLabel}
+              </span>
+            ) : null}
+            {areas.length > 0 ? (
+              <span className="flex flex-wrap items-center gap-1.5">
+                {areas.map((area) => (
+                  <span
+                    key={area}
+                    className={cn(
+                      poppins_500.className,
+                      "rounded-full border border-red-100/30 bg-red-700/40 px-2 py-0.5 text-[11px] leading-none"
+                    )}
+                  >
+                    {area}
+                  </span>
+                ))}
+              </span>
+            ) : null}
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDismissedId(broadcast.id)}
+          aria-label="Dismiss emergency alert"
+          className="shrink-0 rounded-full p-1 text-red-100 transition hover:bg-red-700/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-100"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/providers/AppProviders.jsx
+++ b/components/providers/AppProviders.jsx
@@ -7,6 +7,7 @@ import CacheProvider from "@/components/providers/CacheProvider";
 import FeatureFlagProvider from "@/components/providers/FeatureFlagProvider";
 import StellarProvider from "@/components/stellar/StellarProvider";
 import MaintenanceGate from "@/components/maintenance/MaintenanceGate";
+import EmergencyBroadcastBanner from "@/components/broadcast/EmergencyBroadcastBanner";
 import AdminIdleGuard from "@/components/auth/AdminIdleGuard";
 
 export default function AppProviders({ children }) {
@@ -22,6 +23,14 @@ export default function AppProviders({ children }) {
                  * client-side user; it wraps the whole app so maintenance mode
                  * applies platform-wide on every render/navigation (#303).
                  */}
+                {/*
+                 * Learner-side red alert banner for the emergency-broadcast
+                 * quick-action (#307). Renders nothing when no incident is
+                 * active; shown app-wide to every visitor when one is. Mounted
+                 * alongside the maintenance gate so both surfaces read their
+                 * public state and stay in sync within a session.
+                 */}
+                <EmergencyBroadcastBanner />
                 <MaintenanceGate>{children}</MaintenanceGate>
                 {/* Idle-timeout auto-logout for admin sessions (#337).
                     Self-noops for non-admins and non-admin routes. */}

--- a/hooks/useEmergencyBroadcast.js
+++ b/hooks/useEmergencyBroadcast.js
@@ -1,0 +1,111 @@
+"use client";
+/**
+ * useEmergencyBroadcast — data hook for the emergency-broadcast quick-action (#307).
+ * ---------------------------------------------------------------------------
+ * Loads the currently active emergency broadcast via the stubbed service in
+ * `lib/actions/admin-emergency-broadcast` and exposes the immediate `send` /
+ * `clear` mutations the admin quick-action page uses, so the page and the
+ * learner-side `EmergencyBroadcastBanner` drive one code path and stay
+ * consistent within a session.
+ *
+ * The active read is **public** (the banner reads it for any visitor), so this
+ * hook fetches it for everyone — unlike `useMaintenanceMode`, which only fetches
+ * for admins. Sending/clearing is still an admin-only surface (the page is
+ * wrapped in `AdminTierGuard`); this hook does not itself gate the mutations.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+  getActiveEmergencyBroadcast,
+  sendEmergencyBroadcast,
+  clearEmergencyBroadcast,
+} from "@/lib/actions/admin-emergency-broadcast";
+
+export default function useEmergencyBroadcast() {
+  const [broadcast, setBroadcast] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSending, setIsSending] = useState(false);
+  const [error, setError] = useState(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const { broadcast: active } = await getActiveEmergencyBroadcast();
+      setBroadcast(active);
+      return active;
+    } catch (err) {
+      setError(err?.message || "Failed to load emergency broadcast");
+      return null;
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const { broadcast: active } = await getActiveEmergencyBroadcast();
+        if (!cancelled) setBroadcast(active);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err?.message || "Failed to load emergency broadcast");
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /**
+   * Immediately send an emergency broadcast. Surfaces success/failure via toast
+   * and re-throws on failure so the caller can keep its confirm dialog open.
+   *
+   * @param {{template: string, title: string, body?: string, etaAt?: string|null, affectedAreas?: string[]}} payload
+   */
+  const send = useCallback(async (payload) => {
+    setIsSending(true);
+    try {
+      const { broadcast: next } = await sendEmergencyBroadcast(payload);
+      setBroadcast(next);
+      toast.success("Emergency broadcast sent — learners are seeing it now.");
+      return next;
+    } catch (err) {
+      toast.error(err?.message || "Couldn't send the emergency broadcast");
+      throw err;
+    } finally {
+      setIsSending(false);
+    }
+  }, []);
+
+  /** Resolve / dismiss the active emergency broadcast. */
+  const clear = useCallback(async () => {
+    setIsSending(true);
+    try {
+      await clearEmergencyBroadcast();
+      setBroadcast(null);
+      toast.success("Emergency broadcast resolved.");
+      return null;
+    } catch (err) {
+      toast.error(err?.message || "Couldn't resolve the emergency broadcast");
+      throw err;
+    } finally {
+      setIsSending(false);
+    }
+  }, []);
+
+  return {
+    broadcast,
+    isLoading,
+    isSending,
+    error,
+    send,
+    clear,
+    refresh,
+  };
+}

--- a/lib/actions/admin-emergency-broadcast.js
+++ b/lib/actions/admin-emergency-broadcast.js
@@ -1,0 +1,217 @@
+/**
+ * Emergency-broadcast service — one-click incident alerts (#307).
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Every function here resolves with mocked data backed by a
+ * module-level store so the admin quick-action page and the learner-side
+ * `EmergencyBroadcastBanner` can be built, wired together, and reviewed before
+ * the backend endpoints exist. Sending from the admin page mutates the same
+ * in-memory store the banner reads, so the two stay in sync within a browser
+ * session (until a full reload re-seeds the module).
+ *
+ * Unlike the ordinary broadcast (`admin-broadcast.js`), an emergency broadcast
+ * is an IMMEDIATE send — it bypasses any scheduling: `sendEmergencyBroadcast`
+ * stamps `sentAt = now`, becomes the single CURRENTLY ACTIVE emergency
+ * broadcast, and fires a non-blocking audit event (mirrors the fire-and-forget
+ * pattern in `admin-broadcast.js`).
+ *
+ * Active emergency-broadcast state shape owned by the backend:
+ *
+ *   {
+ *     id: string,                       // server-assigned id
+ *     template: "outage" | "security",  // which incident preset was used
+ *     title: string,                    // learner-facing headline
+ *     body: string,                     // learner-facing detail copy
+ *     etaAt: string | null,             // optional ISO 8601 "resolved by" target
+ *     affectedAreas: string[],          // which platform areas are impacted
+ *     sentAt: string,                   // ISO 8601 send timestamp (immediate)
+ *   }
+ *
+ * TODO(backend):
+ *   - POST /api/admin/broadcasts/emergency  (admin-only, server-side tier check)
+ *       IMMEDIATE send — no scheduling window is accepted or honoured.
+ *       Payload: { template, title, body?, etaAt?: string|null, affectedAreas: string[] }
+ *       201 → { broadcast: ActiveEmergencyBroadcast } with server-stamped id/sentAt.
+ *       403 for non-admins.
+ *   - GET /api/admin/broadcasts/emergency/active  is **public / unauthenticated**
+ *       so the learner banner can read the active alert for any visitor.
+ *       200 → { broadcast: ActiveEmergencyBroadcast | null }
+ *   - DELETE /api/admin/broadcasts/emergency/active  (admin-only) resolves/clears
+ *       the active alert.
+ *       200 → { broadcast: null }
+ */
+
+import { logAuditEvent, AUDIT_ACTIONS } from "@/lib/admin/audit";
+
+const MOCK_DELAY_MS = 300;
+
+/**
+ * Fixed incident templates. Frozen so a call site can't mutate the presets.
+ * Each preset seeds the quick-action form with sensible default copy and the
+ * areas most commonly affected by that class of incident — the admin can still
+ * edit the title, ETA, and toggle areas before sending.
+ *
+ * @readonly
+ */
+export const INCIDENT_TEMPLATES = Object.freeze({
+  outage: Object.freeze({
+    id: "outage",
+    label: "Platform outage",
+    title: "Platform outage",
+    body: "We're aware of a platform outage and our team is actively working to restore service. Thank you for your patience.",
+    defaultAffectedAreas: Object.freeze(["courses", "payments", "ai"]),
+  }),
+  security: Object.freeze({
+    id: "security",
+    label: "Security notice",
+    title: "Security notice",
+    body: "We're investigating a security event. As a precaution some features may be temporarily limited. Please do not share your password with anyone.",
+    defaultAffectedAreas: Object.freeze(["payments", "community"]),
+  }),
+});
+
+/**
+ * The fixed set of platform areas an emergency can be scoped to. Rendered as
+ * the "Affected areas" checkboxes on the admin page and as chips on the learner
+ * banner. Frozen to keep the vocabulary consistent across both surfaces.
+ *
+ * @readonly
+ */
+export const AFFECTED_AREAS = Object.freeze([
+  Object.freeze({ id: "courses", label: "Courses" }),
+  Object.freeze({ id: "payments", label: "Payments / Wallet" }),
+  Object.freeze({ id: "community", label: "Community" }),
+  Object.freeze({ id: "ai", label: "AI Assistant" }),
+  Object.freeze({ id: "library", label: "Library" }),
+]);
+
+/** O(1) lookup from area id → human label, for the banner. */
+const AREA_LABELS = Object.freeze(
+  AFFECTED_AREAS.reduce((acc, area) => {
+    acc[area.id] = area.label;
+    return acc;
+  }, {})
+);
+
+/**
+ * Resolve an array of area ids to their human labels, dropping unknown ids.
+ *
+ * @param {string[]} [ids]
+ * @returns {string[]}
+ */
+export function labelForAreas(ids = []) {
+  if (!Array.isArray(ids)) return [];
+  return ids.map((id) => AREA_LABELS[id] || id);
+}
+
+/**
+ * In-memory store holding the single CURRENTLY ACTIVE emergency broadcast, so
+ * the stubbed send/read round-trips within a session. Seeded to `null` (no
+ * active alert — the normal, fail-open state).
+ *
+ * @type {{id: string, template: string, title: string, body: string, etaAt: string|null, affectedAreas: string[], sentAt: string}|null}
+ */
+let activeBroadcast = null;
+
+function withMockDelay(value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_DELAY_MS));
+}
+
+/**
+ * Read the currently active emergency broadcast (or `null` when none).
+ *
+ * Mirrors the **public** GET contract: no auth required, so the banner can call
+ * it for any visitor. Returns a defensive copy so callers can't mutate the
+ * store directly.
+ *
+ * TODO(backend): return axiosInstance.get("/api/admin/broadcasts/emergency/active").then((res) => res.data);
+ *
+ * @returns {Promise<{broadcast: {id: string, template: string, title: string, body: string, etaAt: string|null, affectedAreas: string[], sentAt: string}|null}>}
+ */
+export async function getActiveEmergencyBroadcast() {
+  // TODO(backend): return axiosInstance.get("/api/admin/broadcasts/emergency/active").then((res) => res.data);
+  return withMockDelay({
+    broadcast: activeBroadcast ? { ...activeBroadcast } : null,
+  });
+}
+
+/**
+ * Immediately send an emergency broadcast. Validates the required fields,
+ * stamps `sentAt`, stores the result as the single active alert, and fires a
+ * non-blocking audit event. There is no scheduling — the alert is live the
+ * moment this resolves.
+ *
+ * TODO(backend):
+ *   const { data } = await axiosInstance.post(
+ *     "/api/admin/broadcasts/emergency",
+ *     { template, title, body, etaAt, affectedAreas },
+ *   );
+ *   return data;
+ *
+ * @param {{template: string, title: string, body?: string, etaAt?: string|null, affectedAreas?: string[]}} payload
+ * @returns {Promise<{broadcast: {id: string, template: string, title: string, body: string, etaAt: string|null, affectedAreas: string[], sentAt: string}}>}
+ */
+export async function sendEmergencyBroadcast(payload = {}) {
+  const template = payload.template;
+  const title = typeof payload.title === "string" ? payload.title.trim() : "";
+  const body = typeof payload.body === "string" ? payload.body.trim() : "";
+  const affectedAreas = Array.isArray(payload.affectedAreas)
+    ? payload.affectedAreas.filter((id) => typeof id === "string")
+    : [];
+
+  if (!template || !INCIDENT_TEMPLATES[template]) {
+    throw new Error("An incident template (outage or security) is required.");
+  }
+  if (!title) {
+    throw new Error("A title is required to send an emergency broadcast.");
+  }
+  if (affectedAreas.length === 0) {
+    throw new Error("Select at least one affected area.");
+  }
+
+  // TODO(backend):
+  //   const { data } = await axiosInstance.post(
+  //     "/api/admin/broadcasts/emergency",
+  //     { template, title, body, etaAt, affectedAreas },
+  //   );
+  const next = {
+    id: `eb_${Math.random().toString(36).slice(2, 10)}`,
+    template,
+    title,
+    body: body || INCIDENT_TEMPLATES[template].body,
+    etaAt: payload.etaAt || null,
+    affectedAreas,
+    sentAt: new Date().toISOString(),
+  };
+
+  const result = await withMockDelay({ broadcast: { ...next } });
+  activeBroadcast = next;
+
+  // Fire-and-forget audit trail — never awaited, never blocks the caller.
+  logAuditEvent({
+    action: AUDIT_ACTIONS.EMERGENCY_BROADCAST,
+    target: { label: title || "Emergency broadcast", href: null },
+    metadata: {
+      template,
+      affectedAreas,
+      hasEta: Boolean(next.etaAt),
+      immediate: true,
+    },
+  });
+
+  return result;
+}
+
+/**
+ * Resolve / dismiss the active emergency broadcast, clearing it for everyone.
+ * Mirrors the **admin-only** DELETE contract.
+ *
+ * TODO(backend): return axiosInstance.delete("/api/admin/broadcasts/emergency/active").then((res) => res.data);
+ *
+ * @returns {Promise<{broadcast: null}>}
+ */
+export async function clearEmergencyBroadcast() {
+  // TODO(backend): return axiosInstance.delete("/api/admin/broadcasts/emergency/active").then((res) => res.data);
+  const result = await withMockDelay({ broadcast: null });
+  activeBroadcast = null;
+  return result;
+}

--- a/lib/admin/audit.js
+++ b/lib/admin/audit.js
@@ -66,6 +66,7 @@ export const AUDIT_ACTIONS = Object.freeze({
 
   // Communications
   BROADCAST: "broadcast.send",
+  EMERGENCY_BROADCAST: "broadcast.emergency",
 
   // Platform / feature flags
   FLAG_TOGGLE: "flag.toggle",
@@ -106,6 +107,7 @@ const ACTION_CATEGORY = Object.freeze({
   [AUDIT_ACTIONS.RESTORE]: "moderation",
   [AUDIT_ACTIONS.REFUND]: "payment",
   [AUDIT_ACTIONS.BROADCAST]: "system",
+  [AUDIT_ACTIONS.EMERGENCY_BROADCAST]: "system",
   [AUDIT_ACTIONS.FLAG_TOGGLE]: "system",
   [AUDIT_ACTIONS.FLAG_CREATE]: "system",
 });


### PR DESCRIPTION
## Emergency broadcast quick-action (#307)

A one-click emergency broadcast system for rapid communication during outages and security events. Built by mirroring the maintenance feature's house pattern: **stubbed service → hook → `AdminTierGuard` page → learner-side surface mounted in `AppProviders`**.

### What was built
- **`lib/actions/admin-emergency-broadcast.js`** — stubbed service. Frozen `INCIDENT_TEMPLATES` (`outage` "Platform outage", `security` "Security notice") each with default title/body/affected-areas; frozen `AFFECTED_AREAS` vocabulary; module-level in-memory store holding the single active alert (seeded `null`). `sendEmergencyBroadcast()` validates required fields, stamps `sentAt`, stores active, and fires a **non-blocking** audit event (reuses the fire-and-forget pattern from `admin-broadcast.js`). `getActiveEmergencyBroadcast()` + `clearEmergencyBroadcast()`. Full `TODO(backend)` contract (immediate POST; public GET active; admin DELETE).
- **`hooks/useEmergencyBroadcast.js`** — exposes active `broadcast`, `isLoading`/`isSending`, `send(payload)`, `clear()`, with sonner toasts.
- **`app/[locale]/dashboard/admin/broadcast/emergency/page.jsx`** — speed-first quick-action wrapped in `AdminTierGuard`: two big template buttons that prefill, editable Title, ETA (`datetime-local`, iso↔local helpers reused from the maintenance page), functional Affected-areas checkboxes, typed-confirmation dialog, red/destructive styling, and a live learner preview.
- **`components/broadcast/EmergencyBroadcastBanner.jsx`** — dismissible learner-side **RED** banner mounted app-wide in `AppProviders`; reads the public active state, polls + refetches on focus, renders nothing when no incident is active (safe for logged-out/non-admin).
- **`lib/admin/audit.js`** — adds `EMERGENCY_BROADCAST` to the frozen `AUDIT_ACTIONS` map (category `system`).

### Acceptance criteria → where
- **Quick-action created** — `app/[locale]/dashboard/admin/broadcast/emergency/page.jsx`
- **Fixed outage + security templates** — `INCIDENT_TEMPLATES` in the action module; template buttons on the page
- **Editable Title** — Title `Input` on the page
- **Editable ETA** — `datetime-local` `Input` with iso↔local helpers
- **Affected areas checkboxes (functional)** — `AFFECTED_AREAS` rendered as `@/components/ui` `Checkbox`es wired to state
- **Immediate send (bypasses scheduling)** — `sendEmergencyBroadcast` stamps `sentAt = now`; no schedule field anywhere
- **Typed confirmation** — confirm dialog requires typing `SEND EMERGENCY`; Send stays disabled until it matches
- **Red variant learner-side** — `EmergencyBroadcastBanner` (destructive red) + red preview on the admin page
- **Complete flow under 30s** — tap template → (optional tweak) → type phrase → send; few interactions, immediate
- **Rehearsed in dev before merge** — see below

### Speed / safety / red-variant
The flow is: choose a template (prefills title, body, affected areas) → optionally edit Title/ETA/areas → click Send → type `SEND EMERGENCY` → Send now. The typed phrase is the only gate; the red/destructive treatment on both admin page and learner banner keeps the severity unmistakable and distinct from the amber maintenance surface.

### Session rehearsal (single in-memory store)
Admin page `send()` and the learner banner both go through `lib/actions/admin-emergency-broadcast.js`'s module store, so within a session: (1) open the quick-action, pick **Platform outage**, (2) confirm — the store's active alert is set, the admin page shows the "Live emergency broadcast" row, (3) the `EmergencyBroadcastBanner` (mounted in `AppProviders`) picks it up on its next poll/focus and shows the red banner to learners, (4) "Mark resolved" clears the store and the banner disappears.

### Backend
Left as `TODO(backend)` JSDoc contract in the action module: immediate `POST /api/admin/broadcasts/emergency`, public `GET .../emergency/active` for the banner, admin `DELETE .../emergency/active`.

### Build / lint / a11y
- `npm run build` — compiles green; both `/[locale]/dashboard/admin/broadcast/emergency` locales emitted. (The build logs a pre-existing `getaddrinfo ENOTFOUND api.example.com` course-fetch warning from the placeholder API host — unrelated, build still succeeds.)
- `npm run a11y` — zero errors on the added files (every control has an associated label; checkboxes and the confirmation input are labelled).
- `npm run lint` — no new errors from these files; only pre-existing `import/no-anonymous-default-export` warnings remain in unrelated files.

Repo CI is Lint-and-Build only.

Closes #307


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an admin emergency broadcast dashboard with outage and security templates, editable incident details, preview, confirmation safeguards, and immediate sending.
  - Added app-wide emergency alerts displaying the incident title, message, estimated resolution time, and affected areas.
  - Alerts refresh automatically, support dismissal, and remain visible using the last known information if updates temporarily fail.
  - Added the ability for administrators to resolve active emergency broadcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->