### PR TITLE
feat(admin): add space reports deep-link integration (#276)

### DIFF
--- a/app/[locale]/dashboard/spaces/page.jsx
+++ b/app/[locale]/dashboard/spaces/page.jsx
@@ -1,9 +1,10 @@
 "use client";
 import React, { useState, useEffect } from "react";
-import { Globe, Plus } from "lucide-react";
+import { Globe, Plus, Flag } from "lucide-react";
 import SpaceCard from "@/components/molecules/dashboard/cards/spaceCard";
 import CourseCardSkeleton from "@/components/atoms/skeletons/CourseCardSkeleton";
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
 import { PageShell } from "@/components/ui/page-shell";
 import { PageHeader } from "@/components/ui/page-header";
 import { CardGrid } from "@/components/ui/card-grid";
@@ -15,6 +16,7 @@ import useAuth from "@/hooks/useAuth";
 import { useCan } from "@/hooks/useCan";
 import { CAPABILITIES } from "@/lib/auth/roles";
 import NetworkErrorComp from "@/components/molecules/errors/NetworkError";
+import useFlaggedContent from "@/hooks/useFlaggedContent";
 import { cn } from "@/lib/utils";
 
 const tabnames = [
@@ -66,9 +68,14 @@ const Page = () => {
     );
   }
 
-  const filteredSpaces = spaces.filter((space) =>
+  const tabFiltered = spaces.filter((space) =>
     selectedTab === "all" ? true : space?.status === selectedTab
   );
+
+  const { flaggedCount, showFlaggedOnly, toggleFlaggedOnly, filteredItems } =
+    useFlaggedContent(tabFiltered);
+
+  const filteredSpaces = filteredItems;
 
   return (
     <PageShell>
@@ -91,7 +98,7 @@ const Page = () => {
       />
 
       {/* Tab Filters */}
-      <div className="flex gap-2">
+      <div className="flex gap-2 flex-wrap">
         {tabnames.map((tab) => (
           <Button
             key={tab.value}
@@ -105,6 +112,32 @@ const Page = () => {
             {tab.label}
           </Button>
         ))}
+        {flaggedCount > 0 && (
+          <Button
+            variant={showFlaggedOnly ? "default" : "outline"}
+            className={cn(
+              "rounded-full gap-1.5",
+              showFlaggedOnly
+                ? "bg-red-500 text-white hover:bg-red-600"
+                : "border-red-200 text-red-600 hover:bg-red-50"
+            )}
+            onClick={toggleFlaggedOnly}
+          >
+            <Flag className="h-3.5 w-3.5" />
+            Flagged
+            <Badge
+              variant="secondary"
+              className={cn(
+                "ml-1 text-xs px-1.5 py-0",
+                showFlaggedOnly
+                  ? "bg-white/20 text-white"
+                  : "bg-red-100 text-red-600"
+              )}
+            >
+              {flaggedCount}
+            </Badge>
+          </Button>
+        )}
       </div>
 
       {loading ? (

--- a/components/molecules/dashboard/cards/spaceCard.jsx
+++ b/components/molecules/dashboard/cards/spaceCard.jsx
@@ -8,7 +8,7 @@ import {
   AvatarFallback,
   AvatarImage,
 } from "@/components/ui/avatar";
-import { VideoIcon, Clock, CirclePlus } from "lucide-react";
+import { VideoIcon, Clock, CirclePlus, Flag } from "lucide-react";
 import { format } from "date-fns";
 import { cn } from "@/lib/utils";
 import {
@@ -54,16 +54,24 @@ const SpaceCard = ({ space }) => {
         <div className="pointer-events-none absolute inset-0 z-10 bg-gradient-to-t from-black/80 via-black/10 to-transparent" />
         {/* Category + Status */}
         <div className="absolute left-4 right-4 top-4 z-20 flex items-center justify-between">
-          {category && (
-            <span
-              className={cn(
-                poppins_600,
-                "rounded-full border border-accent/15 bg-surface-raised/80 px-3 py-1 text-xs uppercase tracking-wider text-ink shadow-sm"
-              )}
-            >
-              {category}
-            </span>
-          )}
+          <div className="flex items-center gap-2">
+            {category && (
+              <span
+                className={cn(
+                  poppins_600,
+                  "rounded-full border border-accent/15 bg-surface-raised/80 px-3 py-1 text-xs uppercase tracking-wider text-ink shadow-sm"
+                )}
+              >
+                {category}
+              </span>
+            )}
+            {space.flagCount > 0 && (
+              <span className="flex items-center gap-1 rounded-full bg-red-500/90 px-2.5 py-1 text-xs font-medium text-white shadow-sm">
+                <Flag className="h-3 w-3" />
+                {space.flagCount}
+              </span>
+            )}
+          </div>
           {status && (
             <div
               className={cn(

--- a/hooks/useFlaggedContent.js
+++ b/hooks/useFlaggedContent.js
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useCallback, useMemo } from "react";
+
+/**
+ * Shared hook for flag-integration across content types (courses, reels, spaces).
+ *
+ * Provides flag counts, flagged-only filtering, and toggle state for any list
+ * of items that carry a `flagCount` property.
+ *
+ * @param {Array<{flagCount?: number}>} items - The full list of content items.
+ * @param {object} [options]
+ * @param {boolean} [options.initialFlaggedOnly=false]
+ * @returns {{
+ *   flaggedCount: number,
+ *   showFlaggedOnly: boolean,
+ *   toggleFlaggedOnly: () => void,
+ *   filteredItems: Array,
+ * }}
+ */
+export default function useFlaggedContent(items = [], { initialFlaggedOnly = false } = {}) {
+  const [showFlaggedOnly, setShowFlaggedOnly] = useState(initialFlaggedOnly);
+
+  const flaggedCount = useMemo(
+    () => items.filter((item) => (item.flagCount ?? 0) > 0).length,
+    [items]
+  );
+
+  const filteredItems = useMemo(
+    () =>
+      showFlaggedOnly
+        ? items.filter((item) => (item.flagCount ?? 0) > 0)
+        : items,
+    [items, showFlaggedOnly]
+  );
+
+  const toggleFlaggedOnly = useCallback(() => {
+    setShowFlaggedOnly((prev) => !prev);
+  }, []);
+
+  return { flaggedCount, showFlaggedOnly, toggleFlaggedOnly, filteredItems };
+}


### PR DESCRIPTION
Closes #276

Light implementation of space reports integration with shared flag pattern.

- Added `useFlaggedContent` shared hook for flag-integration across content types
- Added Flagged filter toggle to spaces list for flagged-only queue mode
- Added flag count badge on SpaceCard for visible report counts
- Follows existing report-queue patterns from the unified reports page