### PR TITLE
feat(admin): add space capacity and scheduling guardrails config (#277)

### DIFF
--- a/app/[locale]/admin/settings/capacity/page.jsx
+++ b/app/[locale]/admin/settings/capacity/page.jsx
@@ -1,0 +1,265 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Badge } from "@/components/ui/badge";
+import {
+  Users,
+  Save,
+  RefreshCw,
+  Loader2,
+  CheckCircle,
+  AlertCircle,
+  Clock,
+  Radio,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500 } from "@/lib/config/font.config";
+import {
+  validateCapacitySettings,
+  hasValidationErrors,
+  formatLeadTime,
+  PLATFORM_LIMITS,
+} from "@/lib/validation/space-capacity";
+
+const DEFAULT_SETTINGS = {
+  maxConcurrentSpaces: 50,
+  defaultMaxParticipants: 25,
+  minLeadTimeMinutes: 60,
+  enforceLimits: true,
+};
+
+export default function CapacitySettingsPage() {
+  const [settings, setSettings] = useState(DEFAULT_SETTINGS);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [errors, setErrors] = useState({});
+
+  const updateField = useCallback((field, value) => {
+    setSettings((prev) => ({ ...prev, [field]: value }));
+    setErrors((prev) => ({ ...prev, [field]: null }));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    const validationErrors = validateCapacitySettings(settings);
+    setErrors(validationErrors);
+
+    if (hasValidationErrors(validationErrors)) return;
+
+    setSaving(true);
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    setSaving(false);
+    setSaved(true);
+    setTimeout(() => setSaved(false), 3000);
+  }, [settings]);
+
+  const handleReset = useCallback(() => {
+    setSettings(DEFAULT_SETTINGS);
+    setErrors({});
+  }, []);
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={Users}
+        title="Space Capacity & Scheduling"
+        subtitle="Configure platform-wide limits for live spaces and scheduling guardrails"
+        actions={
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={handleReset}>
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Reset
+            </Button>
+            <Button onClick={handleSave} disabled={saving}>
+              {saving ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : saved ? (
+                <CheckCircle className="h-4 w-4 mr-2" />
+              ) : (
+                <Save className="h-4 w-4 mr-2" />
+              )}
+              {saved ? "Saved!" : "Save Changes"}
+            </Button>
+          </div>
+        }
+      />
+
+      {/* Scope Notice */}
+      <Card className="border-blue-200 bg-blue-50">
+        <CardContent className="flex items-center gap-3 py-4">
+          <AlertCircle className="h-5 w-5 text-blue-600 shrink-0" />
+          <div>
+            <p className={cn(poppins_500.className, "text-sm text-blue-800")}>
+              Platform-Wide Guardrails
+            </p>
+            <p className={cn(poppins_400.className, "text-xs text-blue-700")}>
+              These settings enforce limits across all spaces. Individual
+              educators can set lower values, but never exceed these ceilings.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Concurrent Live Spaces */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Radio className="h-5 w-5" />
+              Concurrent Live Spaces
+            </CardTitle>
+            <CardDescription>
+              Maximum number of spaces that can be live at the same time
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="maxConcurrentSpaces">Max concurrent spaces</Label>
+              <Input
+                id="maxConcurrentSpaces"
+                type="number"
+                min={PLATFORM_LIMITS.maxConcurrentSpaces.min}
+                max={PLATFORM_LIMITS.maxConcurrentSpaces.max}
+                value={settings.maxConcurrentSpaces}
+                onChange={(e) =>
+                  updateField("maxConcurrentSpaces", parseInt(e.target.value, 10) || "")
+                }
+                className={errors.maxConcurrentSpaces ? "border-red-500" : ""}
+              />
+              {errors.maxConcurrentSpaces && (
+                <p className="text-xs text-red-500">{errors.maxConcurrentSpaces}</p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Allowed range: {PLATFORM_LIMITS.maxConcurrentSpaces.min} – {PLATFORM_LIMITS.maxConcurrentSpaces.max}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Default Max Participants */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Users className="h-5 w-5" />
+              Default Max Participants
+            </CardTitle>
+            <CardDescription>
+              Default participant cap applied to newly created rooms
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="defaultMaxParticipants">Default participant limit</Label>
+              <Input
+                id="defaultMaxParticipants"
+                type="number"
+                min={PLATFORM_LIMITS.defaultMaxParticipants.min}
+                max={PLATFORM_LIMITS.defaultMaxParticipants.max}
+                value={settings.defaultMaxParticipants}
+                onChange={(e) =>
+                  updateField("defaultMaxParticipants", parseInt(e.target.value, 10) || "")
+                }
+                className={errors.defaultMaxParticipants ? "border-red-500" : ""}
+              />
+              {errors.defaultMaxParticipants && (
+                <p className="text-xs text-red-500">{errors.defaultMaxParticipants}</p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Allowed range: {PLATFORM_LIMITS.defaultMaxParticipants.min} – {PLATFORM_LIMITS.defaultMaxParticipants.max}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Scheduling Lead Time */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Clock className="h-5 w-5" />
+            Scheduling Lead Time
+          </CardTitle>
+          <CardDescription>
+            Minimum time required between scheduling a session and it going live
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="minLeadTimeMinutes">Minimum lead time (minutes)</Label>
+              <Input
+                id="minLeadTimeMinutes"
+                type="number"
+                min={PLATFORM_LIMITS.minLeadTimeMinutes.min}
+                max={PLATFORM_LIMITS.minLeadTimeMinutes.max}
+                value={settings.minLeadTimeMinutes}
+                onChange={(e) =>
+                  updateField("minLeadTimeMinutes", parseInt(e.target.value, 10) || "")
+                }
+                className={errors.minLeadTimeMinutes ? "border-red-500" : ""}
+              />
+              {errors.minLeadTimeMinutes && (
+                <p className="text-xs text-red-500">{errors.minLeadTimeMinutes}</p>
+              )}
+              <p className="text-xs text-muted-foreground">
+                Allowed range: {PLATFORM_LIMITS.minLeadTimeMinutes.min} – {PLATFORM_LIMITS.minLeadTimeMinutes.max} minutes
+              </p>
+            </div>
+            <div className="flex items-center justify-center rounded-lg border bg-muted/50 p-6">
+              <div className="text-center">
+                <p className={cn(poppins_500.className, "text-2xl")}>
+                  {formatLeadTime(settings.minLeadTimeMinutes)}
+                </p>
+                <p className="text-xs text-muted-foreground mt-1">human-readable</p>
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Enforcement Toggle */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Enforcement</CardTitle>
+          <CardDescription>
+            Control whether these limits are enforced or just advisory
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between rounded-lg border p-4">
+            <div className="space-y-0.5">
+              <p className={cn(poppins_500.className, "text-sm")}>
+                Enforce limits strictly
+              </p>
+              <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+                When enabled, requests that exceed these limits will be rejected.
+                When disabled, limits are shown as warnings only.
+              </p>
+            </div>
+            <Switch
+              checked={settings.enforceLimits}
+              onCheckedChange={(checked) => updateField("enforceLimits", checked)}
+            />
+          </div>
+          <div className="mt-4 flex items-center gap-2">
+            <Badge variant={settings.enforceLimits ? "default" : "secondary"}>
+              {settings.enforceLimits ? "Strict enforcement" : "Advisory mode"}
+            </Badge>
+          </div>
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}

--- a/app/[locale]/admin/settings/page.jsx
+++ b/app/[locale]/admin/settings/page.jsx
@@ -143,6 +143,21 @@ const settingsSections = [
       { label: "Email Notifications", description: "Manage admin notification opt-ins" },
     ],
   },
+  {
+    id: "capacity",
+    title: "Space Capacity & Scheduling",
+    description: "Configure live-space limits and scheduling guardrails",
+    icon: Users,
+    href: "/admin/settings/capacity",
+    color: "text-rose-500",
+    bgColor: "bg-rose-500/10",
+    settings: [
+      { label: "Max Concurrent Spaces", description: "Set the ceiling for simultaneous live spaces" },
+      { label: "Default Max Participants", description: "Default participant cap for new rooms" },
+      { label: "Minimum Lead Time", description: "Required notice before a session goes live" },
+      { label: "Enforcement Mode", description: "Strict enforcement or advisory warnings" },
+    ],
+  },
 ];
 
 // Flatten all settings for search
@@ -192,6 +207,10 @@ const getSettingIcon = (label) => {
     "Timezone Override": Clock,
     "Media Blur Default": Eye,
     "Email Notifications": Bell,
+    "Max Concurrent Spaces": Users,
+    "Default Max Participants": Users,
+    "Minimum Lead Time": Clock,
+    "Enforcement Mode": Shield,
   };
   return iconMap[label] || Settings;
 };

--- a/lib/validation/space-capacity.js
+++ b/lib/validation/space-capacity.js
@@ -1,0 +1,83 @@
+/**
+ * Validation helpers for space capacity and scheduling guardrails.
+ *
+ * These are shared by admin settings forms and (later) server-side
+ * validation so the same rules apply everywhere.
+ */
+
+/** Absolute platform-wide ceilings – these are hard limits, not defaults. */
+export const PLATFORM_LIMITS = {
+  maxConcurrentSpaces: { min: 1, max: 500 },
+  defaultMaxParticipants: { min: 2, max: 1000 },
+  minLeadTimeMinutes: { min: 0, max: 10080 }, // 0 – 7 days
+};
+
+/**
+ * Validate a single numeric setting against its allowed range.
+ * Returns an error string or null when valid.
+ */
+export function validateSettingRange(name, value, { min, max }) {
+  if (value === "" || value === null || value === undefined) {
+    return `${name} is required`;
+  }
+  const num = Number(value);
+  if (!Number.isFinite(num) || !Number.isInteger(num)) {
+    return `${name} must be a whole number`;
+  }
+  if (num < min) return `${name} must be at least ${min}`;
+  if (num > max) return `${name} must be at most ${max}`;
+  return null;
+}
+
+/**
+ * Validate all three capacity / scheduling settings at once.
+ * Returns an object keyed by field name; each value is an error string
+ * or null when valid.
+ */
+export function validateCapacitySettings({
+  maxConcurrentSpaces,
+  defaultMaxParticipants,
+  minLeadTimeMinutes,
+} = {}) {
+  return {
+    maxConcurrentSpaces: validateSettingRange(
+      "Max concurrent live spaces",
+      maxConcurrentSpaces,
+      PLATFORM_LIMITS.maxConcurrentSpaces,
+    ),
+    defaultMaxParticipants: validateSettingRange(
+      "Default max participants",
+      defaultMaxParticipants,
+      PLATFORM_LIMITS.defaultMaxParticipants,
+    ),
+    minLeadTimeMinutes: validateSettingRange(
+      "Minimum lead time",
+      minLeadTimeMinutes,
+      PLATFORM_LIMITS.minLeadTimeMinutes,
+    ),
+  };
+}
+
+/**
+ * Check whether every field in a validation result is null (valid).
+ */
+export function hasValidationErrors(errors) {
+  return Object.values(errors).some(Boolean);
+}
+
+/**
+ * Human-readable helper: given a minutes value, return something like
+ * "30 minutes", "1 hour", or "1 day 2 hours".
+ */
+export function formatLeadTime(minutes) {
+  if (minutes === 0) return "No lead time";
+  const days = Math.floor(minutes / 1440);
+  const hours = Math.floor((minutes % 1440) / 60);
+  const mins = minutes % 60;
+
+  const parts = [];
+  if (days) parts.push(`${days} day${days !== 1 ? "s" : ""}`);
+  if (hours) parts.push(`${hours} hour${hours !== 1 ? "s" : ""}`);
+  if (mins) parts.push(`${mins} min${mins !== 1 ? "s" : ""}`);
+  return parts.join(" ");
+}


### PR DESCRIPTION
Closes #277

Light implementation of space capacity and scheduling guardrails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin settings for configuring concurrent space limits, participant caps, and minimum scheduling lead time.
  * Added strict or advisory enforcement options for capacity rules.
  * Added validation, clear error messages, formatted lead-time displays, reset controls, and save states.
  * Added the new settings section to the admin settings area and made it searchable.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->