### PR TITLE
feat(admin): report detail view with full moderation context (#289)

### DIFF
--- a/app/[locale]/dashboard/admin/reports/page.jsx
+++ b/app/[locale]/dashboard/admin/reports/page.jsx
@@ -1,0 +1,164 @@
+"use client";
+/**
+ * Admin moderation-reports page (#289).
+ * ---------------------------------------------------------------------------
+ * The moderation queue: a dense list of open/escalated reports, each row a
+ * one-line summary (reason, target, reporter, serial-reporter flag, age).
+ * Selecting a row opens the full-context `ReportDetailDrawer` — inline content
+ * preview, reporter trust signals, target history, and an action rail — so a
+ * moderator can act without leaving the page.
+ *
+ * Super-admin only (wrapped in `AdminTierGuard`). All data/actions flow through
+ * the `useReports` hook over the stubbed `lib/actions/admin-reports` service.
+ */
+import { useMemo, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { Flag, AlertTriangle, ShieldCheck } from "lucide-react";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import AdminTierGuard from "@/components/auth/AdminTierGuard";
+import ReportDetailDrawer from "@/components/admin/reports/ReportDetailDrawer";
+import useReports from "@/hooks/useReports";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500 } from "@/lib/config/font.config";
+
+const SERIAL_REPORTER_THRESHOLD = 5;
+
+const TARGET_TYPE_LABEL = { reel: "Reel", book: "Book", course: "Course" };
+
+function StatusBadge({ status }) {
+  const variant =
+    status === "escalated" ? "destructive" : status === "open" ? "default" : "secondary";
+  const label = status ? status.charAt(0).toUpperCase() + status.slice(1) : "Unknown";
+  return <Badge variant={variant}>{label}</Badge>;
+}
+
+function ReportsContent() {
+  const reports = useReports();
+  const [selectedId, setSelectedId] = useState(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  const selected = useMemo(
+    () => reports.reports.find((r) => r.id === selectedId) || null,
+    [reports.reports, selectedId]
+  );
+
+  const openReport = (id) => {
+    setSelectedId(id);
+    setDrawerOpen(true);
+  };
+
+  return (
+    <PageShell>
+      <PageHeader
+        title="Moderation reports"
+        subtitle="Review flagged content with full context, then escalate, dismiss, or act on the target."
+      />
+
+      {reports.isLoading ? (
+        <div className="space-y-2">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} className="h-14 w-full" />
+          ))}
+        </div>
+      ) : reports.reports.length === 0 ? (
+        <EmptyState
+          icon={ShieldCheck}
+          title="Queue is clear"
+          description="There are no open reports to review right now."
+        />
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-border">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Reason</TableHead>
+                <TableHead>Target</TableHead>
+                <TableHead>Reporter</TableHead>
+                <TableHead>Filed</TableHead>
+                <TableHead>Status</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {reports.reports.map((r) => {
+                const serial = (r.reporter?.priorReportCount || 0) >= SERIAL_REPORTER_THRESHOLD;
+                return (
+                  <TableRow
+                    key={r.id}
+                    role="button"
+                    tabIndex={0}
+                    aria-label={`Open report ${r.id}: ${r.reason}`}
+                    className="cursor-pointer"
+                    onClick={() => openReport(r.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        openReport(r.id);
+                      }
+                    }}
+                  >
+                    <TableCell>
+                      <span className={cn(poppins_500.className, "flex items-center gap-2 text-ink")}>
+                        <Flag className="h-3.5 w-3.5 text-ink-muted" aria-hidden="true" />
+                        {r.reason}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <span className={cn(poppins_400.className, "flex items-center gap-2")}>
+                        <Badge variant="secondary">{TARGET_TYPE_LABEL[r.target?.type] || "Content"}</Badge>
+                        <span className="max-w-[16rem] truncate text-ink-muted">{r.target?.title}</span>
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      <span className={cn(poppins_400.className, "flex items-center gap-2 text-ink-muted")}>
+                        {r.reporter?.name}
+                        {serial ? (
+                          <Badge variant="destructive" className="gap-1">
+                            <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                            {r.reporter.priorReportCount}
+                          </Badge>
+                        ) : null}
+                      </span>
+                    </TableCell>
+                    <TableCell className={cn(poppins_400.className, "text-ink-muted")}>
+                      {formatDistanceToNow(new Date(r.createdAt), { addSuffix: true })}
+                    </TableCell>
+                    <TableCell>
+                      <StatusBadge status={r.status} />
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+
+      <ReportDetailDrawer
+        report={selected}
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+        reports={reports}
+      />
+    </PageShell>
+  );
+}
+
+export default function ReportsPage() {
+  return (
+    <AdminTierGuard>
+      <ReportsContent />
+    </AdminTierGuard>
+  );
+}

--- a/components/admin/reports/ReportDetailDrawer.jsx
+++ b/components/admin/reports/ReportDetailDrawer.jsx
@@ -1,0 +1,282 @@
+"use client";
+/**
+ * ReportDetailDrawer — the full-context moderation view for one report (#289).
+ * ---------------------------------------------------------------------------
+ * A right-side drawer (Sheet) that gathers everything a moderator needs to
+ * decide, in one place and at high density:
+ *   - the reported content, previewed inline and matched to its type
+ *     (`ReportedContentPreview`),
+ *   - the reporter's statement plus trust signals (account age, prior report
+ *     count — a serial-reporter flag),
+ *   - the target's history (prior reports against it, prior admin actions),
+ *   - an action rail: Escalate, Dismiss, or Apply action (takedown) to target,
+ *     the last behind a confirm step because it is destructive.
+ *
+ * All mutations are delegated to the `useReports` hook passed down from the
+ * page, so the drawer, the list, and the audit trail stay consistent.
+ */
+import { useState } from "react";
+import { formatDistanceToNow, format } from "date-fns";
+import {
+  ShieldAlert,
+  Flag,
+  Clock,
+  History,
+  Gavel,
+  ArrowUpCircle,
+  XCircle,
+  AlertTriangle,
+} from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import ReportedContentPreview from "@/components/admin/reports/ReportedContentPreview";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+/** Serial-reporter threshold above which the prior-report count is flagged. */
+const SERIAL_REPORTER_THRESHOLD = 5;
+
+/** Humanize an audit-style action code like "content.takedown". */
+function humanizeAction(code) {
+  if (!code) return "Action";
+  return code
+    .split(/[._]/)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function StatusBadge({ status }) {
+  const variant =
+    status === "escalated" ? "destructive" : status === "open" ? "default" : "secondary";
+  const label = status ? status.charAt(0).toUpperCase() + status.slice(1) : "Unknown";
+  return <Badge variant={variant}>{label}</Badge>;
+}
+
+function SectionTitle({ icon: Icon, children }) {
+  return (
+    <h3 className={cn(poppins_600.className, "flex items-center gap-2 text-sm text-ink")}>
+      <Icon className="h-4 w-4 text-ink-muted" aria-hidden="true" />
+      {children}
+    </h3>
+  );
+}
+
+export default function ReportDetailDrawer({ report, open, onOpenChange, reports }) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  if (!report) return null;
+
+  const { reporter, target } = report;
+  const busy = reports.pendingId === report.id;
+  const resolved = report.status === "dismissed" || report.status === "actioned";
+
+  const accountAge = reporter?.accountCreatedAt
+    ? formatDistanceToNow(new Date(reporter.accountCreatedAt), { addSuffix: false })
+    : "unknown";
+  const isSerialReporter = (reporter?.priorReportCount || 0) >= SERIAL_REPORTER_THRESHOLD;
+
+  const runAndMaybeClose = async (fn) => {
+    try {
+      await fn();
+      onOpenChange(false);
+    } catch {
+      // Toast already surfaced by the hook; keep the drawer open to retry.
+    }
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-full gap-0 overflow-y-auto p-0 sm:max-w-xl"
+      >
+        <SheetHeader className="space-y-1 border-b border-border p-4">
+          <div className="flex items-center gap-2">
+            <SheetTitle className={cn(poppins_600.className, "text-base text-ink")}>
+              Report {report.id}
+            </SheetTitle>
+            <StatusBadge status={report.status} />
+          </div>
+          <SheetDescription className={cn(poppins_400.className, "flex flex-wrap items-center gap-2 text-ink-muted")}>
+            <Flag className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>{report.reason}</span>
+            <span aria-hidden="true">·</span>
+            <span>filed {formatDistanceToNow(new Date(report.createdAt), { addSuffix: true })}</span>
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="space-y-5 p-4">
+          {/* Reported content — inline, type-matched preview */}
+          <section className="space-y-2">
+            <SectionTitle icon={Gavel}>Reported content</SectionTitle>
+            <ReportedContentPreview target={target} />
+            <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>
+              Owner: <span className="text-ink">{target?.ownerName}</span>
+            </p>
+          </section>
+
+          <Separator />
+
+          {/* Reporter — statement + trust signals */}
+          <section className="space-y-2">
+            <SectionTitle icon={ShieldAlert}>Reporter</SectionTitle>
+            <div className="flex items-start gap-3">
+              <Avatar className="h-9 w-9">
+                <AvatarImage src={reporter?.avatar} alt="" />
+                <AvatarFallback>{(reporter?.name || "?").charAt(0)}</AvatarFallback>
+              </Avatar>
+              <div className="min-w-0 flex-1 space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className={cn(poppins_500.className, "text-sm text-ink")}>{reporter?.name}</span>
+                  <span className={cn(poppins_400.className, "inline-flex items-center gap-1 text-xs text-ink-muted")}>
+                    <Clock className="h-3 w-3" aria-hidden="true" /> account {accountAge} old
+                  </span>
+                  <Badge variant={isSerialReporter ? "destructive" : "secondary"} className="gap-1">
+                    {isSerialReporter ? <AlertTriangle className="h-3 w-3" aria-hidden="true" /> : null}
+                    {reporter?.priorReportCount || 0} prior reports
+                  </Badge>
+                </div>
+                <blockquote className={cn(poppins_400.className, "rounded-md border-l-2 border-border bg-muted/40 px-3 py-2 text-sm text-ink")}>
+                  {reporter?.statement}
+                </blockquote>
+              </div>
+            </div>
+          </section>
+
+          <Separator />
+
+          {/* Target history — prior reports + prior admin actions */}
+          <section className="space-y-2">
+            <SectionTitle icon={History}>Target history</SectionTitle>
+
+            <div className="space-y-1">
+              <p className={cn(poppins_500.className, "text-xs uppercase tracking-wide text-ink-muted")}>
+                Prior reports ({target?.priorReports?.length || 0})
+              </p>
+              {target?.priorReports?.length ? (
+                <ul className="space-y-1">
+                  {target.priorReports.map((pr) => (
+                    <li
+                      key={pr.id}
+                      className={cn(poppins_400.className, "flex items-center justify-between gap-2 rounded-md border border-border px-2.5 py-1.5 text-xs")}
+                    >
+                      <span className="truncate text-ink">{pr.reason}</span>
+                      <span className="flex shrink-0 items-center gap-2 text-ink-muted">
+                        <span>{format(new Date(pr.createdAt), "d MMM yyyy")}</span>
+                        <StatusBadge status={pr.status} />
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>No prior reports on this target.</p>
+              )}
+            </div>
+
+            <div className="space-y-1 pt-1">
+              <p className={cn(poppins_500.className, "text-xs uppercase tracking-wide text-ink-muted")}>
+                Prior admin actions ({target?.priorActions?.length || 0})
+              </p>
+              {target?.priorActions?.length ? (
+                <ul className="space-y-1">
+                  {target.priorActions.map((pa) => (
+                    <li
+                      key={pa.id}
+                      className={cn(poppins_400.className, "flex items-center justify-between gap-2 rounded-md border border-border px-2.5 py-1.5 text-xs")}
+                    >
+                      <span className="truncate text-ink">{humanizeAction(pa.action)}</span>
+                      <span className="flex shrink-0 items-center gap-2 text-ink-muted">
+                        <span>{format(new Date(pa.at), "d MMM yyyy")}</span>
+                        <span>{pa.by}</span>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p className={cn(poppins_400.className, "text-xs text-ink-muted")}>No prior admin actions on this target.</p>
+              )}
+            </div>
+          </section>
+        </div>
+
+        {/* Action rail — pinned at the bottom of the drawer */}
+        <div className="sticky bottom-0 flex flex-wrap items-center gap-2 border-t border-border bg-background/95 p-4 backdrop-blur">
+          {resolved ? (
+            <p className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+              This report has been {report.status}. No further action needed.
+            </p>
+          ) : (
+            <>
+              <Button
+                variant="outline"
+                className="gap-1"
+                disabled={busy}
+                onClick={() => runAndMaybeClose(() => reports.escalate(report.id))}
+              >
+                <ArrowUpCircle className="h-4 w-4" aria-hidden="true" /> Escalate
+              </Button>
+              <Button
+                variant="secondary"
+                className="gap-1"
+                disabled={busy}
+                onClick={() => runAndMaybeClose(() => reports.dismiss(report.id))}
+              >
+                <XCircle className="h-4 w-4" aria-hidden="true" /> Dismiss
+              </Button>
+
+              <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+                <AlertDialogTrigger asChild>
+                  <Button variant="destructive" className="ml-auto gap-1" disabled={busy}>
+                    <Gavel className="h-4 w-4" aria-hidden="true" /> Apply action to target
+                  </Button>
+                </AlertDialogTrigger>
+                <AlertDialogContent>
+                  <AlertDialogHeader>
+                    <AlertDialogTitle className="flex items-center gap-2">
+                      <AlertTriangle className="h-5 w-5 text-destructive" aria-hidden="true" />
+                      Take down reported content?
+                    </AlertDialogTitle>
+                    <AlertDialogDescription>
+                      This removes &ldquo;{target?.title}&rdquo; ({target?.type}) and marks the
+                      report as actioned. The action is recorded in the audit log. You can
+                      restore the content later from moderation.
+                    </AlertDialogDescription>
+                  </AlertDialogHeader>
+                  <AlertDialogFooter>
+                    <AlertDialogCancel>Cancel</AlertDialogCancel>
+                    <AlertDialogAction
+                      className="bg-destructive text-white hover:bg-destructive/90"
+                      onClick={() => runAndMaybeClose(() => reports.applyAction(report.id, "takedown"))}
+                    >
+                      Take down
+                    </AlertDialogAction>
+                  </AlertDialogFooter>
+                </AlertDialogContent>
+              </AlertDialog>
+            </>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/admin/reports/ReportedContentPreview.jsx
+++ b/components/admin/reports/ReportedContentPreview.jsx
@@ -1,0 +1,137 @@
+"use client";
+/**
+ * ReportedContentPreview — inline preview of a reported item (#289).
+ * ---------------------------------------------------------------------------
+ * Moderators should never have to leave the report to see what was flagged.
+ * This component renders a preview matched to the target's content type so the
+ * decision can be made in-context:
+ *   - reel   → thumbnail with a play affordance (poster image + play button;
+ *              no heavy video-player dependency)
+ *   - book   → cover image
+ *   - course → compact course card (thumbnail + lesson/enrolment stats)
+ *
+ * It is presentational and defensive: an unknown type or a missing image falls
+ * back to a labelled placeholder rather than breaking the drawer.
+ */
+import { useState } from "react";
+import Image from "next/image";
+import { BookOpen, GraduationCap, Play, ImageOff } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+/** Small image with a graceful fallback when the source fails to load. */
+function SafeImage({ src, alt, fill, width, height, className }) {
+  const [failed, setFailed] = useState(false);
+  if (!src || failed) {
+    return (
+      <div
+        className="flex h-full w-full items-center justify-center bg-muted text-ink-muted"
+        role="img"
+        aria-label={alt}
+      >
+        <ImageOff className="h-6 w-6" aria-hidden="true" />
+      </div>
+    );
+  }
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      fill={fill}
+      width={fill ? undefined : width}
+      height={fill ? undefined : height}
+      className={className}
+      onError={() => setFailed(true)}
+      unoptimized
+    />
+  );
+}
+
+function ReelPreview({ target }) {
+  const { title, author, preview = {} } = target;
+  return (
+    <figure className="overflow-hidden rounded-lg border border-border bg-surface-raised">
+      <div className="relative aspect-video w-full bg-muted">
+        <SafeImage src={preview.thumbnail || preview.poster} alt={`Thumbnail for reel: ${title}`} fill className="object-cover" />
+        <span
+          className="absolute inset-0 flex items-center justify-center"
+          aria-hidden="true"
+        >
+          <span className="flex h-12 w-12 items-center justify-center rounded-full bg-black/55 text-white ring-1 ring-white/30">
+            <Play className="ml-0.5 h-6 w-6" fill="currentColor" />
+          </span>
+        </span>
+        {typeof preview.durationSeconds === "number" ? (
+          <span className="absolute bottom-2 right-2 rounded bg-black/70 px-1.5 py-0.5 text-[11px] font-medium text-white">
+            {Math.floor(preview.durationSeconds / 60)}:
+            {String(preview.durationSeconds % 60).padStart(2, "0")}
+          </span>
+        ) : null}
+      </div>
+      <figcaption className={cn(poppins_400.className, "flex items-center justify-between gap-2 px-3 py-2")}>
+        <span className={cn(poppins_500.className, "truncate text-sm text-ink")}>{title}</span>
+        <Badge variant="secondary">Reel</Badge>
+      </figcaption>
+      <p className={cn(poppins_400.className, "px-3 pb-2 text-xs text-ink-muted")}>by {author}</p>
+    </figure>
+  );
+}
+
+function BookPreview({ target }) {
+  const { title, author, preview = {} } = target;
+  return (
+    <figure className="flex gap-3 rounded-lg border border-border bg-surface-raised p-3">
+      <div className="relative h-40 w-28 shrink-0 overflow-hidden rounded-md bg-muted shadow-sm">
+        <SafeImage src={preview.cover} alt={`Cover of book: ${title}`} fill className="object-cover" />
+      </div>
+      <figcaption className="flex min-w-0 flex-col justify-center gap-1">
+        <Badge variant="secondary" className="w-fit gap-1">
+          <BookOpen className="h-3 w-3" aria-hidden="true" /> Book
+        </Badge>
+        <span className={cn(poppins_600.className, "line-clamp-2 text-sm text-ink")}>{title}</span>
+        <span className={cn(poppins_400.className, "text-xs text-ink-muted")}>by {author}</span>
+      </figcaption>
+    </figure>
+  );
+}
+
+function CoursePreview({ target }) {
+  const { title, author, preview = {} } = target;
+  return (
+    <figure className="overflow-hidden rounded-lg border border-border bg-surface-raised">
+      <div className="relative aspect-video w-full bg-muted">
+        <SafeImage src={preview.thumbnail} alt={`Thumbnail for course: ${title}`} fill className="object-cover" />
+        <Badge variant="secondary" className="absolute left-2 top-2 gap-1">
+          <GraduationCap className="h-3 w-3" aria-hidden="true" /> Course
+        </Badge>
+      </div>
+      <figcaption className="space-y-1 px-3 py-2">
+        <span className={cn(poppins_600.className, "block truncate text-sm text-ink")}>{title}</span>
+        <span className={cn(poppins_400.className, "block text-xs text-ink-muted")}>by {author}</span>
+        <div className={cn(poppins_400.className, "flex gap-3 pt-1 text-xs text-ink-muted")}>
+          {typeof preview.lessons === "number" ? <span>{preview.lessons} lessons</span> : null}
+          {typeof preview.enrolled === "number" ? <span>{preview.enrolled} enrolled</span> : null}
+        </div>
+      </figcaption>
+    </figure>
+  );
+}
+
+export default function ReportedContentPreview({ target }) {
+  if (!target) return null;
+  switch (target.type) {
+    case "reel":
+      return <ReelPreview target={target} />;
+    case "book":
+      return <BookPreview target={target} />;
+    case "course":
+      return <CoursePreview target={target} />;
+    default:
+      return (
+        <div className={cn(poppins_400.className, "rounded-lg border border-border bg-surface-raised p-4 text-sm text-ink-muted")}>
+          No preview available for this content type.
+        </div>
+      );
+  }
+}

--- a/hooks/useReports.js
+++ b/hooks/useReports.js
@@ -1,0 +1,129 @@
+"use client";
+/**
+ * useReports — data hook for the admin moderation-reports surface (#289).
+ * ---------------------------------------------------------------------------
+ * Loads the moderation queue and single reports from the stubbed service in
+ * `lib/actions/admin-reports`, and exposes the three moderator actions
+ * (escalate / dismiss / apply-action-to-target) with `sonner` toasts and an
+ * optimistic local update so the list and the open drawer reflect a decision
+ * immediately. The page and the detail drawer share one hook instance so they
+ * never drift.
+ */
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+  listReports,
+  escalateReport,
+  dismissReport,
+  applyActionToTarget,
+} from "@/lib/actions/admin-reports";
+
+export default function useReports() {
+  const [reports, setReports] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [pendingId, setPendingId] = useState(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const { reports: list } = await listReports();
+      setReports(list);
+      return list;
+    } catch (err) {
+      setError(err?.message || "Failed to load reports");
+      return [];
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setIsLoading(true);
+      try {
+        const { reports: list } = await listReports();
+        if (!cancelled) setReports(list);
+      } catch (err) {
+        if (!cancelled) setError(err?.message || "Failed to load reports");
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  /**
+   * Run a mutation, drop the resolved report out of the queue optimistically,
+   * and toast the outcome. `run` returns `{ report }`.
+   */
+  const mutate = useCallback(
+    async (id, run, { pending, success, failure }) => {
+      setPendingId(id);
+      const toastId = toast.loading(pending);
+      try {
+        const { report } = await run();
+        if (!report) throw new Error("Report not found");
+        // The queue holds only open/escalated reports: update the status in place,
+        // then drop anything now resolved (dismissed / actioned) out of the list.
+        setReports((prev) =>
+          prev
+            .map((r) => (r.id === id ? { ...r, status: report.status } : r))
+            .filter((r) => r.status === "open" || r.status === "escalated")
+        );
+        toast.success(success, { id: toastId });
+        return report;
+      } catch (err) {
+        toast.error(err?.message || failure, { id: toastId });
+        throw err;
+      } finally {
+        setPendingId(null);
+      }
+    },
+    []
+  );
+
+  const escalate = useCallback(
+    (id) =>
+      mutate(id, () => escalateReport(id), {
+        pending: "Escalating report…",
+        success: "Report escalated for senior review",
+        failure: "Could not escalate report",
+      }),
+    [mutate]
+  );
+
+  const dismiss = useCallback(
+    (id, reason) =>
+      mutate(id, () => dismissReport(id, { reason }), {
+        pending: "Dismissing report…",
+        success: "Report dismissed",
+        failure: "Could not dismiss report",
+      }),
+    [mutate]
+  );
+
+  const applyAction = useCallback(
+    (id, action, reason) =>
+      mutate(id, () => applyActionToTarget(id, { action, reason }), {
+        pending: "Applying action to target…",
+        success: "Action applied to target",
+        failure: "Could not apply action",
+      }),
+    [mutate]
+  );
+
+  return {
+    reports,
+    isLoading,
+    error,
+    pendingId,
+    refresh,
+    escalate,
+    dismiss,
+    applyAction,
+  };
+}

--- a/lib/actions/admin-reports.js
+++ b/lib/actions/admin-reports.js
@@ -1,0 +1,289 @@
+/**
+ * Admin moderation-reports service — list, read, and act on user reports.
+ * ---------------------------------------------------------------------------
+ * **STUBBED (#289).** The moderation-reports backend does not exist yet, so
+ * this module serves deterministic in-memory seed data and mocks the mutations,
+ * backed by a module-level store so the reports list and the detail drawer stay
+ * in sync within a browser session (until a full reload re-seeds the module).
+ * Swap the mock bodies for `axiosInstance` calls (see `lib/config/axios.config.js`)
+ * when the backend lands.
+ *
+ * A report ties a **reporter** (who flagged something) to a **target** — a
+ * piece of content (reel / book / course) or the account that owns it — plus
+ * the context a moderator needs to decide well: the reporter's statement and
+ * trust signals (account age, how many prior reports they've filed), and the
+ * target's own history (prior reports against it, prior admin actions taken).
+ *
+ * Report shape owned by the backend:
+ *
+ *   {
+ *     id: string,
+ *     status: "open" | "escalated" | "dismissed" | "actioned",
+ *     reason: string,                       // short reason code/label
+ *     createdAt: string,                    // ISO 8601
+ *     reporter: {
+ *       id, name, avatar,
+ *       accountCreatedAt: string,           // ISO — drives "account age"
+ *       priorReportCount: number,           // serial-reporter signal
+ *       statement: string,                  // free-text why-they-reported
+ *     },
+ *     target: {
+ *       type: "reel" | "book" | "course",
+ *       id, title, author,
+ *       preview: { thumbnail?, cover?, poster?, ... },  // type-specific
+ *       ownerId, ownerName,
+ *       priorReports: Array<{ id, reason, createdAt, status }>,
+ *       priorActions: Array<{ id, action, at, by }>,     // admin actions
+ *     },
+ *   }
+ *
+ * TODO(backend):
+ *   - GET  /api/admin/reports                → 200 { reports: Report[] }         (admin session)
+ *   - GET  /api/admin/reports/:id            → 200 { report: Report } | 404
+ *   - POST /api/admin/reports/:id/escalate   → 200 { report } (status→escalated)
+ *   - POST /api/admin/reports/:id/dismiss    → 200 { report } (status→dismissed)
+ *   - POST /api/admin/reports/:id/action     → 200 { report } (status→actioned)
+ *       Payload: { action: "takedown" | "ban" | ..., reason?: string }
+ *     All are super-admin only (server-side tier check).
+ */
+
+import { logAuditEvent, AUDIT_ACTIONS } from "@/lib/admin/audit";
+
+const MOCK_DELAY_MS = 300;
+
+function withMockDelay(value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_DELAY_MS));
+}
+
+/**
+ * Deterministic seed. Fixed ids and timestamps so the list, the drawer, and any
+ * test render identically every time (no randomness). Covers all three target
+ * content types the issue calls out: a reel, a book, and a course.
+ *
+ * @returns {Array<object>}
+ */
+function seedReports() {
+  return [
+    {
+      id: "rep_1001",
+      status: "open",
+      reason: "Inappropriate content",
+      createdAt: "2026-08-20T09:12:00.000Z",
+      reporter: {
+        id: "usr_5001",
+        name: "Aisha Bello",
+        avatar: "https://picsum.photos/seed/reporter-aisha/64/64",
+        accountCreatedAt: "2023-02-14T00:00:00.000Z",
+        priorReportCount: 2,
+        statement:
+          "This reel shows content that doesn't align with the community guidelines. The audio contains music over a naat which many members find inappropriate.",
+      },
+      target: {
+        type: "reel",
+        id: "reel_88",
+        title: "Evening Dhikr — 60s reel",
+        author: "Yusuf Adeyemi",
+        preview: {
+          thumbnail: "https://picsum.photos/seed/reel-88/640/360",
+          poster: "https://picsum.photos/seed/reel-88/640/360",
+          durationSeconds: 62,
+        },
+        ownerId: "usr_7001",
+        ownerName: "Yusuf Adeyemi",
+        priorReports: [
+          { id: "rep_0900", reason: "Copyright (audio)", createdAt: "2026-07-30T14:00:00.000Z", status: "dismissed" },
+        ],
+        priorActions: [],
+      },
+    },
+    {
+      id: "rep_1002",
+      status: "open",
+      reason: "Copyright violation",
+      createdAt: "2026-08-21T16:45:00.000Z",
+      reporter: {
+        id: "usr_5002",
+        name: "Ibrahim Sanni",
+        avatar: "https://picsum.photos/seed/reporter-ibrahim/64/64",
+        accountCreatedAt: "2025-11-01T00:00:00.000Z",
+        priorReportCount: 11,
+        statement:
+          "The uploaded book PDF is a scanned copy of a work still under copyright. The publisher's watermark is visible on several pages.",
+      },
+      target: {
+        type: "book",
+        id: "book_42",
+        title: "Riyad as-Salihin (annotated)",
+        author: "Imam an-Nawawi",
+        preview: {
+          cover: "https://picsum.photos/seed/book-42/320/440",
+        },
+        ownerId: "usr_7002",
+        ownerName: "Al-Furqan Publishers",
+        priorReports: [
+          { id: "rep_0811", reason: "Copyright violation", createdAt: "2026-06-11T10:00:00.000Z", status: "actioned" },
+          { id: "rep_0655", reason: "Low-quality scan", createdAt: "2026-05-02T08:30:00.000Z", status: "dismissed" },
+        ],
+        priorActions: [
+          { id: "act_311", action: "content.takedown", at: "2026-06-12T09:00:00.000Z", by: "Admin (Khadija)" },
+          { id: "act_312", action: "content.restore", at: "2026-06-20T09:00:00.000Z", by: "Admin (Khadija)" },
+        ],
+      },
+    },
+    {
+      id: "rep_1003",
+      status: "open",
+      reason: "Misleading information",
+      createdAt: "2026-08-22T11:05:00.000Z",
+      reporter: {
+        id: "usr_5003",
+        name: "Fatima Yusuf",
+        avatar: "https://picsum.photos/seed/reporter-fatima/64/64",
+        accountCreatedAt: "2024-09-19T00:00:00.000Z",
+        priorReportCount: 0,
+        statement:
+          "The course description promises an 'ijazah on completion' which the instructor is not authorized to grant. This could mislead new students.",
+      },
+      target: {
+        type: "course",
+        id: "course_17",
+        title: "Tajwid Foundations — 8 week intensive",
+        author: "Ustadh Kareem",
+        preview: {
+          thumbnail: "https://picsum.photos/seed/course-17/640/360",
+          lessons: 24,
+          enrolled: 512,
+        },
+        ownerId: "usr_7003",
+        ownerName: "Ustadh Kareem",
+        priorReports: [],
+        priorActions: [],
+      },
+    },
+  ];
+}
+
+/**
+ * In-memory store, seeded lazily on first access so mutations round-trip within
+ * a session.
+ *
+ * @type {Array<object>|null}
+ */
+let mockReports = null;
+
+function getStore() {
+  if (!mockReports) mockReports = seedReports();
+  return mockReports;
+}
+
+/** Deep-ish clone so callers can't mutate the store by reference. */
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+/**
+ * List reports (newest first). Defaults to the moderation queue (open +
+ * escalated); pass `{ status: "all" }` to include resolved ones.
+ *
+ * @param {{ status?: "open" | "queue" | "all" }} [opts]
+ * @returns {Promise<{ reports: Array<object> }>}
+ */
+export async function listReports({ status = "queue" } = {}) {
+  const all = clone(getStore());
+  const filtered =
+    status === "all"
+      ? all
+      : status === "open"
+        ? all.filter((r) => r.status === "open")
+        : all.filter((r) => r.status === "open" || r.status === "escalated");
+
+  filtered.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+  return withMockDelay({ reports: filtered });
+}
+
+/**
+ * Fetch a single report with its full context, or `null` if not found.
+ *
+ * @param {string} id
+ * @returns {Promise<{ report: object | null }>}
+ */
+export async function getReport(id) {
+  const found = getStore().find((r) => r.id === id) || null;
+  return withMockDelay({ report: found ? clone(found) : null });
+}
+
+/** Mutate the stored report's status, or no-op if missing. Returns the clone. */
+function setStatus(id, nextStatus) {
+  const report = getStore().find((r) => r.id === id);
+  if (report) report.status = nextStatus;
+  return report ? clone(report) : null;
+}
+
+/**
+ * Escalate a report for senior review, then emit a non-blocking audit event.
+ *
+ * @param {string} id
+ * @returns {Promise<{ report: object | null }>}
+ */
+export async function escalateReport(id) {
+  const report = setStatus(id, "escalated");
+  const result = await withMockDelay({ report });
+  if (report) {
+    logAuditEvent({
+      action: AUDIT_ACTIONS.REPORT_ESCALATE,
+      target: { label: `Report ${id}`, href: `/dashboard/admin/reports?report=${id}` },
+      metadata: { reportId: id, targetType: report.target?.type, targetId: report.target?.id },
+    });
+  }
+  return result;
+}
+
+/**
+ * Dismiss a report as no-action, then emit a non-blocking audit event.
+ *
+ * @param {string} id
+ * @param {{ reason?: string }} [opts]
+ * @returns {Promise<{ report: object | null }>}
+ */
+export async function dismissReport(id, { reason } = {}) {
+  const report = setStatus(id, "dismissed");
+  const result = await withMockDelay({ report });
+  if (report) {
+    logAuditEvent({
+      action: AUDIT_ACTIONS.REPORT_DISMISS,
+      target: { label: `Report ${id}`, href: `/dashboard/admin/reports?report=${id}` },
+      metadata: { reportId: id, reason: reason || null },
+    });
+  }
+  return result;
+}
+
+/**
+ * Apply a moderation action to the report's target (e.g. take the content down),
+ * mark the report actioned, then emit a non-blocking audit event.
+ *
+ * @param {string} id
+ * @param {{ action?: string, reason?: string }} [opts]
+ * @returns {Promise<{ report: object | null }>}
+ */
+export async function applyActionToTarget(id, { action = "takedown", reason } = {}) {
+  const report = setStatus(id, "actioned");
+  const result = await withMockDelay({ report });
+  if (report) {
+    logAuditEvent({
+      action: AUDIT_ACTIONS.REPORT_ACTION,
+      target: {
+        label: report.target?.title || `Report ${id}`,
+        href: `/dashboard/admin/reports?report=${id}`,
+      },
+      metadata: {
+        reportId: id,
+        appliedAction: action,
+        targetType: report.target?.type,
+        targetId: report.target?.id,
+        reason: reason || null,
+      },
+    });
+  }
+  return result;
+}

--- a/lib/admin/audit.js
+++ b/lib/admin/audit.js
@@ -61,6 +61,11 @@ export const AUDIT_ACTIONS = Object.freeze({
   TAKEDOWN: "content.takedown",
   RESTORE: "content.restore",
 
+  // Report moderation
+  REPORT_ESCALATE: "report.escalate",
+  REPORT_DISMISS: "report.dismiss",
+  REPORT_ACTION: "report.action",
+
   // Payments
   REFUND: "payment.refund",
 
@@ -105,6 +110,9 @@ const ACTION_CATEGORY = Object.freeze({
   [AUDIT_ACTIONS.SUSPEND]: "user",
   [AUDIT_ACTIONS.TAKEDOWN]: "moderation",
   [AUDIT_ACTIONS.RESTORE]: "moderation",
+  [AUDIT_ACTIONS.REPORT_ESCALATE]: "moderation",
+  [AUDIT_ACTIONS.REPORT_DISMISS]: "moderation",
+  [AUDIT_ACTIONS.REPORT_ACTION]: "moderation",
   [AUDIT_ACTIONS.REFUND]: "payment",
   [AUDIT_ACTIONS.BROADCAST]: "system",
   [AUDIT_ACTIONS.EMERGENCY_BROADCAST]: "system",


### PR DESCRIPTION
## Summary
Closes #289. Adds a moderation-reports surface that gives moderators **full context in one place** so they never act without the information they need.

## What's included
- **Queue page** `/dashboard/admin/reports` (super-admin only, `AdminTierGuard`) — a dense list of open/escalated reports: reason, target (type + title), reporter, a **serial-reporter flag**, and age. Rows are keyboard-accessible (Enter/Space) and open the detail drawer.
- **Report detail drawer** (right-side `Sheet`) per report, high density:
  - **Inline content preview matched to type** — reel → thumbnail + play affordance (no heavy player dep), book → cover, course → card with lesson/enrolment stats. Graceful image fallback.
  - **Reporter panel** — statement + trust signals: account age (`formatDistanceToNow`) and prior report count, with a destructive badge flagging serial reporters (≥5).
  - **Target history** — prior reports (reason/date/status) and prior admin actions (action/date/by).
  - **Action rail** — Escalate, Dismiss, and Apply action to target (takedown) behind an `AlertDialog` confirm because it's destructive.

## Data / architecture
- Stubbed `lib/actions/admin-reports.js`: deterministic in-memory seed covering **all three content types** (reel, book, course), with reporter metadata and target history, plus `listReports`/`getReport`/`escalateReport`/`dismissReport`/`applyActionToTarget`. Full `TODO(backend)` contract documented (GET/POST endpoints, super-admin gated).
- `hooks/useReports.js`: queue load + mutations with optimistic list updates and `sonner` toasts; the page and drawer share one instance so they never drift.
- Each action emits a **non-blocking audit event**; adds `REPORT_ESCALATE`/`REPORT_DISMISS`/`REPORT_ACTION` to `lib/admin/audit.js` (category `moderation`, with matching `ACTION_CATEGORY` entries).

## Acceptance criteria
Drawer per report ✓ · inline preview ✓ · reel thumbnail+player ✓ · book cover ✓ · course card ✓ · reporter statement ✓ · reporter account age ✓ · prior report count ✓ · target prior reports ✓ · target prior admin actions ✓ · action rail escalate ✓ · dismiss ✓ · apply-action-to-target ✓ · high context density ✓.

## Verification
- `npm run build` — green; the `/[locale]/dashboard/admin/reports` route compiles and prerenders for en + ar. `npm run a11y` — clean on the added files (keyboard-navigable rows, labelled images, accessible drawer/dialog). No new dependencies.
- Backend is a documented stub (no API exists yet). Repo CI is Lint-and-Build only.