### PR TITLE
test(e2e): admin smoke flow — login through moderation action (#341)

### DIFF
--- a/e2e/README-admin-smoke.md
+++ b/e2e/README-admin-smoke.md
@@ -1,0 +1,102 @@
+# Admin smoke E2E (#341)
+
+A single, comprehensive **happy-path** Playwright test that proves the admin
+spine works end-to-end: **login → guarded admin surface → moderation action →
+audit trail**.
+
+- Spec: [`e2e/admin-smoke.spec.js`](./admin-smoke.spec.js)
+- Deterministic fixtures/seed: [`e2e/fixtures/admin-seed.js`](./fixtures/admin-seed.js)
+
+## The happy path covered
+
+1. **Login** — drives the real `/login` form. `POST /api/auth/login` is
+   intercepted to return the seeded super-admin `{ token, user }`; the app's own
+   `login()` → `persistSession()` then writes the `authToken` + `userInfo`
+   cookies. The test asserts those cookies were persisted (the real
+   `AuthProvider` session flow).
+2. **Admin surface (overview)** — navigates to `/dashboard/admin/team`, the
+   admin landing surface, and asserts the real super-admin guard
+   (`AdminTierGuard` / `canManageTeam`) lets the seeded super-admin through and
+   the real roster renders (not the "insufficient permissions" fallback).
+3. **Moderation action (ban-equivalent)** — opens the row actions dropdown for a
+   seeded member, chooses **Revoke access**, satisfies the real type-to-confirm
+   **step-up dialog** (typing the member's email), and confirms. The member's
+   row disappears — the mutation that fires the fire-and-forget audit event.
+4. **Audit trail** — navigates to `/dashboard/admin/audit-logs`, filters by the
+   **moderation** category using the real filter control, and asserts the trail
+   surfaces both a **ban** entry (`moderation.user_banned`) and a
+   **report-resolution** entry (`moderation.report_dismissed`).
+
+## What is REAL vs MOCKED
+
+**REAL (exercised for real):**
+
+- The Next.js pages: `/login`, `/dashboard/admin/team`,
+  `/dashboard/admin/audit-logs` (served by `next start`, a production build).
+- The auth session flow: `persistSession()` + `AuthProvider` reading the
+  `authToken` / `userInfo` cookies and deriving `user`.
+- The authorization guard: `AdminTierGuard` → `canManageTeam` (super-admin
+  tiering in `lib/auth/admin-tiers.js`).
+- The rendered UI controls: login form, actions dropdown, the step-up
+  confirmation dialog, the audit category filter, and the tables.
+
+**MOCKED / SEEDED:**
+
+- `POST /api/auth/login` is intercepted (Playwright `page.route`) and returns
+  the seeded super-admin token+user. There is **no real auth server** — the
+  token is a fixed seed string.
+- Every other `**/api/**` call is stubbed out (aborted).
+- The seeded session user lives in `e2e/fixtures/admin-seed.js`
+  (`SEED_SUPER_ADMIN`, `SEED_AUTH_TOKEN`), deterministic (fixed ids, no
+  randomness).
+
+**Important reality — no `/api/admin/*` to mock.** The admin backend is not
+built yet, so the admin **team roster** (`lib/actions/admin-team.js`
+`listAdmins()`) and the **audit log** (`lib/actions/admin-audit.js`) are served
+by the app's **own client-side stub services**, not the network. The fixtures
+file mirrors the relevant values from those stubs so the spec asserts against
+named fixtures. When the backend lands and those services switch to
+`axiosInstance` calls, the same flow can be re-pointed at `page.route`-mocked
+`/api/admin/*` responses.
+
+## Deviations from the issue's literal step list
+
+- **"users list" / "ban/unban":** there is no standalone users page, no
+  moderation/reports page, and no ban UI wired to any route (`banUser` in
+  `lib/actions/admin-users.js` is unused by any page). The real, guarded
+  user-management surface is the **admin-team** page, whose **Revoke access**
+  action is the ban-equivalent (removes a member's admin access behind a
+  step-up confirmation). **Unban** has no real UI surface, so it is not driven.
+- **Fresh audit entry after the action:** `next start` serves a production
+  build, so moving from the team page to the audit-logs page is a hard document
+  load that resets the client-side stub module — a just-created entry cannot
+  survive that cross-page hard navigation. The test therefore asserts the
+  deterministic audit trail already surfaces the **ban** and **report-resolution**
+  moderation entries, which proves the audit viewer spine.
+
+## Failure artifacts
+
+`playwright.config.js` sets `trace: "retain-on-failure"` and
+`screenshot: "only-on-failure"` (global; harmless to the other specs). On a
+failing run, the trace + screenshot are written under `test-results/`.
+
+## How to run
+
+Local (Playwright's `webServer` starts `next start -p 3123` automatically):
+
+```bash
+# build once (production build is what the webServer serves)
+NEXT_PUBLIC_API_URL=https://api.example.com \
+NEXT_PUBLIC_STELLAR_NETWORK=testnet \
+npm run build
+
+# run the admin smoke spec headless
+npm run test:e2e:admin
+# or: npx playwright test e2e/admin-smoke.spec.js --reporter=list
+```
+
+If Chromium is missing: `npx playwright install chromium`.
+
+**CI note:** this repo's CI is **Lint-and-Build only** — Playwright is not run
+in CI. This spec is the local "working demo (test output)" proof and is run via
+`npm run test:e2e:admin` after `npm run build`.

--- a/e2e/admin-smoke.spec.js
+++ b/e2e/admin-smoke.spec.js
@@ -1,0 +1,183 @@
+import { test, expect } from "@playwright/test";
+import {
+  SEED_SUPER_ADMIN,
+  SEED_ADMIN_ROSTER,
+  SEED_REVOKE_TARGET,
+  EXPECTED_AUDIT,
+  loginResponseBody,
+} from "./fixtures/admin-seed.js";
+
+/**
+ * Admin smoke flow — login → admin surface → moderation action → audit trail (#341).
+ * ===========================================================================
+ * ONE comprehensive happy-path test that proves the admin spine works
+ * end-to-end against the REAL Next.js pages, the REAL `AuthProvider` cookie
+ * session flow, and the REAL super-admin guard.
+ *
+ * REAL vs MOCKED (full write-up in e2e/README-admin-smoke.md):
+ *   REAL   — the `/login` form, `persistSession()` → `AuthProvider` cookie
+ *            reading, `AdminTierGuard` / `canManageTeam`, and the rendered
+ *            `/dashboard/admin/team` + `/dashboard/admin/audit-logs` pages
+ *            with their real UI controls (dropdown, step-up confirm dialog,
+ *            category filter, table).
+ *   MOCKED — the backend. `POST /api/auth/login` is intercepted to return the
+ *            seeded super-admin token+user; every other backend API call is
+ *            stubbed out. NOTE: the admin team roster and audit log are served
+ *            by the app's OWN client-side stub services (the admin backend is
+ *            not built yet), so there are no admin API responses to mock —
+ *            those data sets are deterministic in-app fixtures we mirror in
+ *            e2e/fixtures/admin-seed.js.
+ *
+ * DEVIATIONS from the issue's literal step list (documented honestly):
+ *   - "users list" / "ban/unban": there is no standalone users or moderation
+ *     page and no ban UI wired to any route. The real, guarded user-management
+ *     surface is the admin-team page, whose "Revoke access" action is the
+ *     ban-equivalent (removes a member's admin access behind a type-to-confirm
+ *     step-up). "Unban" has no real UI surface. We drive Revoke.
+ *   - "resolve report" + "audit entry": the audit viewer is a separate page
+ *     and `next start` serves a production build, so navigating to it is a hard
+ *     document load that resets the client-side stub module — a freshly-created
+ *     entry cannot survive the cross-page hard navigation. We instead assert
+ *     the deterministic audit trail surfaces both the ban and the
+ *     report-resolution moderation entries, proving the audit spine.
+ */
+
+const ADMIN_TEAM_URL = "/dashboard/admin/team";
+const AUDIT_LOGS_URL = "/dashboard/admin/audit-logs";
+
+/**
+ * Stub the backend for the whole flow. Registration order matters: Playwright
+ * runs the most-recently-registered matching handler first, so the catch-all
+ * is registered before the login-specific handler.
+ */
+async function stubBackend(page) {
+  // Catch-all: no real backend exists in E2E — fail these fast. The admin
+  // pages use client-side stubs and don't need any of these; peripheral
+  // dashboard calls handle rejection gracefully.
+  await page.route("**/api/**", (route) => route.abort());
+
+  // The one real request in the flow: authenticate the seeded super-admin.
+  await page.route("**/api/auth/login", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(loginResponseBody()),
+    })
+  );
+}
+
+test("admin smoke: login → team → revoke (ban) → audit trail", async ({
+  page,
+  context,
+}) => {
+  await stubBackend(page);
+
+  await test.step("login through the real form persists a super-admin session", async () => {
+    await page.goto("/login");
+
+    // The login page can render more than one copy of the form (responsive
+    // layouts) — scope to the first one to stay unambiguous.
+    const form = page.locator("form").first();
+    await form.getByRole("heading", { name: /welcome back/i }).waitFor();
+    await form.getByLabel("Email").fill(SEED_SUPER_ADMIN.email);
+    await form.getByLabel("Password", { exact: true }).fill("e2e-super-admin-pass");
+    await form.getByRole("button", { name: "Login", exact: true }).click();
+
+    // The real `login()` → `persistSession()` flow writes the session cookies
+    // that `AuthProvider` reads on every protected route.
+    await expect
+      .poll(async () => {
+        const cookies = await context.cookies();
+        return cookies.some((c) => c.name === "authToken");
+      }, { timeout: 15_000 })
+      .toBe(true);
+
+    const cookies = await context.cookies();
+    expect(cookies.some((c) => c.name === "userInfo")).toBe(true);
+
+    // The login form self-navigates to /dashboard on success — let that settle
+    // so it can't abort our later navigation to the admin surface.
+    await page.waitForURL(/\/dashboard(\/|$)/, { timeout: 15_000 });
+  });
+
+  // This app renders two identical <main> content subtrees in this
+  // environment; scope stateful assertions/interactions to the first one so
+  // the revoke mutation and its resulting list update are read consistently.
+  // (Radix dropdown/dialog/select content portals to <body>, and only one is
+  // ever open at a time, so those stay page-level.)
+  let surface;
+
+  await test.step("super-admin reaches the guarded admin-team surface (overview)", async () => {
+    // Navigate straight to the admin surface (there is no admin overview page;
+    // the team page is the admin landing). Cookies from the login step carry
+    // the session; the real AdminTierGuard must let a super-admin through.
+    await page.goto(ADMIN_TEAM_URL);
+    surface = page.locator("main").first();
+
+    await expect(
+      surface.getByRole("heading", { name: "Admin team" })
+    ).toBeVisible();
+
+    // Real roster rendered — not an "insufficient permissions" fallback.
+    // Assert on emails: names repeat in the "Added by" column, emails are
+    // unique per row.
+    for (const member of SEED_ADMIN_ROSTER) {
+      await expect(
+        surface.getByText(member.email, { exact: true })
+      ).toBeVisible();
+    }
+    await expect(surface.getByText(/only super admins/i)).toHaveCount(0);
+  });
+
+  await test.step("perform the moderation action: revoke a member's admin access", async () => {
+    // Open the row actions for the target member (real Radix dropdown).
+    await surface
+      .getByRole("button", { name: `Actions for ${SEED_REVOKE_TARGET.name}` })
+      .click();
+    await page.getByRole("menuitem", { name: /revoke access/i }).click();
+
+    // Real step-up confirmation: type the member's email to unlock, confirm.
+    const confirmInput = page.getByRole("textbox", {
+      name: `Type ${SEED_REVOKE_TARGET.email} to confirm`,
+    });
+    await expect(confirmInput).toBeVisible();
+    await confirmInput.fill(SEED_REVOKE_TARGET.email);
+    await page.getByRole("button", { name: "Revoke", exact: true }).click();
+
+    // Member removed from the list — the ban-equivalent mutation succeeded
+    // (this is the flow that fires the fire-and-forget audit event).
+    await expect(
+      surface.getByText(SEED_REVOKE_TARGET.email, { exact: true })
+    ).toHaveCount(0);
+    // Other members remain.
+    await expect(
+      surface.getByText(SEED_ADMIN_ROSTER[0].email, { exact: true })
+    ).toBeVisible();
+  });
+
+  await test.step("audit trail surfaces the ban + resolve-report moderation entries", async () => {
+    await page.goto(AUDIT_LOGS_URL);
+    const auditSurface = page.locator("main").first();
+
+    await expect(
+      auditSurface.getByRole("heading", { name: "Audit logs" })
+    ).toBeVisible();
+
+    // Narrow to moderation actions via the real category filter so both the
+    // ban and the report-resolution entries land on the first page.
+    await auditSurface
+      .getByRole("combobox", { name: "Filter by action category" })
+      .click();
+    await page.getByRole("option", { name: EXPECTED_AUDIT.category }).click();
+
+    // The moderation spine: a ban entry and a report-resolution entry.
+    await expect(
+      auditSurface.getByText(EXPECTED_AUDIT.banAction, { exact: true }).first()
+    ).toBeVisible();
+    await expect(
+      auditSurface
+        .getByText(EXPECTED_AUDIT.resolveReportAction, { exact: true })
+        .first()
+    ).toBeVisible();
+  });
+});

--- a/e2e/fixtures/admin-seed.js
+++ b/e2e/fixtures/admin-seed.js
@@ -1,0 +1,106 @@
+/**
+ * Deterministic seed / fixtures for the admin smoke E2E (#341).
+ * ===========================================================================
+ * Everything here is fixed — no randomness, no `Date.now()` — so the smoke
+ * flow is reproducible run to run and in CI.
+ *
+ * WHAT IS SEEDED HERE vs WHAT THE APP PROVIDES
+ * --------------------------------------------
+ *   - `SEED_SUPER_ADMIN` + `SEED_AUTH_TOKEN`: the logged-in session. This is
+ *     the only piece we truly inject — it is returned from the intercepted
+ *     `POST /api/auth/login` so the real `persistSession()` / `AuthProvider`
+ *     cookie flow treats us as a signed-in super-admin.
+ *   - `SEED_ADMIN_ROSTER` / `EXPECTED_AUDIT`: these MIRROR the values the app's
+ *     own client-side stub services already return
+ *     (`lib/actions/admin-team.js` `listAdmins()` and
+ *     `lib/actions/admin-audit.js`). The admin backend is not built yet, so the
+ *     team roster and audit trail are deterministic in-app fixtures rather than
+ *     network responses. We copy the relevant values here so the spec asserts
+ *     against named fixtures instead of magic strings. See
+ *     `e2e/README-admin-smoke.md` for the full mocked-vs-real breakdown.
+ */
+
+/** Fixed bearer token returned by the mocked login endpoint. */
+export const SEED_AUTH_TOKEN = "seed-e2e-super-admin-token-341";
+
+/**
+ * The seeded super-admin session user. Shape must satisfy the admin guard:
+ * `canManageTeam(user)` requires `role` → "admin" AND `tier` → "super_admin"
+ * (see `lib/auth/admin-tiers.js` / `lib/auth/roles.js`). The whole object is
+ * JSON-stringified into the `userInfo` cookie by `persistSession()`.
+ */
+export const SEED_SUPER_ADMIN = Object.freeze({
+  id: "e2e-super-admin-001",
+  _id: "e2e-super-admin-001",
+  name: "Test SuperAdmin",
+  email: "superadmin@e2e.deenbridge.test",
+  role: "admin",
+  tier: "super_admin",
+});
+
+/**
+ * A non-super-admin seed user, kept for documentation/negative reasoning — the
+ * guard must reject this shape. Not currently driven by the happy path.
+ */
+export const SEED_STAFF_ADMIN = Object.freeze({
+  id: "e2e-staff-admin-001",
+  _id: "e2e-staff-admin-001",
+  name: "Test StaffAdmin",
+  email: "staff@e2e.deenbridge.test",
+  role: "admin",
+  tier: "staff",
+});
+
+/**
+ * The admin-team roster the app renders. Mirrors `listAdmins()` in
+ * `lib/actions/admin-team.js`. Ids/tiers are stable in that stub.
+ */
+export const SEED_ADMIN_ROSTER = Object.freeze([
+  Object.freeze({ id: "admin-001", name: "Amina Yusuf", email: "amina@deenbridge.org", tier: "super_admin" }),
+  Object.freeze({ id: "admin-002", name: "Bilal Karim", email: "bilal@deenbridge.org", tier: "staff" }),
+  Object.freeze({ id: "admin-003", name: "Zaynab Idris", email: "zaynab@deenbridge.org", tier: "staff" }),
+]);
+
+/**
+ * The roster member we revoke ("ban" equivalent — remove admin access). A
+ * staff member so only the "Revoke access" action is offered. Revoking a
+ * member removes their row and fires the fire-and-forget audit event.
+ */
+export const SEED_REVOKE_TARGET = SEED_ADMIN_ROSTER[1]; // Bilal Karim
+
+/**
+ * Deterministic audit-trail action keys the viewer is expected to surface.
+ * These correspond to entries in the `AUDIT_LOGS` dataset in
+ * `lib/actions/admin-audit.js` (all `category: "moderation"`). They cover the
+ * issue's "ban" and "resolve report" moderation-spine steps.
+ */
+export const EXPECTED_AUDIT = Object.freeze({
+  category: "moderation",
+  banAction: "moderation.user_banned",
+  resolveReportAction: "moderation.report_dismissed",
+});
+
+/** Body returned by the mocked `POST /api/auth/login`. */
+export function loginResponseBody() {
+  return { token: SEED_AUTH_TOKEN, user: SEED_SUPER_ADMIN };
+}
+
+/**
+ * Cookie descriptors for seeding a super-admin session directly onto a browser
+ * context (alternative to driving the login form). Exported for reuse/docs;
+ * the happy path exercises the real login form instead, per the issue.
+ *
+ * @param {string} baseURL e.g. "http://localhost:3123"
+ */
+export function seedAuthCookies(baseURL) {
+  const { hostname } = new URL(baseURL);
+  return [
+    { name: "authToken", value: SEED_AUTH_TOKEN, domain: hostname, path: "/" },
+    {
+      name: "userInfo",
+      value: encodeURIComponent(JSON.stringify(SEED_SUPER_ADMIN)),
+      domain: hostname,
+      path: "/",
+    },
+  ];
+}

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "a11y": "eslint --config eslint.config.a11y.mjs components app",
     "test": "vitest --run",
     "test:watch": "vitest",
-    "test:e2e": "playwright test e2e/i18n.spec.js"
+    "test:e2e": "playwright test e2e/i18n.spec.js",
+    "test:e2e:admin": "playwright test e2e/admin-smoke.spec.js"
   },
   "dependencies": {
     "@creit.tech/stellar-wallets-kit": "^2.4.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -14,7 +14,10 @@ export default defineConfig({
   reporter: [["list"]],
   use: {
     baseURL: `http://localhost:${PORT}`,
-    trace: "off",
+    // Failure artifacts (#341): keep a trace + screenshot only when a test
+    // fails. Global and harmless to the passing i18n/documents specs.
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
   },
   webServer: {
     command: `npx next start -p ${PORT}`,


### PR DESCRIPTION
## E2E smoke flow: admin login → moderation action → audit trail (#341)

Adds one comprehensive happy-path Playwright E2E test that proves the admin spine works end-to-end against the **real** Next.js pages, the **real** `AuthProvider` cookie session, and the **real** super-admin guard.

### Flow covered
1. **Login** — drives the real `/login` form; `POST /api/auth/login` is intercepted to return the seeded super-admin `{ token, user }`; asserts the app persisted the `authToken` + `userInfo` cookies (the real `persistSession()` → `AuthProvider` flow).
2. **Guarded admin surface (overview)** — `/dashboard/admin/team` (the admin landing); asserts `AdminTierGuard` / `canManageTeam` lets the super-admin through and the roster renders (not the "insufficient permissions" fallback).
3. **Moderation action (ban-equivalent)** — opens the row actions dropdown, chooses **Revoke access**, satisfies the real type-to-confirm step-up dialog, confirms; the member's row is removed.
4. **Audit trail** — `/dashboard/admin/audit-logs`; filters by the **moderation** category and asserts the trail surfaces a **ban** (`moderation.user_banned`) and a **report-resolution** (`moderation.report_dismissed`) entry.

### Real vs mocked
- **Real:** the `/login`, team, and audit-log pages (production `next start` build); the cookie session flow; the `AdminTierGuard` super-admin guard; all rendered UI controls (dropdown, step-up dialog, category filter, tables).
- **Mocked / seeded:** `POST /api/auth/login` returns a seeded super-admin token+user (no real auth server); every other API call is stubbed. The admin backend is not built yet, so the **team roster** and **audit log** are served by the app's own client-side stub services (`lib/actions/admin-team.js`, `lib/actions/admin-audit.js`) — there are no `/api/admin/*` responses to mock; the deterministic fixtures in `e2e/fixtures/admin-seed.js` mirror those stub values.

Full write-up: `e2e/README-admin-smoke.md`.

### Deviations from the issue's literal step list (documented honestly)
- **No standalone users / reports / moderation page and no ban UI is wired to any route** (`banUser` in `lib/actions/admin-users.js` is unused). The real, guarded user-management surface is the admin-team page, whose **Revoke access** action is the ban-equivalent (removes admin access behind a step-up confirm). **Unban** has no real UI surface.
- `next start` serves a production build, so the team → audit hard navigation resets the client-side stub module and a freshly-created entry can't survive it. The test asserts the deterministic audit trail already surfaces the ban + report-resolution entries, proving the audit-viewer spine.

### Failure artifacts
`playwright.config.js` sets `trace: retain-on-failure` and `screenshot: only-on-failure` (global; harmless to the existing specs).

### Passing test output
```
Running 1 test using 1 worker

  ✓  1 [chromium] › e2e/admin-smoke.spec.js:69:5 › admin smoke: login → team → revoke (ban) → audit trail (7.0s)

  1 passed (12.6s)
```

### How to run
```bash
NEXT_PUBLIC_API_URL=https://api.example.com NEXT_PUBLIC_STELLAR_NETWORK=testnet npm run build
npm run test:e2e:admin
```

This repo's CI is **Lint-and-Build only** — Playwright is not run in CI — so this E2E is run locally via `npm run test:e2e:admin` after `npm run build`.

Closes #341


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an end-to-end smoke test covering admin login, access controls, moderation actions, and audit-log filtering.
  - Added deterministic test data for admin sessions, rosters, moderation targets, and audit entries.
  - Added a dedicated command for running the admin smoke test.

- **Documentation**
  - Added local and CI guidance for the admin smoke test, including covered workflows and limitations.

- **Tests**
  - Failed tests now retain Playwright traces and screenshots to simplify troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->