### PR TITLE
feat(admin): keyboard shortcut layer for power admins (#336)

### DIFF
--- a/components/admin/AdminShortcutsProvider.jsx
+++ b/components/admin/AdminShortcutsProvider.jsx
@@ -1,0 +1,49 @@
+"use client";
+/**
+ * AdminShortcutsProvider — arms the power-admin keyboard layer (#336).
+ * ---------------------------------------------------------------------------
+ * Mirrors `AdminIdleGuard`: mounted **once** in `AppProviders`, it is a
+ * deliberate no-op except when BOTH conditions hold —
+ *   1. the signed-in user is an admin (`normalizeRole(user.role) === ADMIN`), and
+ *   2. the user is currently on an admin surface (an `/admin` or
+ *      `/dashboard/admin` route).
+ *
+ * When armed it activates {@link useAdminShortcuts} (the chord state machine)
+ * and renders the `?` cheatsheet overlay. For non-admins, learners, or any
+ * non-admin route it arms nothing and renders nothing, so the blast radius is
+ * contained and there is zero chance of intercepting a normal user's typing.
+ */
+import { useMemo } from "react";
+import { usePathname } from "next/navigation";
+import useAuth from "@/hooks/useAuth";
+import useAdminShortcuts from "@/hooks/useAdminShortcuts";
+import ShortcutCheatsheet from "@/components/admin/ShortcutCheatsheet";
+import { ROLES, normalizeRole } from "@/lib/auth/roles";
+
+/** Matches an admin surface: ".../admin" or ".../admin/..." (any locale prefix). */
+const ADMIN_ROUTE = /\/admin(\/|$)/;
+
+export default function AdminShortcutsProvider() {
+  const { user, loading } = useAuth();
+  const pathname = usePathname();
+
+  const isAdmin = useMemo(
+    () => Boolean(user) && normalizeRole(user.role) === ROLES.ADMIN,
+    [user]
+  );
+  const onAdminRoute = Boolean(pathname && ADMIN_ROUTE.test(pathname));
+
+  // Only arm once auth is resolved — never mid-load.
+  const armed = !loading && isAdmin && onAdminRoute;
+
+  const { isCheatsheetOpen, setCheatsheetOpen } = useAdminShortcuts({
+    enabled: armed,
+  });
+
+  // Nothing to render unless armed; the cheatsheet is only reachable then.
+  if (!armed) return null;
+
+  return (
+    <ShortcutCheatsheet open={isCheatsheetOpen} onOpenChange={setCheatsheetOpen} />
+  );
+}

--- a/components/admin/ShortcutCheatsheet.jsx
+++ b/components/admin/ShortcutCheatsheet.jsx
@@ -1,0 +1,158 @@
+"use client";
+/**
+ * ShortcutCheatsheet — the discoverable `?` overlay for the admin keyboard
+ * layer (#336).
+ * ---------------------------------------------------------------------------
+ * Renders every binding from the shared {@link SHORTCUTS} registry (the same
+ * source of truth the hook uses), grouped, with proper `<kbd>` styling. Built
+ * on the ui-kit `Dialog` so it inherits focus trapping, an accessible
+ * title/description, Escape-to-close and overlay dismissal for free.
+ *
+ * It is a pure presentational component: open state is owned by
+ * `useAdminShortcuts` and passed down, so the `?` key and the overlay stay in
+ * sync.
+ */
+import { useMemo } from "react";
+import { Keyboard } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { SHORTCUTS, SEQUENCE_PREFIX } from "@/hooks/useAdminShortcuts";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+/** Best-effort platform detection so we show ⌘ on macOS and Ctrl elsewhere. */
+function isMacPlatform() {
+  if (typeof navigator === "undefined") return false;
+  const uaPlatform = navigator.userAgentData?.platform || navigator.platform || "";
+  return /mac|iphone|ipad|ipod/i.test(uaPlatform);
+}
+
+/** A single styled key cap. */
+function Kbd({ children }) {
+  return (
+    <kbd
+      className={cn(
+        poppins_500.className,
+        "inline-flex min-w-[1.75rem] items-center justify-center rounded-md border border-border bg-surface-raised px-2 py-0.5 text-xs text-ink shadow-sm"
+      )}
+    >
+      {children}
+    </kbd>
+  );
+}
+
+/** Render the key(s) for a shortcut as one or more <kbd> caps. */
+function ShortcutKeys({ shortcut }) {
+  if (shortcut.type === "sequence") {
+    return (
+      <span className="flex items-center gap-1" aria-hidden="true">
+        <Kbd>{shortcut.keys[0]}</Kbd>
+        <span className="text-xs text-ink-muted">then</span>
+        <Kbd>{shortcut.keys[1]}</Kbd>
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-1" aria-hidden="true">
+      <Kbd>{shortcut.key}</Kbd>
+    </span>
+  );
+}
+
+/** Screen-reader text describing how to trigger a shortcut. */
+function keysLabel(shortcut) {
+  if (shortcut.type === "sequence") {
+    return `Press ${shortcut.keys[0]} then ${shortcut.keys[1]}`;
+  }
+  return `Press ${shortcut.key}`;
+}
+
+/**
+ * @param {Object} props
+ * @param {boolean} props.open
+ * @param {(open: boolean) => void} props.onOpenChange
+ */
+export default function ShortcutCheatsheet({ open, onOpenChange }) {
+  const isMac = useMemo(() => isMacPlatform(), []);
+
+  // Group shortcuts in registry order, preserving first-seen group order.
+  const groups = useMemo(() => {
+    const order = [];
+    const byGroup = new Map();
+    for (const s of SHORTCUTS) {
+      if (!byGroup.has(s.group)) {
+        byGroup.set(s.group, []);
+        order.push(s.group);
+      }
+      byGroup.get(s.group).push(s);
+    }
+    return order.map((name) => ({ name, items: byGroup.get(name) }));
+  }, []);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg bg-surface-raised">
+        <DialogHeader>
+          <DialogTitle
+            className={cn(poppins_600.className, "flex items-center gap-2 text-ink")}
+          >
+            <Keyboard className="h-5 w-5 text-accent" aria-hidden="true" />
+            Keyboard shortcuts
+          </DialogTitle>
+          <DialogDescription className={cn(poppins_400.className, "text-ink-muted")}>
+            Chord shortcuts for admin surfaces. Press{" "}
+            <kbd className="rounded border border-border px-1 text-[0.7rem]">
+              {SEQUENCE_PREFIX}
+            </kbd>{" "}
+            then a key to jump to a page. These are plain-key chords (no{" "}
+            {isMac ? "⌘" : "Ctrl"}), so they never clash with browser or OS
+            shortcuts. The command palette also opens with{" "}
+            <kbd className="rounded border border-border px-1 text-[0.7rem]">
+              {isMac ? "⌘" : "Ctrl"}
+            </kbd>
+            <kbd className="rounded border border-border px-1 text-[0.7rem]">K</kbd>.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="mt-2 flex flex-col gap-5">
+          {groups.map((group) => (
+            <section key={group.name} aria-label={group.name}>
+              <h3
+                className={cn(
+                  poppins_600.className,
+                  "mb-2 text-xs uppercase tracking-wide text-ink-muted"
+                )}
+              >
+                {group.name}
+              </h3>
+              <ul className="flex flex-col gap-1.5">
+                {group.items.map((shortcut) => (
+                  <li
+                    key={shortcut.label}
+                    className="flex items-center justify-between gap-4"
+                  >
+                    <span className={cn(poppins_400.className, "text-sm text-ink")}>
+                      {shortcut.label}
+                      {shortcut.description ? (
+                        <span className="ml-2 text-xs text-ink-muted">
+                          {shortcut.description}
+                        </span>
+                      ) : null}
+                    </span>
+                    <span className="sr-only">{keysLabel(shortcut)}</span>
+                    <ShortcutKeys shortcut={shortcut} />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/providers/AppProviders.jsx
+++ b/components/providers/AppProviders.jsx
@@ -9,6 +9,7 @@ import StellarProvider from "@/components/stellar/StellarProvider";
 import MaintenanceGate from "@/components/maintenance/MaintenanceGate";
 import EmergencyBroadcastBanner from "@/components/broadcast/EmergencyBroadcastBanner";
 import AdminIdleGuard from "@/components/auth/AdminIdleGuard";
+import AdminShortcutsProvider from "@/components/admin/AdminShortcutsProvider";
 
 export default function AppProviders({ children }) {
   return (
@@ -35,6 +36,10 @@ export default function AppProviders({ children }) {
                 {/* Idle-timeout auto-logout for admin sessions (#337).
                     Self-noops for non-admins and non-admin routes. */}
                 <AdminIdleGuard />
+                {/* Power-admin keyboard shortcut layer (#336). Chord shortcuts
+                    (g→key) + `?` cheatsheet; self-noops off admin routes and
+                    for non-admins, and defers ⌘K to the CommandPalette. */}
+                <AdminShortcutsProvider />
                 {children}
               </StellarProvider>
             </FeatureFlagProvider>

--- a/hooks/useAdminShortcuts.js
+++ b/hooks/useAdminShortcuts.js
@@ -1,0 +1,255 @@
+"use client";
+/**
+ * useAdminShortcuts — a two-key-sequence ("chord") keyboard layer for power
+ * admins (#336).
+ * ---------------------------------------------------------------------------
+ * Power admins asked for Gmail/GitHub-style keyboard navigation: press a
+ * prefix key (`g`, for "go to") and then a second key to jump straight to an
+ * admin surface, plus a discoverable `?` cheatsheet. This hook implements the
+ * state machine; the guard (`AdminShortcutsProvider`) decides *when* it is
+ * armed and renders the overlay.
+ *
+ * Design constraints (why it is built this way):
+ *   - **No conflict with the CommandPalette (⌘K / Ctrl+K).** The palette owns
+ *     modifier combos. We therefore IGNORE any event where
+ *     `metaKey || ctrlKey || altKey` is held, so ⌘K/Ctrl+K/⌥… never reach us
+ *     and stay with the OS/browser/palette. Our bindings are plain, unmodified
+ *     keys — true "chords", which also means they never collide with macOS or
+ *     Windows modifier conventions.
+ *   - **Never hijack typing.** If the event originates from a text field
+ *     (INPUT/TEXTAREA/SELECT, `contenteditable`, or a `role="textbox"`), we
+ *     bail — an admin filling a form can still type `g`, `?`, etc.
+ *   - **Discoverable & single-source-of-truth.** Every binding lives in
+ *     {@link SHORTCUTS}; the cheatsheet renders from the same list so docs can
+ *     never drift from behaviour.
+ *   - **Integration, not duplication.** The palette binding dispatches the
+ *     existing `open-command-palette` window event rather than re-implementing
+ *     search.
+ *
+ * The hook is a no-op whenever `enabled` is false, so mounting it app-wide is
+ * safe: it only listens while an admin is on an `/admin` surface.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+
+/** The prefix key that opens the "go to" sequence window. */
+export const SEQUENCE_PREFIX = "g";
+
+/** How long (ms) after the prefix we wait for the second key before cancelling. */
+export const SEQUENCE_TIMEOUT_MS = 1000;
+
+/**
+ * The canonical shortcut registry — the single source of truth shared by the
+ * hook (behaviour) and the cheatsheet (documentation).
+ *
+ * Each entry is one of:
+ *   - a "sequence" binding: `{ type, keys: [prefix, second], href|event, ... }`
+ *   - a "single" binding:   `{ type, key, event|action, ... }`
+ *
+ * Hrefs map to admin routes that actually exist in the app router. They are
+ * locale-agnostic (next-intl middleware prepends the active locale).
+ *
+ * @typedef {Object} Shortcut
+ * @property {"sequence"|"single"} type
+ * @property {string[]} [keys]   two keys for a sequence binding
+ * @property {string}   [key]    single key for a single binding
+ * @property {string}   [href]   navigation target for "go to" bindings
+ * @property {string}   [event]  window CustomEvent to dispatch (integration)
+ * @property {string}   label    short human label for the cheatsheet
+ * @property {string}   [description] longer description for the cheatsheet
+ * @property {string}   group    cheatsheet grouping
+ */
+
+/** @type {ReadonlyArray<Shortcut>} */
+export const SHORTCUTS = Object.freeze([
+  {
+    type: "sequence",
+    keys: [SEQUENCE_PREFIX, "d"],
+    href: "/dashboard/admin",
+    label: "Go to Admin dashboard",
+    group: "Navigate",
+  },
+  {
+    type: "sequence",
+    keys: [SEQUENCE_PREFIX, "t"],
+    href: "/dashboard/admin/team",
+    label: "Go to Team",
+    group: "Navigate",
+  },
+  {
+    type: "sequence",
+    keys: [SEQUENCE_PREFIX, "a"],
+    href: "/dashboard/admin/audit-logs",
+    label: "Go to Audit logs",
+    group: "Navigate",
+  },
+  {
+    type: "sequence",
+    keys: [SEQUENCE_PREFIX, "r"],
+    href: "/dashboard/admin/reconciliation",
+    label: "Go to Reconciliation",
+    group: "Navigate",
+  },
+  {
+    type: "sequence",
+    keys: [SEQUENCE_PREFIX, "s"],
+    href: "/dashboard/admin/settings/flags",
+    label: "Go to Feature flags",
+    group: "Navigate",
+  },
+  {
+    type: "sequence",
+    keys: [SEQUENCE_PREFIX, "m"],
+    href: "/dashboard/admin/settings/maintenance",
+    label: "Go to Maintenance",
+    group: "Navigate",
+  },
+  {
+    type: "single",
+    key: "/",
+    event: "open-command-palette",
+    label: "Open command palette",
+    description: "Also available with ⌘K / Ctrl+K.",
+    group: "Tools",
+  },
+  {
+    type: "single",
+    key: "?",
+    action: "toggle-cheatsheet",
+    label: "Show this cheatsheet",
+    group: "Help",
+  },
+]);
+
+/** Sequence bindings keyed by their second key, for O(1) lookup. */
+const SEQUENCE_BY_SECOND_KEY = SHORTCUTS.reduce((acc, s) => {
+  if (s.type === "sequence" && s.keys?.[0] === SEQUENCE_PREFIX) {
+    acc[s.keys[1]] = s;
+  }
+  return acc;
+}, /** @type {Record<string, Shortcut>} */ ({}));
+
+/**
+ * Whether the keydown originated from an editable surface where the user is
+ * (or may be) typing — in which case shortcuts must not fire.
+ *
+ * @param {EventTarget|null} target
+ * @returns {boolean}
+ */
+function isTypingTarget(target) {
+  if (!target || typeof target !== "object" || !("tagName" in target)) {
+    return false;
+  }
+  const el = /** @type {HTMLElement} */ (target);
+  const tag = el.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (el.isContentEditable) return true;
+  // Composite widgets that accept text (e.g. cmdk input, rich editors).
+  if (typeof el.closest === "function") {
+    if (el.closest('[contenteditable="true"],[contenteditable=""]')) return true;
+    if (el.closest('[role="textbox"]')) return true;
+  }
+  return false;
+}
+
+/**
+ * The admin keyboard-shortcut state machine.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.enabled] arm the listener (admin + on /admin route)
+ * @returns {{
+ *   isCheatsheetOpen: boolean,
+ *   setCheatsheetOpen: (open: boolean) => void,
+ *   shortcuts: ReadonlyArray<Shortcut>,
+ * }}
+ */
+export default function useAdminShortcuts({ enabled = false } = {}) {
+  const router = useRouter();
+  const [isCheatsheetOpen, setCheatsheetOpen] = useState(false);
+
+  // `g` was pressed and we're within the window awaiting a second key.
+  const awaitingSecondKeyRef = useRef(false);
+  const timerRef = useRef(null);
+
+  const clearSequence = useCallback(() => {
+    awaitingSecondKeyRef.current = false;
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  // When disarmed, forget any half-typed sequence and close the overlay so we
+  // never leave stale state behind after leaving an admin route / signing out.
+  useEffect(() => {
+    if (!enabled) {
+      clearSequence();
+      setCheatsheetOpen(false);
+    }
+  }, [enabled, clearSequence]);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    const handleKeyDown = (e) => {
+      // Leave modifier combos (⌘K, Ctrl+K, ⌥…) to the OS / CommandPalette.
+      if (e.metaKey || e.ctrlKey || e.altKey) {
+        clearSequence();
+        return;
+      }
+      // Never intercept while the user is typing.
+      if (isTypingTarget(e.target)) return;
+
+      const key = e.key;
+
+      // Escape always closes the cheatsheet (and cancels any sequence).
+      if (key === "Escape") {
+        clearSequence();
+        setCheatsheetOpen((open) => (open ? false : open));
+        return;
+      }
+
+      // Second key of a `g <key>` sequence.
+      if (awaitingSecondKeyRef.current) {
+        clearSequence();
+        const match = SEQUENCE_BY_SECOND_KEY[key?.toLowerCase?.()];
+        if (match) {
+          e.preventDefault();
+          if (match.href) router.push(match.href);
+          else if (match.event) window.dispatchEvent(new CustomEvent(match.event));
+        }
+        // A non-matching second key simply cancels — no action.
+        return;
+      }
+
+      // `?` (Shift+/) toggles the cheatsheet.
+      if (key === "?") {
+        e.preventDefault();
+        setCheatsheetOpen((open) => !open);
+        return;
+      }
+
+      // `/` opens the command palette (integration with the existing widget).
+      if (key === "/") {
+        e.preventDefault();
+        window.dispatchEvent(new CustomEvent("open-command-palette"));
+        return;
+      }
+
+      // Prefix key: start the sequence window.
+      if (key?.toLowerCase?.() === SEQUENCE_PREFIX) {
+        e.preventDefault();
+        awaitingSecondKeyRef.current = true;
+        timerRef.current = setTimeout(clearSequence, SEQUENCE_TIMEOUT_MS);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      clearSequence();
+    };
+  }, [enabled, router, clearSequence]);
+
+  return { isCheatsheetOpen, setCheatsheetOpen, shortcuts: SHORTCUTS };
+}


### PR DESCRIPTION
## Summary
Closes #336. Adds a Gmail/GitHub-style **two-key chord** keyboard layer for power admins, scoped to `/admin`, with a discoverable `?` cheatsheet.

## Bindings (all map to existing admin routes)
| Keys | Action |
|------|--------|
| `g` then `d` | Admin dashboard |
| `g` then `t` | Team |
| `g` then `a` | Audit logs |
| `g` then `r` | Reconciliation |
| `g` then `s` | Feature flags |
| `g` then `m` | Maintenance |
| `/` | Open command palette (dispatches the existing `open-command-palette` event) |
| `?` | Toggle the shortcuts cheatsheet |

## How it meets the acceptance criteria
- **Two-key sequences** — a `g`-prefixed state machine with a 1s window; a non-matching or timed-out second key cancels cleanly.
- **`?` cheatsheet overlay** — a ui-kit `Dialog` (focus-trapped, accessible title) rendering every binding from the shared `SHORTCUTS` registry — single source of truth, so docs can't drift from behaviour.
- **No CommandPalette conflict** — the handler ignores any event with `meta/ctrl/alt` held, so `⌘K`/`Ctrl+K` stay with the palette; `/` *integrates* by dispatching the palette's own event.
- **Disabled while typing** — events from `INPUT`/`TEXTAREA`/`SELECT`/`contenteditable`/`role=textbox` are skipped.
- **macOS/Windows conventions** — these are unmodified chords (not Ctrl/Cmd combos), so they never collide with OS modifiers; the cheatsheet shows ⌘ vs Ctrl for the palette hint via platform detection.
- **Scoped to /admin, minimal deps** — mounted once in `AppProviders`, armed only for an admin on an `/admin` route (mirrors `AdminIdleGuard`); a no-op otherwise. No new dependencies.

## Files
- `hooks/useAdminShortcuts.js` — the chord state machine + `SHORTCUTS` registry.
- `components/admin/ShortcutCheatsheet.jsx` — the `?` overlay.
- `components/admin/AdminShortcutsProvider.jsx` — the /admin-scoped arming guard.
- `components/providers/AppProviders.jsx` — mounts the provider once.

## Verification
- `npm run build` — green (exit 0). `npm run a11y` — clean on the added files. No new lint errors (only pre-existing `cached-api.js`/`cloudinaryUpload.js` warnings on `dev`).
- Repo CI is Lint-and-Build only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin emergency broadcasts with templates, previews, affected-area targeting, confirmation-protected sending, and resolution controls.
  * Added platform maintenance mode with custom messaging, ETA countdowns, admin controls, and live previews.
  * Added refunds management with filtering, summaries, audit trails, transaction links, and retry actions.
  * Added scheduled report digest configuration, including delivery schedules and recipient management.
  * Added admin keyboard shortcuts, shortcut guidance, reel hide/unhide controls, and public emergency alerts.

* **Improvements**
  * Standardized the offline experience with a shared lock-screen layout.
  * Added optimistic updates with rollback and clearer error feedback across moderation actions.

* **Documentation & Tests**
  * Added admin smoke-test documentation and end-to-end coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->