### PR TITLE
feat(admin): add custom report builder with saved queries

### DIFF
--- a/__tests__/admin/ReportBuilderPage.test.jsx
+++ b/__tests__/admin/ReportBuilderPage.test.jsx
@@ -1,0 +1,183 @@
+/**
+ * Report builder page — dataset / filters / columns / preview / saved-query
+ * and export state tests (#329).
+ * ---------------------------------------------------------------------------
+ * The builder composes existing datasets into named saved queries. These tests
+ * mock the admin-reports service and the CSV download trigger, then assert the
+ * presentational flow: dataset selection, filter + column controls, preview
+ * rendering, the saved-queries sidebar, and export.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/config/font.config", () => ({
+  poppins_400: { className: "" },
+  poppins_500: { className: "" },
+  poppins_600: { className: "" },
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => ({ user: { id: "me", _id: "me" } }),
+  useAuth: () => ({ user: { id: "me", _id: "me" } }),
+}));
+
+// Bypass the super-admin page guard — its behaviour is out of scope here.
+vi.mock("@/components/auth/AdminTierGuard", () => ({
+  default: ({ children }) => children,
+}));
+
+const csvMock = vi.hoisted(() => ({ downloadCsv: vi.fn() }));
+vi.mock("@/lib/utils/csv", () => ({ downloadCsv: csvMock.downloadCsv }));
+
+const serviceMocks = vi.hoisted(() => ({
+  fetchReportRows: vi.fn(),
+  listSavedQueries: vi.fn(),
+  saveQuery: vi.fn(),
+  deleteSavedQuery: vi.fn(),
+}));
+vi.mock("@/lib/actions/admin-reports", async () => {
+  const actual = await vi.importActual("@/lib/actions/admin-reports");
+  return {
+    ...actual,
+    fetchReportRows: serviceMocks.fetchReportRows,
+    listSavedQueries: serviceMocks.listSavedQueries,
+    saveQuery: serviceMocks.saveQuery,
+    deleteSavedQuery: serviceMocks.deleteSavedQuery,
+  };
+});
+
+const USER_ROWS = [
+  { id: "u1", name: "Amina Yusuf", email: "amina@deenbridge.org", role: "student", status: "active", joinedAt: "2025-01-12" },
+  { id: "u2", name: "Bilal Karim", email: "bilal@deenbridge.org", role: "educator", status: "active", joinedAt: "2025-02-03" },
+];
+
+const SAVED_QUERIES = [
+  {
+    id: "q_1",
+    name: "Active users",
+    datasetId: "users",
+    filters: { status: "active", from: "", to: "" },
+    columns: ["name", "email"],
+    createdAt: "2026-08-01T00:00:00.000Z",
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  serviceMocks.fetchReportRows.mockResolvedValue({ rows: USER_ROWS });
+  serviceMocks.listSavedQueries.mockResolvedValue({ queries: SAVED_QUERIES });
+  serviceMocks.saveQuery.mockResolvedValue({
+    query: { ...SAVED_QUERIES[0], id: "q_new" },
+  });
+  serviceMocks.deleteSavedQuery.mockResolvedValue({ deleted: true, queryId: "q_1" });
+
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  if (!window.ResizeObserver) {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+let ReportBuilderPage;
+beforeEach(async () => {
+  if (!ReportBuilderPage) {
+    const mod = await import("@/app/[locale]/dashboard/admin/report-builder/page");
+    ReportBuilderPage = mod.default;
+  }
+});
+
+describe("ReportBuilderPage", () => {
+  it("renders the dataset selector with all three datasets", async () => {
+    render(<ReportBuilderPage />);
+    expect(await screen.findByText("Report builder")).toBeInTheDocument();
+    expect(screen.getByText("Dataset")).toBeInTheDocument();
+    // Open the dataset dropdown and confirm the three options exist (labels
+    // also appear in the saved-queries sidebar, so match any occurrence).
+    fireEvent.click(screen.getByLabelText("Select report dataset"));
+    expect((await screen.findAllByText("Users")).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Transactions").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Reports").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders filter controls and column checkboxes for the default dataset", async () => {
+    render(<ReportBuilderPage />);
+    expect(await screen.findByText("Filters")).toBeInTheDocument();
+    expect(screen.getByLabelText("Status filter")).toBeInTheDocument();
+    expect(screen.getByLabelText("Joined from filter")).toBeInTheDocument();
+    expect(screen.getByText("Output columns")).toBeInTheDocument();
+    // Column names repeat in the preview table header, so match any occurrence.
+    expect(screen.getAllByText("Name").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Email").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the preview table with fetched rows", async () => {
+    render(<ReportBuilderPage />);
+    expect(await screen.findByText("Amina Yusuf")).toBeInTheDocument();
+    expect(screen.getByText("Bilal Karim")).toBeInTheDocument();
+  });
+
+  it("renders saved queries in the sidebar and loads one on click", async () => {
+    render(<ReportBuilderPage />);
+    expect(await screen.findByText("Active users")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /run query active users/i }));
+    await waitFor(() => {
+      expect(serviceMocks.fetchReportRows).toHaveBeenCalledWith(
+        "users",
+        expect.objectContaining({ status: "active" }),
+        expect.objectContaining({ limit: 50 })
+      );
+    });
+  });
+
+  it("saves the current query from the dialog", async () => {
+    render(<ReportBuilderPage />);
+    await screen.findByText("Report builder");
+
+    fireEvent.click(screen.getByRole("button", { name: /save query/i }));
+    const nameInput = await screen.findByLabelText("Query name");
+    fireEvent.change(nameInput, { target: { value: "Active users" } });
+    fireEvent.click(screen.getByRole("button", { name: /save query/i }));
+
+    await waitFor(() => {
+      expect(serviceMocks.saveQuery).toHaveBeenCalledWith(
+        "me",
+        expect.objectContaining({
+          name: "Active users",
+          datasetId: "users",
+          columns: expect.arrayContaining(["name", "email"]),
+        })
+      );
+    });
+  });
+
+  it("deletes a saved query from the sidebar", async () => {
+    render(<ReportBuilderPage />);
+    await screen.findByText("Active users");
+
+    fireEvent.click(screen.getByRole("button", { name: /delete query active users/i }));
+    await waitFor(() => {
+      expect(serviceMocks.deleteSavedQuery).toHaveBeenCalledWith("me", "q_1");
+    });
+  });
+
+  it("exports the preview as CSV via the standard path", async () => {
+    render(<ReportBuilderPage />);
+    await screen.findByText("Amina Yusuf");
+
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+    expect(csvMock.downloadCsv).toHaveBeenCalledTimes(1);
+    const args = csvMock.downloadCsv.mock.calls[0][0];
+    expect(args.filename).toContain("users-report");
+    expect(args.headers).toContain("Name");
+    expect(args.rows.length).toBe(2);
+  });
+});

--- a/__tests__/admin/admin-reports.service.test.js
+++ b/__tests__/admin/admin-reports.service.test.js
@@ -1,0 +1,147 @@
+/**
+ * Admin report-builder service — contract tests (#329).
+ * ------------------------------------------------------------------
+ * Pins the report-builder seam in `lib/actions/admin-reports.js`: the three
+ * datasets (users / transactions / reports), default filters, filtered preview
+ * rows, and the per-admin saved-query CRUD that backs the sidebar. No
+ * cross-dataset joins or SQL are expected anywhere in the resolved shapes.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  REPORT_DATASETS,
+  defaultFiltersFor,
+  fetchReportRows,
+  listSavedQueries,
+  saveQuery,
+  deleteSavedQuery,
+} from "@/lib/actions/admin-reports";
+
+const DATASET_IDS = ["users", "transactions", "reports"];
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("REPORT_DATASETS", () => {
+  it("exposes the three scoped datasets with filters and columns", () => {
+    expect(REPORT_DATASETS.map((d) => d.id)).toEqual(DATASET_IDS);
+    for (const dataset of REPORT_DATASETS) {
+      expect(typeof dataset.label).toBe("string");
+      expect(dataset.filters.length).toBeGreaterThan(0);
+      expect(dataset.columns.length).toBeGreaterThan(0);
+      for (const filter of dataset.filters) {
+        expect(["select", "date"]).toContain(filter.type);
+        expect(typeof filter.key).toBe("string");
+        expect(typeof filter.label).toBe("string");
+      }
+      for (const column of dataset.columns) {
+        expect(typeof column.key).toBe("string");
+        expect(typeof column.label).toBe("string");
+      }
+    }
+  });
+
+  it("defines only existing module filter sets (no custom SQL / joins)", () => {
+    for (const dataset of REPORT_DATASETS) {
+      const keys = dataset.filters.map((f) => f.key);
+      // date-range pairs plus per-dataset selects only
+      expect(keys.filter((k) => k === "from").length).toBeLessThanOrEqual(1);
+      expect(keys.filter((k) => k === "to").length).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("defaultFiltersFor", () => {
+  it("returns 'all' for selects and '' for date filters", () => {
+    const filters = defaultFiltersFor("users");
+    expect(filters.status).toBe("all");
+    expect(filters.from).toBe("");
+    expect(filters.to).toBe("");
+  });
+
+  it("returns an empty object for an unknown dataset", () => {
+    expect(defaultFiltersFor("nope")).toEqual({});
+  });
+});
+
+describe("fetchReportRows", () => {
+  it("rejects an unknown dataset", async () => {
+    await expect(fetchReportRows("nope", {})).rejects.toThrow(/unknown report dataset/i);
+  });
+
+  it("returns all rows for a dataset by default", async () => {
+    const { rows } = await fetchReportRows("users", {});
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it("applies a select filter", async () => {
+    const { rows } = await fetchReportRows("users", { status: "banned" });
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) expect(row.status).toBe("banned");
+  });
+
+  it("applies the date-range filters", async () => {
+    const { rows } = await fetchReportRows("users", { from: "2025-04-01", to: "2025-05-31" });
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.joinedAt >= "2025-04-01").toBe(true);
+      expect(row.joinedAt <= "2025-05-31").toBe(true);
+    }
+  });
+
+  it("honors the preview limit option", async () => {
+    const { rows } = await fetchReportRows("users", {}, { limit: 2 });
+    expect(rows.length).toBe(2);
+  });
+});
+
+describe("saved queries (per admin)", () => {
+  const QUERY = {
+    name: "Active users",
+    datasetId: "users",
+    filters: { status: "active" },
+    columns: ["name", "email"],
+  };
+
+  it("round-trips a saved query for an admin user", async () => {
+    const { query } = await saveQuery("admin-1", QUERY);
+    expect(query.id).toMatch(/^q_/);
+    expect(query.name).toBe("Active users");
+    expect(query.datasetId).toBe("users");
+    expect(query.columns).toEqual(["name", "email"]);
+    expect(query.filters.status).toBe("active");
+    expect(typeof query.createdAt).toBe("string");
+
+    const { queries } = await listSavedQueries("admin-1");
+    expect(queries).toHaveLength(1);
+    expect(queries[0].id).toBe(query.id);
+  });
+
+  it("scopes saved queries per admin user", async () => {
+    await saveQuery("admin-1", QUERY);
+    const { queries } = await listSavedQueries("admin-2");
+    expect(queries).toHaveLength(0);
+  });
+
+  it("rejects a save without a name", async () => {
+    await expect(saveQuery("admin-1", { ...QUERY, name: "  " })).rejects.toThrow(/name is required/i);
+  });
+
+  it("rejects a save for an unknown dataset", async () => {
+    await expect(saveQuery("admin-1", { ...QUERY, datasetId: "nope" })).rejects.toThrow(/unknown report dataset/i);
+  });
+
+  it("rejects a save without any columns", async () => {
+    await expect(saveQuery("admin-1", { ...QUERY, columns: [] })).rejects.toThrow(/at least one column/i);
+  });
+
+  it("deletes a saved query", async () => {
+    const { query } = await saveQuery("admin-1", QUERY);
+    const { deleted, queryId } = await deleteSavedQuery("admin-1", query.id);
+    expect(deleted).toBe(true);
+    expect(queryId).toBe(query.id);
+
+    const { queries } = await listSavedQueries("admin-1");
+    expect(queries).toHaveLength(0);
+  });
+});

--- a/__tests__/utils/csv.test.js
+++ b/__tests__/utils/csv.test.js
@@ -1,0 +1,25 @@
+/**
+ * CSV export helpers (#329).
+ * ------------------------------------------------------------------
+ * The report builder and the existing admin export handlers share the same
+ * quoting/escaping path; these tests pin the shared serializer.
+ */
+import { describe, it, expect } from "vitest";
+import { rowsToCsv } from "@/lib/utils/csv";
+
+describe("rowsToCsv", () => {
+  it("serializes headers and rows", () => {
+    const csv = rowsToCsv(["Name", "Role"], [["Amina", "student"]]);
+    expect(csv).toBe('"Name","Role"\n"Amina","student"');
+  });
+
+  it("quote-escapes cells containing commas and quotes", () => {
+    const csv = rowsToCsv(["Note"], [['He said "hi", ok']]);
+    expect(csv).toBe('"Note"\n"He said ""hi"", ok"');
+  });
+
+  it("treats null/undefined cells as empty strings", () => {
+    const csv = rowsToCsv(["A", "B"], [[null, undefined]]);
+    expect(csv).toBe('"A","B"\n"",""');
+  });
+});

--- a/app/[locale]/dashboard/admin/report-builder/page.jsx
+++ b/app/[locale]/dashboard/admin/report-builder/page.jsx
@@ -1,0 +1,664 @@
+"use client";
+/**
+ * Admin custom report builder (saved queries) (#329).
+ * ---------------------------------------------------------------------------
+ * Super-admin surface (wrapped in `AdminTierGuard`) that composes the existing
+ * report datasets (users / transactions / reports) into a named, saved query:
+ * pick a dataset, tune its filters, choose output columns, preview the rows,
+ * and export via the standard CSV path. Strict scope discipline — no
+ * cross-dataset joins, no custom SQL, no scheduling.
+ *
+ * Mirrors the structure/styling of the audit-logs admin page.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  Table2,
+  Save,
+  Download,
+  Trash2,
+  Play,
+  Plus,
+  ListChecks,
+  Filter,
+  Eye,
+} from "lucide-react";
+import { toast } from "sonner";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import AdminTierGuard from "@/components/auth/AdminTierGuard";
+import {
+  REPORT_DATASETS,
+  defaultFiltersFor,
+  fetchReportRows,
+  listSavedQueries,
+  saveQuery,
+  deleteSavedQuery,
+} from "@/lib/actions/admin-reports";
+import { downloadCsv } from "@/lib/utils/csv";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+const PREVIEW_LIMIT = 50;
+const DEFAULT_DATASET = "users";
+
+function formatDate(iso) {
+  const date = iso ? new Date(iso) : null;
+  if (!date || Number.isNaN(date.getTime())) return "Unknown";
+  return date.toLocaleDateString(undefined, { day: "2-digit", month: "short", year: "numeric" });
+}
+
+function SavedQueriesPanel({ queries, activeQueryId, onLoad, onDelete, onOpenSave }) {
+  return (
+    <Card className="h-fit lg:sticky lg:top-6">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <ListChecks className="h-5 w-5" />
+          Saved queries
+        </CardTitle>
+        <CardDescription>
+          Rerun a previously saved report
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          type="button"
+          size="sm"
+          className="mb-4 w-full rounded-full"
+          onClick={onOpenSave}
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Save current query
+        </Button>
+
+        {queries.length === 0 ? (
+          <p className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+            No saved queries yet. Compose a report and save it to rerun it here.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {queries.map((query) => {
+              const dataset = REPORT_DATASETS.find((d) => d.id === query.datasetId);
+              const isActive = query.id === activeQueryId;
+              return (
+                <li
+                  key={query.id}
+                  className={cn(
+                    "flex items-start justify-between gap-2 rounded-xl border p-3 transition-colors",
+                    isActive
+                      ? "border-accent/30 bg-accent/5"
+                      : "border-accent/10 bg-surface-raised hover:border-accent/20"
+                  )}
+                >
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 text-left"
+                    onClick={() => onLoad(query)}
+                    aria-label={`Run query ${query.name}`}
+                  >
+                    <p className={cn(poppins_500.className, "truncate text-sm text-ink")}>
+                      {query.name}
+                    </p>
+                    <p className={cn(poppins_400.className, "mt-0.5 text-xs text-ink-muted")}>
+                      {dataset?.label || query.datasetId} · {formatDate(query.createdAt)}
+                    </p>
+                  </button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0 rounded-full text-ink-muted hover:text-destructive"
+                    onClick={() => onDelete(query.id)}
+                    aria-label={`Delete query ${query.name}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DatasetSelector({ value, onChange }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Table2 className="h-5 w-5" />
+          Dataset
+        </CardTitle>
+        <CardDescription>
+          Choose which report to compose
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Select value={value} onValueChange={onChange}>
+          <SelectTrigger id="report-dataset" className="w-full" aria-label="Select report dataset">
+            <SelectValue placeholder="Select a dataset" />
+          </SelectTrigger>
+          <SelectContent>
+            {REPORT_DATASETS.map((dataset) => (
+              <SelectItem key={dataset.id} value={dataset.id}>
+                {dataset.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className={cn(poppins_400.className, "mt-2 text-xs text-ink-muted")}>
+          {REPORT_DATASETS.find((d) => d.id === value)?.description}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FilterControls({ dataset, filters, onChange }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 rounded-2xl border border-accent/10 bg-surface-raised p-4 shadow-sm sm:grid-cols-2 lg:grid-cols-4">
+      {dataset.filters.map((filter) => {
+        if (filter.type === "date") {
+          const isFrom = filter.key === "from";
+          return (
+            <div key={filter.key} className="space-y-1.5">
+              <Label
+                htmlFor={`report-filter-${dataset.id}-${filter.key}`}
+                className={cn(poppins_500.className, "text-ink")}
+              >
+                {filter.label}
+              </Label>
+              <Input
+                id={`report-filter-${dataset.id}-${filter.key}`}
+                type="date"
+                value={filters[filter.key] || ""}
+                max={!isFrom ? undefined : filters.to || undefined}
+                min={isFrom ? undefined : filters.from || undefined}
+                onChange={(event) => onChange(filter.key, event.target.value)}
+                aria-label={`${filter.label} filter`}
+              />
+            </div>
+          );
+        }
+
+        return (
+          <div key={filter.key} className="space-y-1.5">
+            <Label
+              htmlFor={`report-filter-${dataset.id}-${filter.key}`}
+              className={cn(poppins_500.className, "text-ink")}
+            >
+              {filter.label}
+            </Label>
+            <Select
+              value={filters[filter.key] || "all"}
+              onValueChange={(value) => onChange(filter.key, value)}
+            >
+              <SelectTrigger
+                id={`report-filter-${dataset.id}-${filter.key}`}
+                className="w-full"
+                aria-label={`${filter.label} filter`}
+              >
+                <SelectValue placeholder="All" />
+              </SelectTrigger>
+              <SelectContent>
+                {filter.options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ColumnChooser({ dataset, selected, onToggle, onToggleAll }) {
+  const allSelected = selected.length === dataset.columns.length;
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-accent/10 bg-surface-raised p-4 shadow-sm">
+      <div className="flex items-center justify-between gap-2">
+        <p className={cn(poppins_500.className, "text-sm text-ink")}>
+          Output columns
+        </p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="rounded-full text-xs"
+          onClick={onToggleAll}
+        >
+          {allSelected ? "Clear all" : "Select all"}
+        </Button>
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {dataset.columns.map((column) => (
+          <label
+            key={column.key}
+            className="flex cursor-pointer items-center gap-2 rounded-lg border border-accent/10 px-3 py-2 text-sm transition-colors hover:border-accent/30"
+          >
+            <Checkbox
+              checked={selected.includes(column.key)}
+              onCheckedChange={() => onToggle(column.key)}
+            />
+            <span className={cn(poppins_400.className, "text-ink")}>{column.label}</span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PreviewTable({ dataset, columns, rows, loading, error }) {
+  const visibleColumns = dataset.columns.filter((column) =>
+    columns.includes(column.key)
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Eye className="h-5 w-5" />
+          Preview
+        </CardTitle>
+        <CardDescription>
+          Validating query results · up to {PREVIEW_LIMIT} matching rows
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <EmptyState icon={Table2} title="Failed to load preview" description={error} />
+        ) : loading ? (
+          <div className="overflow-x-auto rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {visibleColumns.map((column) => (
+                    <TableHead key={column.key}>{column.label}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <TableRow key={index}>
+                    {visibleColumns.map((column) => (
+                      <TableCell key={column.key} className="py-3">
+                        <Skeleton className="h-4 w-full rounded-full" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        ) : rows.length === 0 ? (
+          <EmptyState
+            icon={Table2}
+            title="No matching rows"
+            description="No rows match these filters and columns. Try adjusting them."
+          />
+        ) : (
+          <div className="overflow-x-auto rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {visibleColumns.map((column) => (
+                    <TableHead key={column.key}>{column.label}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row, index) => (
+                  <TableRow key={`${row.id || index}`}>
+                    {visibleColumns.map((column) => (
+                      <TableCell
+                        key={column.key}
+                        className={cn(poppins_400.className, "text-sm text-ink")}
+                      >
+                        {row[column.key] ?? "—"}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ReportBuilderContent() {
+  const { user } = useAuth();
+  const userId = user?._id || user?.id;
+
+  const [datasetId, setDatasetId] = useState(DEFAULT_DATASET);
+  const [filters, setFilters] = useState(() => defaultFiltersFor(DEFAULT_DATASET));
+  const [selectedColumns, setSelectedColumns] = useState(() =>
+    REPORT_DATASETS[0].columns.map((column) => column.key)
+  );
+
+  const [rows, setRows] = useState([]);
+  const [rowsLoading, setRowsLoading] = useState(true);
+  const [rowsError, setRowsError] = useState(null);
+
+  const [savedQueries, setSavedQueries] = useState([]);
+  const [activeQueryId, setActiveQueryId] = useState(null);
+
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [queryName, setQueryName] = useState("");
+
+  const dataset = useMemo(
+    () => REPORT_DATASETS.find((d) => d.id === datasetId),
+    [datasetId]
+  );
+
+  useEffect(() => {
+    let active = true;
+    if (!userId) return undefined;
+
+    listSavedQueries(userId)
+      .then(({ queries }) => {
+        if (active) setSavedQueries(queries);
+      })
+      .catch(() => {
+        if (active) setSavedQueries([]);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [userId]);
+
+  useEffect(() => {
+    let active = true;
+    setRowsLoading(true);
+    setRowsError(null);
+
+    fetchReportRows(datasetId, filters, { limit: PREVIEW_LIMIT })
+      .then(({ rows: nextRows }) => {
+        if (active) {
+          setRows(nextRows);
+          setRowsLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setRowsError(err?.message || "Failed to load preview");
+          setRowsLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [datasetId, filters]);
+
+  const selectDataset = (id) => {
+    const nextDataset = REPORT_DATASETS.find((d) => d.id === id);
+    setDatasetId(id);
+    setFilters(defaultFiltersFor(id));
+    setSelectedColumns(nextDataset.columns.map((column) => column.key));
+    setActiveQueryId(null);
+  };
+
+  const updateFilter = (key, value) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const toggleColumn = (key) => {
+    setSelectedColumns((prev) =>
+      prev.includes(key) ? prev.filter((c) => c !== key) : [...prev, key]
+    );
+  };
+
+  const toggleAllColumns = () => {
+    setSelectedColumns((prev) =>
+      prev.length === dataset.columns.length
+        ? []
+        : dataset.columns.map((column) => column.key)
+    );
+  };
+
+  const handleSave = async () => {
+    const name = queryName.trim();
+    if (!name) return;
+    try {
+      const { query } = await saveQuery(userId, {
+        name,
+        datasetId,
+        filters,
+        columns: selectedColumns,
+      });
+      setSavedQueries((prev) => [query, ...prev]);
+      setActiveQueryId(query.id);
+      setQueryName("");
+      setSaveOpen(false);
+      toast.success("Query saved");
+    } catch (err) {
+      toast.error(err?.message || "Failed to save query");
+    }
+  };
+
+  const handleLoad = (query) => {
+    setDatasetId(query.datasetId);
+    setFilters(query.filters || defaultFiltersFor(query.datasetId));
+    setSelectedColumns(query.columns || []);
+    setActiveQueryId(query.id);
+    toast.success(`Running "${query.name}"`);
+  };
+
+  const handleDelete = async (queryId) => {
+    try {
+      await deleteSavedQuery(userId, queryId);
+      setSavedQueries((prev) => prev.filter((q) => q.id !== queryId));
+      if (activeQueryId === queryId) setActiveQueryId(null);
+      toast.success("Query deleted");
+    } catch (err) {
+      toast.error(err?.message || "Failed to delete query");
+    }
+  };
+
+  const handleExport = () => {
+    const visibleColumns = dataset.columns.filter((column) =>
+      selectedColumns.includes(column.key)
+    );
+    const headers = visibleColumns.map((column) => column.label);
+    const exportRows = rows.map((row) =>
+      visibleColumns.map((column) => row[column.key] ?? "")
+    );
+    downloadCsv({
+      filename: `${datasetId}-report-${new Date().toISOString().slice(0, 10)}.csv`,
+      headers,
+      rows: exportRows,
+    });
+    toast.success("Report exported as CSV");
+  };
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={Table2}
+        title="Report builder"
+        subtitle="Compose, save, and rerun custom reports from existing datasets"
+        actions={
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={handleExport}
+              disabled={rowsLoading || rows.length === 0 || selectedColumns.length === 0}
+            >
+              <Download className="mr-1 h-4 w-4" />
+              Export CSV
+            </Button>
+            <Button
+              type="button"
+              className="rounded-full"
+              onClick={() => setSaveOpen(true)}
+              disabled={selectedColumns.length === 0}
+            >
+              <Save className="mr-1 h-4 w-4" />
+              Save query
+            </Button>
+          </div>
+        }
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,280px)_1fr]">
+        <SavedQueriesPanel
+          queries={savedQueries}
+          activeQueryId={activeQueryId}
+          onLoad={handleLoad}
+          onDelete={handleDelete}
+          onOpenSave={() => setSaveOpen(true)}
+        />
+
+        <div className="min-w-0 space-y-6">
+          <DatasetSelector value={datasetId} onChange={selectDataset} />
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Filter className="h-5 w-5" />
+                Filters
+              </CardTitle>
+              <CardDescription>
+                Tune the report with the dataset&apos;s filter set
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <FilterControls dataset={dataset} filters={filters} onChange={updateFilter} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <ListChecks className="h-5 w-5" />
+                Columns
+              </CardTitle>
+              <CardDescription>
+                Choose which columns appear in the output
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ColumnChooser
+                dataset={dataset}
+                selected={selectedColumns}
+                onToggle={toggleColumn}
+                onToggleAll={toggleAllColumns}
+              />
+            </CardContent>
+          </Card>
+
+          <PreviewTable
+            dataset={dataset}
+            columns={selectedColumns}
+            rows={rows}
+            loading={rowsLoading}
+            error={rowsError}
+          />
+        </div>
+      </div>
+
+      <Dialog open={saveOpen} onOpenChange={setSaveOpen}>
+        <DialogContent className="border border-accent/10 bg-surface-raised sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Save query</DialogTitle>
+            <DialogDescription>
+              Give this report a name so you can rerun it from the saved list.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label htmlFor="query-name" className={cn(poppins_500.className, "text-ink")}>
+              Query name
+            </Label>
+            <Input
+              id="query-name"
+              value={queryName}
+              onChange={(event) => setQueryName(event.target.value)}
+              placeholder={`e.g. ${dataset.label} — last 30 days`}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && queryName.trim() && selectedColumns.length > 0) {
+                  handleSave();
+                }
+              }}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={() => setSaveOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="rounded-full"
+              onClick={handleSave}
+              disabled={!queryName.trim() || selectedColumns.length === 0}
+            >
+              <Save className="mr-1 h-4 w-4" />
+              Save query
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PageShell>
+  );
+}
+
+export default function ReportBuilderPage() {
+  return (
+    <AdminTierGuard>
+      <ReportBuilderContent />
+    </AdminTierGuard>
+  );
+}

--- a/lib/actions/admin-reports.js
+++ b/lib/actions/admin-reports.js
@@ -1,0 +1,333 @@
+/**
+ * Admin report-builder service — datasets, preview rows, saved queries (#329).
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Composes the custom report builder from the existing pieces the
+ * issue scopes it to: the three datasets (users / transactions / reports),
+ * each with its own filter set and column list. There is deliberately **no**
+ * cross-dataset join, no custom SQL, and no scheduling — the builder only
+ * composes existing filters and columns.
+ *
+ * Saved queries persist per admin user to `localStorage` (`dnb_admin_saved_queries_<userId>`)
+ * so the sidebar round-trips today. Swap for `axiosInstance` calls (see
+ * `lib/config/axios.config.js`) when the backend lands:
+ *
+ *   TODO(backend): GET    /api/admin/saved-queries
+ *   TODO(backend): POST   /api/admin/saved-queries   { name, datasetId, filters, columns }
+ *   TODO(backend): DELETE /api/admin/saved-queries/:id
+ *   TODO(backend): GET    /api/admin/report-rows?dataset=&filters...
+ *
+ * Saved query shape owned by the backend:
+ *   { id: string, name: string, datasetId: "users"|"transactions"|"reports",
+ *     filters: object, columns: string[], createdAt: string }
+ */
+
+const SAVED_QUERIES_PREFIX = "dnb_admin_saved_queries_";
+
+/** The three report datasets and their filter/column definitions. */
+export const REPORT_DATASETS = Object.freeze([
+  {
+    id: "users",
+    label: "Users",
+    description: "Platform user accounts",
+    filters: [
+      {
+        key: "status",
+        label: "Status",
+        type: "select",
+        options: [
+          { value: "all", label: "All statuses" },
+          { value: "active", label: "Active" },
+          { value: "banned", label: "Banned" },
+        ],
+      },
+      { key: "from", label: "Joined from", type: "date" },
+      { key: "to", label: "Joined to", type: "date" },
+    ],
+    columns: [
+      { key: "name", label: "Name" },
+      { key: "email", label: "Email" },
+      { key: "role", label: "Role" },
+      { key: "status", label: "Status" },
+      { key: "joinedAt", label: "Joined" },
+    ],
+    dateColumn: "joinedAt",
+  },
+  {
+    id: "transactions",
+    label: "Transactions",
+    description: "Purchase and payment transactions",
+    filters: [
+      {
+        key: "status",
+        label: "Status",
+        type: "select",
+        options: [
+          { value: "all", label: "All statuses" },
+          { value: "confirmed", label: "Confirmed" },
+          { value: "pending", label: "Pending" },
+          { value: "submitted", label: "Submitted" },
+          { value: "failed", label: "Failed" },
+          { value: "expired", label: "Expired" },
+        ],
+      },
+      {
+        key: "itemType",
+        label: "Item type",
+        type: "select",
+        options: [
+          { value: "all", label: "All types" },
+          { value: "course", label: "Course" },
+          { value: "book", label: "Book" },
+        ],
+      },
+      { key: "from", label: "Date from", type: "date" },
+      { key: "to", label: "Date to", type: "date" },
+    ],
+    columns: [
+      { key: "id", label: "Reference" },
+      { key: "createdAt", label: "Date" },
+      { key: "itemType", label: "Item type" },
+      { key: "itemTitle", label: "Item" },
+      { key: "amount", label: "Amount" },
+      { key: "status", label: "Status" },
+      { key: "buyer", label: "Buyer" },
+    ],
+    dateColumn: "createdAt",
+  },
+  {
+    id: "reports",
+    label: "Reports",
+    description: "Content moderation reports",
+    filters: [
+      {
+        key: "contentType",
+        label: "Content type",
+        type: "select",
+        options: [
+          { value: "all", label: "All content" },
+          { value: "course", label: "Course" },
+          { value: "book", label: "Book" },
+          { value: "space", label: "Space" },
+        ],
+      },
+      {
+        key: "status",
+        label: "Status",
+        type: "select",
+        options: [
+          { value: "all", label: "All statuses" },
+          { value: "open", label: "Open" },
+          { value: "investigating", label: "Investigating" },
+          { value: "resolved", label: "Resolved" },
+          { value: "dismissed", label: "Dismissed" },
+        ],
+      },
+      { key: "from", label: "Reported from", type: "date" },
+      { key: "to", label: "Reported to", type: "date" },
+    ],
+    columns: [
+      { key: "id", label: "ID" },
+      { key: "createdAt", label: "Reported" },
+      { key: "contentType", label: "Content type" },
+      { key: "itemTitle", label: "Item" },
+      { key: "reason", label: "Reason" },
+      { key: "status", label: "Status" },
+      { key: "reportedBy", label: "Reported by" },
+    ],
+    dateColumn: "createdAt",
+  },
+]);
+
+/** Fixed sample rows per dataset so previews are deterministic and filterable. */
+const SAMPLE_ROWS = Object.freeze({
+  users: [
+    { name: "Amina Yusuf", email: "amina@deenbridge.org", role: "student", status: "active", joinedAt: "2025-01-12" },
+    { name: "Bilal Karim", email: "bilal@deenbridge.org", role: "educator", status: "active", joinedAt: "2025-02-03" },
+    { name: "Zaynab Idris", email: "zaynab@deenbridge.org", role: "student", status: "banned", joinedAt: "2025-03-17" },
+    { name: "Umar Farouk", email: "umar@deenbridge.org", role: "student", status: "active", joinedAt: "2025-04-21" },
+    { name: "Khadija Bello", email: "khadija@deenbridge.org", role: "educator", status: "active", joinedAt: "2025-05-09" },
+  ],
+  transactions: [
+    { id: "TX-1001", createdAt: "2025-06-01", itemType: "course", itemTitle: "Tafsir of Surah Al-Fatihah", amount: 24.5, status: "confirmed", buyer: "amina@deenbridge.org" },
+    { id: "TX-1002", createdAt: "2025-06-05", itemType: "book", itemTitle: "The Sealed Nectar", amount: 9.99, status: "pending", buyer: "umar@deenbridge.org" },
+    { id: "TX-1003", createdAt: "2025-06-08", itemType: "course", itemTitle: "Arabic Grammar Essentials", amount: 35.0, status: "confirmed", buyer: "zaynab@deenbridge.org" },
+    { id: "TX-1004", createdAt: "2025-06-12", itemType: "book", itemTitle: "Stories of the Prophets", amount: 7.5, status: "failed", buyer: "khadija@deenbridge.org" },
+    { id: "TX-1005", createdAt: "2025-06-15", itemType: "course", itemTitle: "Fiqh of Worship", amount: 42.0, status: "confirmed", buyer: "bilal@deenbridge.org" },
+  ],
+  reports: [
+    { id: "REP-201", createdAt: "2025-06-02", contentType: "course", itemTitle: "Tafsir of Surah Al-Fatihah", reason: "copyright", status: "open", reportedBy: "umar@deenbridge.org" },
+    { id: "REP-202", createdAt: "2025-06-06", contentType: "book", itemTitle: "The Sealed Nectar", reason: "spam", status: "investigating", reportedBy: "amina@deenbridge.org" },
+    { id: "REP-203", createdAt: "2025-06-09", contentType: "space", itemTitle: "Evening Dhikr Circle", reason: "inappropriate", status: "resolved", reportedBy: "zaynab@deenbridge.org" },
+    { id: "REP-204", createdAt: "2025-06-13", contentType: "book", itemTitle: "Stories of the Prophets", reason: "duplicate", status: "dismissed", reportedBy: "bilal@deenbridge.org" },
+    { id: "REP-205", createdAt: "2025-06-16", contentType: "course", itemTitle: "Fiqh of Worship", reason: "other", status: "open", reportedBy: "khadija@deenbridge.org" },
+  ],
+});
+
+function getDataset(datasetId) {
+  return REPORT_DATASETS.find((dataset) => dataset.id === datasetId);
+}
+
+/**
+ * Build the default (empty) filter object for a dataset.
+ *
+ * @param {string} datasetId
+ * @returns {Record<string, string>}
+ */
+export function defaultFiltersFor(datasetId) {
+  const dataset = getDataset(datasetId);
+  if (!dataset) return {};
+  const defaults = {};
+  for (const filter of dataset.filters) {
+    defaults[filter.key] = filter.type === "select" ? "all" : "";
+  }
+  return defaults;
+}
+
+function isInDateRange(value, from, to) {
+  if (!from && !to) return true;
+  const date = String(value ?? "").slice(0, 10);
+  if (!date) return false;
+  if (from && date < from) return false;
+  if (to && date > to) return false;
+  return true;
+}
+
+/**
+ * Fetch preview rows for a dataset, applying the composed filters. Only the
+ * dataset's own filters are honored — no joins across datasets.
+ *
+ * TODO(backend): GET /api/admin/report-rows?dataset=<id>&<filters...>
+ *   - Auth: admin only.
+ *   - 200 → { rows: Array<Record<string, unknown>> }
+ *   - 403 for non-admins; 422 for an unknown dataset id.
+ *
+ * @param {string} datasetId
+ * @param {Record<string, string>} [filters]
+ * @param {{limit?: number}} [options]
+ * @returns {Promise<{rows: Array<Record<string, unknown>>}>}
+ */
+export async function fetchReportRows(datasetId, filters = {}, options = {}) {
+  const dataset = getDataset(datasetId);
+  if (!dataset) {
+    throw new Error(`Unknown report dataset: ${datasetId}`);
+  }
+
+  let rows = SAMPLE_ROWS[datasetId] || [];
+
+  for (const filter of dataset.filters) {
+    const value = filters[filter.key];
+    if (!value || value === "all") continue;
+
+    if (filter.type === "date") {
+      const { from, to } = filters;
+      rows = rows.filter((row) => isInDateRange(row[dataset.dateColumn], from, to));
+    } else {
+      rows = rows.filter((row) => row[filter.key] === value);
+    }
+  }
+
+  const limit = options.limit || rows.length;
+  return Promise.resolve({ rows: rows.slice(0, limit) });
+}
+
+function readSavedQueries(userId) {
+  if (typeof window === "undefined" || !userId) return [];
+  try {
+    const raw = window.localStorage.getItem(`${SAVED_QUERIES_PREFIX}${userId}`);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeSavedQueries(userId, queries) {
+  if (typeof window === "undefined" || !userId) return;
+  try {
+    window.localStorage.setItem(
+      `${SAVED_QUERIES_PREFIX}${userId}`,
+      JSON.stringify(queries)
+    );
+  } catch {
+    // Storage unavailable (private mode / quota) — saving silently no-ops.
+  }
+}
+
+function generateQueryId() {
+  return `q_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * List the current admin's saved queries (newest first).
+ *
+ * TODO(backend): GET /api/admin/saved-queries
+ *   - Auth: admin only.
+ *   - 200 → { queries: SavedQuery[] }
+ *
+ * @param {string} userId
+ * @returns {Promise<{queries: Array<object>}>}
+ */
+export async function listSavedQueries(userId) {
+  return Promise.resolve({ queries: readSavedQueries(userId) });
+}
+
+/**
+ * Save a named query for the current admin. Requires a non-empty name, a known
+ * dataset, and at least one selected column.
+ *
+ * TODO(backend): POST /api/admin/saved-queries
+ *   - Auth: admin only.
+ *   - Payload: { name, datasetId, filters, columns }
+ *   - 201 → { query: SavedQuery }
+ *   - 422 for a missing name / unknown dataset / empty columns.
+ *
+ * @param {string} userId
+ * @param {{name: string, datasetId: string, filters: object, columns: string[]}} payload
+ * @returns {Promise<{query: object}>}
+ */
+export async function saveQuery(userId, payload) {
+  const name = String(payload?.name || "").trim();
+  const datasetId = payload?.datasetId;
+  const columns = Array.isArray(payload?.columns) ? payload.columns : [];
+  if (!name) {
+    throw new Error("A query name is required.");
+  }
+  if (!getDataset(datasetId)) {
+    throw new Error(`Unknown report dataset: ${datasetId}`);
+  }
+  if (columns.length === 0) {
+    throw new Error("Select at least one column.");
+  }
+
+  const query = {
+    id: generateQueryId(),
+    name,
+    datasetId,
+    filters: { ...(payload.filters || {}) },
+    columns,
+    createdAt: new Date().toISOString(),
+  };
+
+  const queries = readSavedQueries(userId);
+  queries.unshift(query);
+  writeSavedQueries(userId, queries);
+
+  return Promise.resolve({ query });
+}
+
+/**
+ * Delete a saved query owned by the current admin.
+ *
+ * TODO(backend): DELETE /api/admin/saved-queries/:id
+ *   - Auth: admin only; queries are scoped per admin.
+ *   - 200 → { deleted: true, queryId: string }
+ *
+ * @param {string} userId
+ * @param {string} queryId
+ * @returns {Promise<{deleted: boolean, queryId: string}>}
+ */
+export async function deleteSavedQuery(userId, queryId) {
+  const queries = readSavedQueries(userId).filter((query) => query.id !== queryId);
+  writeSavedQueries(userId, queries);
+  return Promise.resolve({ deleted: true, queryId });
+}

--- a/lib/utils/csv.js
+++ b/lib/utils/csv.js
@@ -1,0 +1,50 @@
+/**
+ * CSV export helpers — the standard DeenBridge export path.
+ * ---------------------------------------------------------------------------
+ * Extracted from the export handlers in the audit-log and reconciliation admin
+ * pages so report-style surfaces (including the report builder, #329) share one
+ * quoting/escaping implementation instead of duplicating it inline.
+ */
+
+/**
+ * Quote-escape a single cell for CSV (double-quote wrap + "" escaping).
+ * @param {unknown} cell
+ * @returns {string}
+ */
+function escapeCell(cell) {
+  return `"${String(cell ?? "").replace(/"/g, '""')}"`;
+}
+
+/**
+ * Build a CSV document from headers and row arrays.
+ *
+ * @param {string[]} headers
+ * @param {Array<Array<unknown>>} rows
+ * @returns {string}
+ */
+export function rowsToCsv(headers, rows) {
+  const lines = [headers.map(escapeCell).join(",")];
+  for (const row of rows) {
+    lines.push(row.map(escapeCell).join(","));
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Serialize and trigger a browser download of the given rows as CSV.
+ *
+ * @param {{filename: string, headers: string[], rows: Array<Array<unknown>>}} options
+ */
+export function downloadCsv({ filename, headers, rows }) {
+  const csv = rowsToCsv(headers, rows);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.setAttribute("href", url);
+  link.setAttribute("download", filename);
+  link.style.visibility = "hidden";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
﻿## Overview

This PR adds a **Custom Report Builder (saved queries)** for super-admins that composes the existing report datasets — **users / transactions / reports** — into named, saved queries: pick a dataset, tune its filters, choose output columns, preview the rows, then save and rerun from a sidebar. Exports reuse the standard CSV path via a shared helper extracted from the existing admin export handlers.

Strict scope discipline is respected: **no cross-dataset joins, no custom SQL, and no scheduling** — the builder only composes existing filters and columns.

## Related Issue

Closes #329

## Changes

* **[ADD]** `app/[locale]/dashboard/admin/report-builder/page.jsx`
  * Dataset picker (users / transactions / reports) with per-dataset description
  * Filter selection composed from each dataset's own filter set (select + date-range), mirroring the audit-logs filter controls
  * Column chooser with select-all / clear-all for customizing output
  * Preview table that validates query results (loading skeleton, empty and error states)
  * Save-query dialog for named, per-admin queries
  * Sidebar list of saved queries to rerun or delete
  * Export button reusing the standard CSV path
* **[ADD]** `lib/actions/admin-reports.js`
  * `REPORT_DATASETS` metadata (filters + columns) for the three datasets
  * `fetchReportRows()` — filtered preview rows honoring the dataset's own filters only
  * Per-admin saved-query CRUD (`listSavedQueries` / `saveQuery` / `deleteSavedQuery`) persisted to `localStorage`, with documented backend contract (`GET/POST/DELETE /api/admin/saved-queries`)
* **[ADD]** `lib/utils/csv.js`
  * `rowsToCsv` + `downloadCsv` — the standard DeenBridge CSV quoting/escaping path, extracted from the audit-log and reconciliation export handlers so report surfaces share one implementation
* **[ADD]** `__tests__/admin/admin-reports.service.test.js` — dataset contract, filter application, saved-query round-trip/validation/per-admin scoping
* **[ADD]** `__tests__/utils/csv.test.js` — CSV serializer quoting/escaping
* **[ADD]** `__tests__/admin/ReportBuilderPage.test.jsx` — dataset selector, filter + column controls, preview, saved-query load/delete/save, CSV export

## Verification Results

```
npx vitest --run __tests__/admin/admin-reports.service.test.js __tests__/utils/csv.test.js __tests__/admin/ReportBuilderPage.test.jsx
✅ 25/25 passed

npx next build --no-lint
✅ Compiled successfully — /[locale]/dashboard/admin/report-builder route included (SSG, en + ar)

npm run lint  → new files clean (remaining errors are pre-existing on main)
npm run a11y  → new page clean (remaining errors are pre-existing on main)
```

> Note: the full `npm run build` is currently blocked on main by a pre-existing syntax error in `lib/admin/messages/common.js:101` (unescaped quotes in `EMPTY_SEARCH_NO_RESULTS`) — unrelated to this PR, left untouched.

| Acceptance Criteria | Status |
| --- | --- |
| Dataset picker functional (users/transactions/reports) | ✅ Users, Transactions, Reports selectable |
| Filter selection uses existing module filter sets | ✅ Per-dataset select + date-range filters |
| Column chooser allows custom output configuration | ✅ Checkbox chooser with select-all/clear-all |
| Preview table displays query results | ✅ Table with loading/empty/error states |
| Named queries can be saved per admin | ✅ Per-admin localStorage store, scoped by user id |
| Saved queries accessible from sidebar list | ✅ Sidebar list to rerun / delete |
| Export uses standard CSV export path | ✅ Shared `lib/utils/csv.js` helper |
| No cross-dataset joins, custom SQL, or scheduling features | ✅ Not implemented — composition only |
