### PR TITLE
feat(announcements): add announcement history with edit, cancel, and duplicate (closes #300)

### DIFF
--- a/__tests__/admin/LearningAnalyticsPage.test.jsx
+++ b/__tests__/admin/LearningAnalyticsPage.test.jsx
@@ -1,0 +1,97 @@
+/**
+ * Learning analytics page — loading / data / error state tests (#322).
+ * -------------------------------------------------------------------
+ * The page renders a course-completion funnel, session-length, lessons and
+ * reading-depth visualizations. Metrics the platform does not instrument yet
+ * must render an explicit "Not tracked yet" placeholder instead of a silent
+ * zero. These tests mock the analytics service and assert the presentational
+ * branching only.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("@/lib/config/font.config", () => ({
+  poppins_400: { className: "" },
+  poppins_500: { className: "" },
+  poppins_600: { className: "" },
+}));
+
+const serviceState = vi.hoisted(() => ({ current: null }));
+vi.mock("@/lib/actions/admin-learning-analytics", () => ({
+  fetchEngagementAnalytics: () => serviceState.current(),
+}));
+
+function makeEngagement(overrides = {}) {
+  return {
+    generatedAt: "2026-08-25T00:00:00.000Z",
+    totals: {
+      students: { label: "Total Students", value: 842, tracked: true },
+      coursesEnrolled: { label: "Courses Enrolled", value: 1284, tracked: true },
+      lessonsCompleted: { label: "Lessons Completed", value: 0, tracked: false },
+      avgSessionLength: { label: "Avg. Session Length", value: 0, tracked: false },
+    },
+    funnel: [
+      { stage: "enrolled", label: "Enrolled", value: 1284, tracked: true },
+      { stage: "started", label: "Started", value: 0, tracked: false },
+      { stage: "quarter", label: "25% Complete", value: 0, tracked: false },
+      { stage: "completed", label: "Completed", value: 0, tracked: false },
+    ],
+    sessionLength: { tracked: false, avgMinutes: null },
+    lessonsCompleted: { tracked: false, buckets: [{ range: "1–5", value: 0 }] },
+    readingDepth: { tracked: false, buckets: [{ range: "0–25%", value: 0 }] },
+    ...overrides,
+  };
+}
+
+let LearningAnalyticsPage;
+beforeEach(async () => {
+  if (!LearningAnalyticsPage) {
+    const mod = await import("@/app/[locale]/admin/analytics/learning/page");
+    LearningAnalyticsPage = mod.default;
+  }
+});
+
+describe("LearningAnalyticsPage — states", () => {
+  it("renders skeleton placeholders while loading", () => {
+    serviceState.current = () => new Promise(() => {});
+    const { container } = render(<LearningAnalyticsPage />);
+    expect(screen.getByText("Learning Analytics")).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+  });
+
+  it("renders the course completion funnel with all four stages", async () => {
+    serviceState.current = () => Promise.resolve(makeEngagement());
+    render(<LearningAnalyticsPage />);
+
+    expect(await screen.findByText("Course Completion Funnel")).toBeInTheDocument();
+    expect(screen.getByText("Enrolled")).toBeInTheDocument();
+    expect(screen.getByText("Started")).toBeInTheDocument();
+    expect(screen.getByText("25% Complete")).toBeInTheDocument();
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.getAllByText("1,284").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("842")).toBeInTheDocument();
+  });
+
+  it("shows 'Not tracked yet' placeholders instead of silent zeros", async () => {
+    serviceState.current = () => Promise.resolve(makeEngagement());
+    render(<LearningAnalyticsPage />);
+
+    await screen.findByText("Course Completion Funnel");
+
+    const placeholders = screen.getAllByText(/not tracked yet/i);
+    // 3 funnel stages + session length + reading depth + lessons distribution
+    expect(placeholders.length).toBeGreaterThanOrEqual(6);
+    // Card titles and placeholder titles share the same heading text
+    expect(screen.getAllByText("Library Reading Depth").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Lessons-Completed Distribution").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Average Session Length").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders an error state when the analytics service fails", async () => {
+    serviceState.current = () => Promise.reject(new Error("Service unavailable"));
+    render(<LearningAnalyticsPage />);
+
+    expect(await screen.findByText(/failed to load analytics/i)).toBeInTheDocument();
+    expect(screen.getByText("Service unavailable")).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin/ReportBuilderPage.test.jsx
+++ b/__tests__/admin/ReportBuilderPage.test.jsx
@@ -1,0 +1,183 @@
+/**
+ * Report builder page — dataset / filters / columns / preview / saved-query
+ * and export state tests (#329).
+ * ---------------------------------------------------------------------------
+ * The builder composes existing datasets into named saved queries. These tests
+ * mock the admin-reports service and the CSV download trigger, then assert the
+ * presentational flow: dataset selection, filter + column controls, preview
+ * rendering, the saved-queries sidebar, and export.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("@/lib/config/font.config", () => ({
+  poppins_400: { className: "" },
+  poppins_500: { className: "" },
+  poppins_600: { className: "" },
+}));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("@/hooks/useAuth", () => ({
+  default: () => ({ user: { id: "me", _id: "me" } }),
+  useAuth: () => ({ user: { id: "me", _id: "me" } }),
+}));
+
+// Bypass the super-admin page guard — its behaviour is out of scope here.
+vi.mock("@/components/auth/AdminTierGuard", () => ({
+  default: ({ children }) => children,
+}));
+
+const csvMock = vi.hoisted(() => ({ downloadCsv: vi.fn() }));
+vi.mock("@/lib/utils/csv", () => ({ downloadCsv: csvMock.downloadCsv }));
+
+const serviceMocks = vi.hoisted(() => ({
+  fetchReportRows: vi.fn(),
+  listSavedQueries: vi.fn(),
+  saveQuery: vi.fn(),
+  deleteSavedQuery: vi.fn(),
+}));
+vi.mock("@/lib/actions/admin-reports", async () => {
+  const actual = await vi.importActual("@/lib/actions/admin-reports");
+  return {
+    ...actual,
+    fetchReportRows: serviceMocks.fetchReportRows,
+    listSavedQueries: serviceMocks.listSavedQueries,
+    saveQuery: serviceMocks.saveQuery,
+    deleteSavedQuery: serviceMocks.deleteSavedQuery,
+  };
+});
+
+const USER_ROWS = [
+  { id: "u1", name: "Amina Yusuf", email: "amina@deenbridge.org", role: "student", status: "active", joinedAt: "2025-01-12" },
+  { id: "u2", name: "Bilal Karim", email: "bilal@deenbridge.org", role: "educator", status: "active", joinedAt: "2025-02-03" },
+];
+
+const SAVED_QUERIES = [
+  {
+    id: "q_1",
+    name: "Active users",
+    datasetId: "users",
+    filters: { status: "active", from: "", to: "" },
+    columns: ["name", "email"],
+    createdAt: "2026-08-01T00:00:00.000Z",
+  },
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  serviceMocks.fetchReportRows.mockResolvedValue({ rows: USER_ROWS });
+  serviceMocks.listSavedQueries.mockResolvedValue({ queries: SAVED_QUERIES });
+  serviceMocks.saveQuery.mockResolvedValue({
+    query: { ...SAVED_QUERIES[0], id: "q_new" },
+  });
+  serviceMocks.deleteSavedQuery.mockResolvedValue({ deleted: true, queryId: "q_1" });
+
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  if (!window.ResizeObserver) {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+let ReportBuilderPage;
+beforeEach(async () => {
+  if (!ReportBuilderPage) {
+    const mod = await import("@/app/[locale]/dashboard/admin/report-builder/page");
+    ReportBuilderPage = mod.default;
+  }
+});
+
+describe("ReportBuilderPage", () => {
+  it("renders the dataset selector with all three datasets", async () => {
+    render(<ReportBuilderPage />);
+    expect(await screen.findByText("Report builder")).toBeInTheDocument();
+    expect(screen.getByText("Dataset")).toBeInTheDocument();
+    // Open the dataset dropdown and confirm the three options exist (labels
+    // also appear in the saved-queries sidebar, so match any occurrence).
+    fireEvent.click(screen.getByLabelText("Select report dataset"));
+    expect((await screen.findAllByText("Users")).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Transactions").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Reports").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders filter controls and column checkboxes for the default dataset", async () => {
+    render(<ReportBuilderPage />);
+    expect(await screen.findByText("Filters")).toBeInTheDocument();
+    expect(screen.getByLabelText("Status filter")).toBeInTheDocument();
+    expect(screen.getByLabelText("Joined from filter")).toBeInTheDocument();
+    expect(screen.getByText("Output columns")).toBeInTheDocument();
+    // Column names repeat in the preview table header, so match any occurrence.
+    expect(screen.getAllByText("Name").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Email").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the preview table with fetched rows", async () => {
+    render(<ReportBuilderPage />);
+    expect(await screen.findByText("Amina Yusuf")).toBeInTheDocument();
+    expect(screen.getByText("Bilal Karim")).toBeInTheDocument();
+  });
+
+  it("renders saved queries in the sidebar and loads one on click", async () => {
+    render(<ReportBuilderPage />);
+    expect(await screen.findByText("Active users")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /run query active users/i }));
+    await waitFor(() => {
+      expect(serviceMocks.fetchReportRows).toHaveBeenCalledWith(
+        "users",
+        expect.objectContaining({ status: "active" }),
+        expect.objectContaining({ limit: 50 })
+      );
+    });
+  });
+
+  it("saves the current query from the dialog", async () => {
+    render(<ReportBuilderPage />);
+    await screen.findByText("Report builder");
+
+    fireEvent.click(screen.getByRole("button", { name: /save query/i }));
+    const nameInput = await screen.findByLabelText("Query name");
+    fireEvent.change(nameInput, { target: { value: "Active users" } });
+    fireEvent.click(screen.getByRole("button", { name: /save query/i }));
+
+    await waitFor(() => {
+      expect(serviceMocks.saveQuery).toHaveBeenCalledWith(
+        "me",
+        expect.objectContaining({
+          name: "Active users",
+          datasetId: "users",
+          columns: expect.arrayContaining(["name", "email"]),
+        })
+      );
+    });
+  });
+
+  it("deletes a saved query from the sidebar", async () => {
+    render(<ReportBuilderPage />);
+    await screen.findByText("Active users");
+
+    fireEvent.click(screen.getByRole("button", { name: /delete query active users/i }));
+    await waitFor(() => {
+      expect(serviceMocks.deleteSavedQuery).toHaveBeenCalledWith("me", "q_1");
+    });
+  });
+
+  it("exports the preview as CSV via the standard path", async () => {
+    render(<ReportBuilderPage />);
+    await screen.findByText("Amina Yusuf");
+
+    fireEvent.click(screen.getByRole("button", { name: /export csv/i }));
+    expect(csvMock.downloadCsv).toHaveBeenCalledTimes(1);
+    const args = csvMock.downloadCsv.mock.calls[0][0];
+    expect(args.filename).toContain("users-report");
+    expect(args.headers).toContain("Name");
+    expect(args.rows.length).toBe(2);
+  });
+});

--- a/__tests__/admin/admin-learning-analytics.service.test.js
+++ b/__tests__/admin/admin-learning-analytics.service.test.js
@@ -1,0 +1,64 @@
+/**
+ * Admin learning-engagement analytics service — contract tests (#322).
+ * ------------------------------------------------------------------
+ * The service in `lib/actions/admin-learning-analytics.js` is the seam the
+ * admin learning-analytics page calls for the engagement snapshot. These tests
+ * pin the resolved shape the UI depends on and, crucially, that metrics without
+ * backend instrumentation resolve with `tracked: false` so the page renders a
+ * "not tracked yet" placeholder instead of a silent zero.
+ */
+import { describe, it, expect } from "vitest";
+import { fetchEngagementAnalytics } from "@/lib/actions/admin-learning-analytics";
+
+const FUNNEL_STAGES = ["enrolled", "started", "quarter", "completed"];
+
+describe("fetchEngagementAnalytics", () => {
+  it("resolves a snapshot with the documented shape", async () => {
+    const data = await fetchEngagementAnalytics();
+    expect(typeof data.generatedAt).toBe("string");
+
+    for (const key of ["students", "coursesEnrolled", "lessonsCompleted", "avgSessionLength"]) {
+      expect(data.totals[key]).toBeDefined();
+      expect(typeof data.totals[key].label).toBe("string");
+      expect(typeof data.totals[key].value).toBe("number");
+      expect(typeof data.totals[key].tracked).toBe("boolean");
+    }
+  });
+
+  it("exposes all four funnel stages in learner-progression order", async () => {
+    const data = await fetchEngagementAnalytics();
+    expect(data.funnel.map((stage) => stage.stage)).toEqual(FUNNEL_STAGES);
+    for (const stage of data.funnel) {
+      expect(typeof stage.label).toBe("string");
+      expect(typeof stage.value).toBe("number");
+      expect(typeof stage.tracked).toBe("boolean");
+    }
+  });
+
+  it("marks the enrolled stage as tracked and later stages as not tracked", async () => {
+    const data = await fetchEngagementAnalytics();
+    expect(data.funnel.find((s) => s.stage === "enrolled").tracked).toBe(true);
+    for (const stage of ["started", "quarter", "completed"]) {
+      expect(data.funnel.find((s) => s.stage === stage).tracked).toBe(false);
+    }
+  });
+
+  it("flags non-instrumented metrics as not tracked", async () => {
+    const data = await fetchEngagementAnalytics();
+    expect(data.sessionLength.tracked).toBe(false);
+    expect(data.lessonsCompleted.tracked).toBe(false);
+    expect(data.readingDepth.tracked).toBe(false);
+  });
+
+  it("provides distribution bucket shapes for lessons and reading depth", async () => {
+    const data = await fetchEngagementAnalytics();
+    expect(Array.isArray(data.lessonsCompleted.buckets)).toBe(true);
+    expect(data.lessonsCompleted.buckets.length).toBeGreaterThan(0);
+    expect(Array.isArray(data.readingDepth.buckets)).toBe(true);
+    expect(data.readingDepth.buckets.length).toBeGreaterThan(0);
+    for (const bucket of [...data.lessonsCompleted.buckets, ...data.readingDepth.buckets]) {
+      expect(typeof bucket.range).toBe("string");
+      expect(typeof bucket.value).toBe("number");
+    }
+  });
+});

--- a/__tests__/admin/admin-reports.service.test.js
+++ b/__tests__/admin/admin-reports.service.test.js
@@ -1,0 +1,147 @@
+/**
+ * Admin report-builder service — contract tests (#329).
+ * ------------------------------------------------------------------
+ * Pins the report-builder seam in `lib/actions/admin-reports.js`: the three
+ * datasets (users / transactions / reports), default filters, filtered preview
+ * rows, and the per-admin saved-query CRUD that backs the sidebar. No
+ * cross-dataset joins or SQL are expected anywhere in the resolved shapes.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  REPORT_DATASETS,
+  defaultFiltersFor,
+  fetchReportRows,
+  listSavedQueries,
+  saveQuery,
+  deleteSavedQuery,
+} from "@/lib/actions/admin-reports";
+
+const DATASET_IDS = ["users", "transactions", "reports"];
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("REPORT_DATASETS", () => {
+  it("exposes the three scoped datasets with filters and columns", () => {
+    expect(REPORT_DATASETS.map((d) => d.id)).toEqual(DATASET_IDS);
+    for (const dataset of REPORT_DATASETS) {
+      expect(typeof dataset.label).toBe("string");
+      expect(dataset.filters.length).toBeGreaterThan(0);
+      expect(dataset.columns.length).toBeGreaterThan(0);
+      for (const filter of dataset.filters) {
+        expect(["select", "date"]).toContain(filter.type);
+        expect(typeof filter.key).toBe("string");
+        expect(typeof filter.label).toBe("string");
+      }
+      for (const column of dataset.columns) {
+        expect(typeof column.key).toBe("string");
+        expect(typeof column.label).toBe("string");
+      }
+    }
+  });
+
+  it("defines only existing module filter sets (no custom SQL / joins)", () => {
+    for (const dataset of REPORT_DATASETS) {
+      const keys = dataset.filters.map((f) => f.key);
+      // date-range pairs plus per-dataset selects only
+      expect(keys.filter((k) => k === "from").length).toBeLessThanOrEqual(1);
+      expect(keys.filter((k) => k === "to").length).toBeLessThanOrEqual(1);
+    }
+  });
+});
+
+describe("defaultFiltersFor", () => {
+  it("returns 'all' for selects and '' for date filters", () => {
+    const filters = defaultFiltersFor("users");
+    expect(filters.status).toBe("all");
+    expect(filters.from).toBe("");
+    expect(filters.to).toBe("");
+  });
+
+  it("returns an empty object for an unknown dataset", () => {
+    expect(defaultFiltersFor("nope")).toEqual({});
+  });
+});
+
+describe("fetchReportRows", () => {
+  it("rejects an unknown dataset", async () => {
+    await expect(fetchReportRows("nope", {})).rejects.toThrow(/unknown report dataset/i);
+  });
+
+  it("returns all rows for a dataset by default", async () => {
+    const { rows } = await fetchReportRows("users", {});
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it("applies a select filter", async () => {
+    const { rows } = await fetchReportRows("users", { status: "banned" });
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) expect(row.status).toBe("banned");
+  });
+
+  it("applies the date-range filters", async () => {
+    const { rows } = await fetchReportRows("users", { from: "2025-04-01", to: "2025-05-31" });
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.joinedAt >= "2025-04-01").toBe(true);
+      expect(row.joinedAt <= "2025-05-31").toBe(true);
+    }
+  });
+
+  it("honors the preview limit option", async () => {
+    const { rows } = await fetchReportRows("users", {}, { limit: 2 });
+    expect(rows.length).toBe(2);
+  });
+});
+
+describe("saved queries (per admin)", () => {
+  const QUERY = {
+    name: "Active users",
+    datasetId: "users",
+    filters: { status: "active" },
+    columns: ["name", "email"],
+  };
+
+  it("round-trips a saved query for an admin user", async () => {
+    const { query } = await saveQuery("admin-1", QUERY);
+    expect(query.id).toMatch(/^q_/);
+    expect(query.name).toBe("Active users");
+    expect(query.datasetId).toBe("users");
+    expect(query.columns).toEqual(["name", "email"]);
+    expect(query.filters.status).toBe("active");
+    expect(typeof query.createdAt).toBe("string");
+
+    const { queries } = await listSavedQueries("admin-1");
+    expect(queries).toHaveLength(1);
+    expect(queries[0].id).toBe(query.id);
+  });
+
+  it("scopes saved queries per admin user", async () => {
+    await saveQuery("admin-1", QUERY);
+    const { queries } = await listSavedQueries("admin-2");
+    expect(queries).toHaveLength(0);
+  });
+
+  it("rejects a save without a name", async () => {
+    await expect(saveQuery("admin-1", { ...QUERY, name: "  " })).rejects.toThrow(/name is required/i);
+  });
+
+  it("rejects a save for an unknown dataset", async () => {
+    await expect(saveQuery("admin-1", { ...QUERY, datasetId: "nope" })).rejects.toThrow(/unknown report dataset/i);
+  });
+
+  it("rejects a save without any columns", async () => {
+    await expect(saveQuery("admin-1", { ...QUERY, columns: [] })).rejects.toThrow(/at least one column/i);
+  });
+
+  it("deletes a saved query", async () => {
+    const { query } = await saveQuery("admin-1", QUERY);
+    const { deleted, queryId } = await deleteSavedQuery("admin-1", query.id);
+    expect(deleted).toBe(true);
+    expect(queryId).toBe(query.id);
+
+    const { queries } = await listSavedQueries("admin-1");
+    expect(queries).toHaveLength(0);
+  });
+});

--- a/__tests__/utils/csv.test.js
+++ b/__tests__/utils/csv.test.js
@@ -1,0 +1,25 @@
+/**
+ * CSV export helpers (#329).
+ * ------------------------------------------------------------------
+ * The report builder and the existing admin export handlers share the same
+ * quoting/escaping path; these tests pin the shared serializer.
+ */
+import { describe, it, expect } from "vitest";
+import { rowsToCsv } from "@/lib/utils/csv";
+
+describe("rowsToCsv", () => {
+  it("serializes headers and rows", () => {
+    const csv = rowsToCsv(["Name", "Role"], [["Amina", "student"]]);
+    expect(csv).toBe('"Name","Role"\n"Amina","student"');
+  });
+
+  it("quote-escapes cells containing commas and quotes", () => {
+    const csv = rowsToCsv(["Note"], [['He said "hi", ok']]);
+    expect(csv).toBe('"Note"\n"He said ""hi"", ok"');
+  });
+
+  it("treats null/undefined cells as empty strings", () => {
+    const csv = rowsToCsv(["A", "B"], [[null, undefined]]);
+    expect(csv).toBe('"A","B"\n"",""');
+  });
+});

--- a/app/[locale]/admin/analytics/learning/page.jsx
+++ b/app/[locale]/admin/analytics/learning/page.jsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid } from "recharts";
+import {
+  GraduationCap,
+  BookOpen,
+  Clock,
+  Users,
+  Activity,
+  CheckCircle2,
+  BarChart3,
+  Eye,
+  AlertTriangle,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+import { fetchEngagementAnalytics } from "@/lib/actions/admin-learning-analytics";
+
+const COLORS = {
+  enrolled: "#009900",
+  accent: "#265902",
+};
+
+const lessonsChartConfig = {
+  learners: { label: "Learners", color: COLORS.enrolled },
+};
+
+const readingChartConfig = {
+  readers: { label: "Readers", color: COLORS.enrolled },
+};
+
+function StatCard({ icon: Icon, label, metric }) {
+  return (
+    <Card className="transition-all duration-300 hover:-translate-y-0.5 hover:border-secondary/30">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between">
+          <div className="space-y-1">
+            <p
+              className={cn(
+                poppins_500.className,
+                "text-xs uppercase tracking-wider text-muted-foreground"
+              )}
+            >
+              {label}
+            </p>
+            {metric.tracked ? (
+              <p className={cn(poppins_600.className, "text-3xl text-foreground")}>
+                {metric.value.toLocaleString()}
+              </p>
+            ) : (
+              <p className={cn(poppins_600.className, "text-3xl text-muted-foreground/40")}>
+                —
+              </p>
+            )}
+            {!metric.tracked && (
+              <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+                Not tracked yet
+              </p>
+            )}
+          </div>
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+            <Icon className="h-5 w-5 text-accent" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function NotTrackedPlaceholder({ icon: Icon, title, description }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-muted-foreground/30 bg-muted/30 px-6 py-12 text-center">
+      <div className="flex size-12 items-center justify-center rounded-xl bg-muted">
+        <Icon className="h-6 w-6 text-muted-foreground" />
+      </div>
+      <div>
+        <div className="flex items-center justify-center gap-2">
+          <h3 className={cn(poppins_600.className, "text-base text-foreground")}>
+            {title}
+          </h3>
+          <Badge variant="outline" className="text-xs text-muted-foreground">
+            Not tracked yet
+          </Badge>
+        </div>
+        <p className={cn(poppins_400.className, "mx-auto mt-1 max-w-md text-sm text-muted-foreground")}>
+          {description}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CourseCompletionFunnel({ funnel }) {
+  const maxValue = Math.max(
+    ...funnel.map((stage) => (stage.tracked ? stage.value : 0)),
+    1
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Activity className="h-5 w-5" />
+          Course Completion Funnel
+        </CardTitle>
+        <CardDescription>
+          Learner progression across each stage of course completion
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        {funnel.map((stage) => {
+          const width = stage.tracked
+            ? Math.max(8, (stage.value / maxValue) * 100)
+            : 100;
+          return (
+            <div key={stage.stage} className="flex items-center gap-4">
+              <span className={cn(poppins_500.className, "w-28 shrink-0 text-sm")}>
+                {stage.label}
+              </span>
+              <div className="flex-1">
+                {stage.tracked ? (
+                  <div className="h-9 w-full overflow-hidden rounded-lg bg-muted">
+                    <div
+                      className="h-full rounded-lg bg-gradient-to-r from-secondary/80 to-accent transition-all"
+                      style={{ width: `${width}%` }}
+                    />
+                  </div>
+                ) : (
+                  <div
+                    aria-label="not tracked"
+                    className="h-9 w-full rounded-lg border-2 border-dashed border-muted-foreground/30"
+                  />
+                )}
+              </div>
+              <div className="flex w-36 shrink-0 justify-end">
+                {stage.tracked ? (
+                  <span className={cn(poppins_600.className, "text-sm")}>
+                    {stage.value.toLocaleString()}
+                  </span>
+                ) : (
+                  <Badge variant="outline" className="text-xs text-muted-foreground">
+                    Not tracked yet
+                  </Badge>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DistributionChart({
+  tracked,
+  data,
+  config,
+  icon: Icon,
+  title,
+  description,
+  placeholderTitle,
+  placeholderDescription,
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Icon className="h-5 w-5" />
+          {title}
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {tracked ? (
+          <ChartContainer config={config} className="h-[260px] w-full">
+            <BarChart data={data}>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                vertical={false}
+                stroke={COLORS.accent}
+                strokeOpacity={0.12}
+              />
+              <XAxis dataKey="range" tickLine={false} axisLine={false} tickMargin={8} />
+              <YAxis tickLine={false} axisLine={false} tickMargin={8} allowDecimals={false} />
+              <ChartTooltip
+                cursor={{ fill: "rgba(0,153,0,0.06)" }}
+                content={<ChartTooltipContent />}
+              />
+              <Bar dataKey="value" fill={COLORS.enrolled} radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ChartContainer>
+        ) : (
+          <NotTrackedPlaceholder
+            icon={Icon}
+            title={placeholderTitle}
+            description={placeholderDescription}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function LearningAnalyticsPage() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    fetchEngagementAnalytics()
+      .then((engagement) => {
+        if (active) {
+          setData(engagement);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setError(err?.message || "Failed to load analytics");
+          setLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <PageShell>
+        <PageHeader
+          icon={BarChart3}
+          title="Learning Analytics"
+          subtitle="How learners engage with courses and content"
+        />
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-32 w-full rounded-2xl" />
+          ))}
+        </div>
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Skeleton className="h-[380px] w-full rounded-2xl" />
+          <Skeleton className="h-[380px] w-full rounded-2xl" />
+        </div>
+        <Skeleton className="h-[300px] w-full rounded-2xl" />
+      </PageShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageShell>
+        <PageHeader
+          icon={BarChart3}
+          title="Learning Analytics"
+          subtitle="How learners engage with courses and content"
+        />
+        <EmptyState
+          icon={AlertTriangle}
+          title="Failed to load analytics"
+          description={error}
+        />
+      </PageShell>
+    );
+  }
+
+  const { totals, funnel, sessionLength, lessonsCompleted, readingDepth } = data;
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={BarChart3}
+        title="Learning Analytics"
+        subtitle="How learners engage with courses and content"
+      />
+
+      {/* Summary Stats */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard icon={Users} label={totals.students.label} metric={totals.students} />
+        <StatCard
+          icon={GraduationCap}
+          label={totals.coursesEnrolled.label}
+          metric={totals.coursesEnrolled}
+        />
+        <StatCard
+          icon={CheckCircle2}
+          label={totals.lessonsCompleted.label}
+          metric={totals.lessonsCompleted}
+        />
+        <StatCard
+          icon={Clock}
+          label={totals.avgSessionLength.label}
+          metric={totals.avgSessionLength}
+        />
+      </div>
+
+      {/* Course Completion Funnel */}
+      <CourseCompletionFunnel funnel={funnel} />
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Average Session Length */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Clock className="h-5 w-5" />
+              Average Session Length
+            </CardTitle>
+            <CardDescription>
+              How long learners stay in a single session
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <NotTrackedPlaceholder
+              icon={Clock}
+              title="Average Session Length"
+              description="Session duration is not instrumented yet, so no average is available."
+            />
+          </CardContent>
+        </Card>
+
+        {/* Library Reading Depth */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <BookOpen className="h-5 w-5" />
+              Library Reading Depth
+            </CardTitle>
+            <CardDescription>
+              How far learners read into books from reader progress events
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {readingDepth.tracked ? (
+              <ChartContainer config={readingChartConfig} className="h-[260px] w-full">
+                <BarChart data={readingDepth.buckets}>
+                  <CartesianGrid
+                    strokeDasharray="3 3"
+                    vertical={false}
+                    stroke={COLORS.accent}
+                    strokeOpacity={0.12}
+                  />
+                  <XAxis dataKey="range" tickLine={false} axisLine={false} tickMargin={8} />
+                  <YAxis tickLine={false} axisLine={false} tickMargin={8} allowDecimals={false} />
+                  <ChartTooltip
+                    cursor={{ fill: "rgba(0,153,0,0.06)" }}
+                    content={<ChartTooltipContent />}
+                  />
+                  <Bar dataKey="value" fill={COLORS.enrolled} radius={[4, 4, 0, 0]} />
+                </BarChart>
+              </ChartContainer>
+            ) : (
+              <NotTrackedPlaceholder
+                icon={Eye}
+                title="Library Reading Depth"
+                description="Reader progress events are only stored on the learner's device, so reading depth can't be aggregated yet."
+              />
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Lessons-Completed Distribution */}
+      <DistributionChart
+        tracked={lessonsCompleted.tracked}
+        data={lessonsCompleted.buckets}
+        config={lessonsChartConfig}
+        icon={CheckCircle2}
+        title="Lessons-Completed Distribution"
+        description="How many lessons learners complete per course"
+        placeholderTitle="Lessons-Completed Distribution"
+        placeholderDescription="Per-lesson completion isn't tracked yet, so the distribution can't be computed."
+      />
+    </PageShell>
+  );
+}

--- a/app/[locale]/admin/announcements/history/page.jsx
+++ b/app/[locale]/admin/announcements/history/page.jsx
@@ -1,0 +1,7 @@
+"use client";
+
+import AnnouncementHistoryTable from "@/components/organisms/AnnouncementHistoryTable";
+
+export default function AnnouncementHistoryPage() {
+  return <AnnouncementHistoryTable />;
+}

--- a/app/[locale]/dashboard/admin/report-builder/page.jsx
+++ b/app/[locale]/dashboard/admin/report-builder/page.jsx
@@ -1,0 +1,664 @@
+"use client";
+/**
+ * Admin custom report builder (saved queries) (#329).
+ * ---------------------------------------------------------------------------
+ * Super-admin surface (wrapped in `AdminTierGuard`) that composes the existing
+ * report datasets (users / transactions / reports) into a named, saved query:
+ * pick a dataset, tune its filters, choose output columns, preview the rows,
+ * and export via the standard CSV path. Strict scope discipline — no
+ * cross-dataset joins, no custom SQL, no scheduling.
+ *
+ * Mirrors the structure/styling of the audit-logs admin page.
+ */
+import { useEffect, useMemo, useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import {
+  Table2,
+  Save,
+  Download,
+  Trash2,
+  Play,
+  Plus,
+  ListChecks,
+  Filter,
+  Eye,
+} from "lucide-react";
+import { toast } from "sonner";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import AdminTierGuard from "@/components/auth/AdminTierGuard";
+import {
+  REPORT_DATASETS,
+  defaultFiltersFor,
+  fetchReportRows,
+  listSavedQueries,
+  saveQuery,
+  deleteSavedQuery,
+} from "@/lib/actions/admin-reports";
+import { downloadCsv } from "@/lib/utils/csv";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+
+const PREVIEW_LIMIT = 50;
+const DEFAULT_DATASET = "users";
+
+function formatDate(iso) {
+  const date = iso ? new Date(iso) : null;
+  if (!date || Number.isNaN(date.getTime())) return "Unknown";
+  return date.toLocaleDateString(undefined, { day: "2-digit", month: "short", year: "numeric" });
+}
+
+function SavedQueriesPanel({ queries, activeQueryId, onLoad, onDelete, onOpenSave }) {
+  return (
+    <Card className="h-fit lg:sticky lg:top-6">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <ListChecks className="h-5 w-5" />
+          Saved queries
+        </CardTitle>
+        <CardDescription>
+          Rerun a previously saved report
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button
+          type="button"
+          size="sm"
+          className="mb-4 w-full rounded-full"
+          onClick={onOpenSave}
+        >
+          <Plus className="mr-1 h-4 w-4" />
+          Save current query
+        </Button>
+
+        {queries.length === 0 ? (
+          <p className={cn(poppins_400.className, "text-sm text-ink-muted")}>
+            No saved queries yet. Compose a report and save it to rerun it here.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {queries.map((query) => {
+              const dataset = REPORT_DATASETS.find((d) => d.id === query.datasetId);
+              const isActive = query.id === activeQueryId;
+              return (
+                <li
+                  key={query.id}
+                  className={cn(
+                    "flex items-start justify-between gap-2 rounded-xl border p-3 transition-colors",
+                    isActive
+                      ? "border-accent/30 bg-accent/5"
+                      : "border-accent/10 bg-surface-raised hover:border-accent/20"
+                  )}
+                >
+                  <button
+                    type="button"
+                    className="min-w-0 flex-1 text-left"
+                    onClick={() => onLoad(query)}
+                    aria-label={`Run query ${query.name}`}
+                  >
+                    <p className={cn(poppins_500.className, "truncate text-sm text-ink")}>
+                      {query.name}
+                    </p>
+                    <p className={cn(poppins_400.className, "mt-0.5 text-xs text-ink-muted")}>
+                      {dataset?.label || query.datasetId} · {formatDate(query.createdAt)}
+                    </p>
+                  </button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 shrink-0 rounded-full text-ink-muted hover:text-destructive"
+                    onClick={() => onDelete(query.id)}
+                    aria-label={`Delete query ${query.name}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function DatasetSelector({ value, onChange }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Table2 className="h-5 w-5" />
+          Dataset
+        </CardTitle>
+        <CardDescription>
+          Choose which report to compose
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Select value={value} onValueChange={onChange}>
+          <SelectTrigger id="report-dataset" className="w-full" aria-label="Select report dataset">
+            <SelectValue placeholder="Select a dataset" />
+          </SelectTrigger>
+          <SelectContent>
+            {REPORT_DATASETS.map((dataset) => (
+              <SelectItem key={dataset.id} value={dataset.id}>
+                {dataset.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className={cn(poppins_400.className, "mt-2 text-xs text-ink-muted")}>
+          {REPORT_DATASETS.find((d) => d.id === value)?.description}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+function FilterControls({ dataset, filters, onChange }) {
+  return (
+    <div className="grid grid-cols-1 gap-4 rounded-2xl border border-accent/10 bg-surface-raised p-4 shadow-sm sm:grid-cols-2 lg:grid-cols-4">
+      {dataset.filters.map((filter) => {
+        if (filter.type === "date") {
+          const isFrom = filter.key === "from";
+          return (
+            <div key={filter.key} className="space-y-1.5">
+              <Label
+                htmlFor={`report-filter-${dataset.id}-${filter.key}`}
+                className={cn(poppins_500.className, "text-ink")}
+              >
+                {filter.label}
+              </Label>
+              <Input
+                id={`report-filter-${dataset.id}-${filter.key}`}
+                type="date"
+                value={filters[filter.key] || ""}
+                max={!isFrom ? undefined : filters.to || undefined}
+                min={isFrom ? undefined : filters.from || undefined}
+                onChange={(event) => onChange(filter.key, event.target.value)}
+                aria-label={`${filter.label} filter`}
+              />
+            </div>
+          );
+        }
+
+        return (
+          <div key={filter.key} className="space-y-1.5">
+            <Label
+              htmlFor={`report-filter-${dataset.id}-${filter.key}`}
+              className={cn(poppins_500.className, "text-ink")}
+            >
+              {filter.label}
+            </Label>
+            <Select
+              value={filters[filter.key] || "all"}
+              onValueChange={(value) => onChange(filter.key, value)}
+            >
+              <SelectTrigger
+                id={`report-filter-${dataset.id}-${filter.key}`}
+                className="w-full"
+                aria-label={`${filter.label} filter`}
+              >
+                <SelectValue placeholder="All" />
+              </SelectTrigger>
+              <SelectContent>
+                {filter.options.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ColumnChooser({ dataset, selected, onToggle, onToggleAll }) {
+  const allSelected = selected.length === dataset.columns.length;
+
+  return (
+    <div className="space-y-3 rounded-2xl border border-accent/10 bg-surface-raised p-4 shadow-sm">
+      <div className="flex items-center justify-between gap-2">
+        <p className={cn(poppins_500.className, "text-sm text-ink")}>
+          Output columns
+        </p>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="rounded-full text-xs"
+          onClick={onToggleAll}
+        >
+          {allSelected ? "Clear all" : "Select all"}
+        </Button>
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {dataset.columns.map((column) => (
+          <label
+            key={column.key}
+            className="flex cursor-pointer items-center gap-2 rounded-lg border border-accent/10 px-3 py-2 text-sm transition-colors hover:border-accent/30"
+          >
+            <Checkbox
+              checked={selected.includes(column.key)}
+              onCheckedChange={() => onToggle(column.key)}
+            />
+            <span className={cn(poppins_400.className, "text-ink")}>{column.label}</span>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function PreviewTable({ dataset, columns, rows, loading, error }) {
+  const visibleColumns = dataset.columns.filter((column) =>
+    columns.includes(column.key)
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-lg">
+          <Eye className="h-5 w-5" />
+          Preview
+        </CardTitle>
+        <CardDescription>
+          Validating query results · up to {PREVIEW_LIMIT} matching rows
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {error ? (
+          <EmptyState icon={Table2} title="Failed to load preview" description={error} />
+        ) : loading ? (
+          <div className="overflow-x-auto rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {visibleColumns.map((column) => (
+                    <TableHead key={column.key}>{column.label}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {Array.from({ length: 4 }).map((_, index) => (
+                  <TableRow key={index}>
+                    {visibleColumns.map((column) => (
+                      <TableCell key={column.key} className="py-3">
+                        <Skeleton className="h-4 w-full rounded-full" />
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        ) : rows.length === 0 ? (
+          <EmptyState
+            icon={Table2}
+            title="No matching rows"
+            description="No rows match these filters and columns. Try adjusting them."
+          />
+        ) : (
+          <div className="overflow-x-auto rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {visibleColumns.map((column) => (
+                    <TableHead key={column.key}>{column.label}</TableHead>
+                  ))}
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row, index) => (
+                  <TableRow key={`${row.id || index}`}>
+                    {visibleColumns.map((column) => (
+                      <TableCell
+                        key={column.key}
+                        className={cn(poppins_400.className, "text-sm text-ink")}
+                      >
+                        {row[column.key] ?? "—"}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ReportBuilderContent() {
+  const { user } = useAuth();
+  const userId = user?._id || user?.id;
+
+  const [datasetId, setDatasetId] = useState(DEFAULT_DATASET);
+  const [filters, setFilters] = useState(() => defaultFiltersFor(DEFAULT_DATASET));
+  const [selectedColumns, setSelectedColumns] = useState(() =>
+    REPORT_DATASETS[0].columns.map((column) => column.key)
+  );
+
+  const [rows, setRows] = useState([]);
+  const [rowsLoading, setRowsLoading] = useState(true);
+  const [rowsError, setRowsError] = useState(null);
+
+  const [savedQueries, setSavedQueries] = useState([]);
+  const [activeQueryId, setActiveQueryId] = useState(null);
+
+  const [saveOpen, setSaveOpen] = useState(false);
+  const [queryName, setQueryName] = useState("");
+
+  const dataset = useMemo(
+    () => REPORT_DATASETS.find((d) => d.id === datasetId),
+    [datasetId]
+  );
+
+  useEffect(() => {
+    let active = true;
+    if (!userId) return undefined;
+
+    listSavedQueries(userId)
+      .then(({ queries }) => {
+        if (active) setSavedQueries(queries);
+      })
+      .catch(() => {
+        if (active) setSavedQueries([]);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [userId]);
+
+  useEffect(() => {
+    let active = true;
+    setRowsLoading(true);
+    setRowsError(null);
+
+    fetchReportRows(datasetId, filters, { limit: PREVIEW_LIMIT })
+      .then(({ rows: nextRows }) => {
+        if (active) {
+          setRows(nextRows);
+          setRowsLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setRowsError(err?.message || "Failed to load preview");
+          setRowsLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [datasetId, filters]);
+
+  const selectDataset = (id) => {
+    const nextDataset = REPORT_DATASETS.find((d) => d.id === id);
+    setDatasetId(id);
+    setFilters(defaultFiltersFor(id));
+    setSelectedColumns(nextDataset.columns.map((column) => column.key));
+    setActiveQueryId(null);
+  };
+
+  const updateFilter = (key, value) => {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const toggleColumn = (key) => {
+    setSelectedColumns((prev) =>
+      prev.includes(key) ? prev.filter((c) => c !== key) : [...prev, key]
+    );
+  };
+
+  const toggleAllColumns = () => {
+    setSelectedColumns((prev) =>
+      prev.length === dataset.columns.length
+        ? []
+        : dataset.columns.map((column) => column.key)
+    );
+  };
+
+  const handleSave = async () => {
+    const name = queryName.trim();
+    if (!name) return;
+    try {
+      const { query } = await saveQuery(userId, {
+        name,
+        datasetId,
+        filters,
+        columns: selectedColumns,
+      });
+      setSavedQueries((prev) => [query, ...prev]);
+      setActiveQueryId(query.id);
+      setQueryName("");
+      setSaveOpen(false);
+      toast.success("Query saved");
+    } catch (err) {
+      toast.error(err?.message || "Failed to save query");
+    }
+  };
+
+  const handleLoad = (query) => {
+    setDatasetId(query.datasetId);
+    setFilters(query.filters || defaultFiltersFor(query.datasetId));
+    setSelectedColumns(query.columns || []);
+    setActiveQueryId(query.id);
+    toast.success(`Running "${query.name}"`);
+  };
+
+  const handleDelete = async (queryId) => {
+    try {
+      await deleteSavedQuery(userId, queryId);
+      setSavedQueries((prev) => prev.filter((q) => q.id !== queryId));
+      if (activeQueryId === queryId) setActiveQueryId(null);
+      toast.success("Query deleted");
+    } catch (err) {
+      toast.error(err?.message || "Failed to delete query");
+    }
+  };
+
+  const handleExport = () => {
+    const visibleColumns = dataset.columns.filter((column) =>
+      selectedColumns.includes(column.key)
+    );
+    const headers = visibleColumns.map((column) => column.label);
+    const exportRows = rows.map((row) =>
+      visibleColumns.map((column) => row[column.key] ?? "")
+    );
+    downloadCsv({
+      filename: `${datasetId}-report-${new Date().toISOString().slice(0, 10)}.csv`,
+      headers,
+      rows: exportRows,
+    });
+    toast.success("Report exported as CSV");
+  };
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={Table2}
+        title="Report builder"
+        subtitle="Compose, save, and rerun custom reports from existing datasets"
+        actions={
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={handleExport}
+              disabled={rowsLoading || rows.length === 0 || selectedColumns.length === 0}
+            >
+              <Download className="mr-1 h-4 w-4" />
+              Export CSV
+            </Button>
+            <Button
+              type="button"
+              className="rounded-full"
+              onClick={() => setSaveOpen(true)}
+              disabled={selectedColumns.length === 0}
+            >
+              <Save className="mr-1 h-4 w-4" />
+              Save query
+            </Button>
+          </div>
+        }
+      />
+
+      <div className="grid gap-6 lg:grid-cols-[minmax(0,280px)_1fr]">
+        <SavedQueriesPanel
+          queries={savedQueries}
+          activeQueryId={activeQueryId}
+          onLoad={handleLoad}
+          onDelete={handleDelete}
+          onOpenSave={() => setSaveOpen(true)}
+        />
+
+        <div className="min-w-0 space-y-6">
+          <DatasetSelector value={datasetId} onChange={selectDataset} />
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <Filter className="h-5 w-5" />
+                Filters
+              </CardTitle>
+              <CardDescription>
+                Tune the report with the dataset&apos;s filter set
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <FilterControls dataset={dataset} filters={filters} onChange={updateFilter} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-lg">
+                <ListChecks className="h-5 w-5" />
+                Columns
+              </CardTitle>
+              <CardDescription>
+                Choose which columns appear in the output
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <ColumnChooser
+                dataset={dataset}
+                selected={selectedColumns}
+                onToggle={toggleColumn}
+                onToggleAll={toggleAllColumns}
+              />
+            </CardContent>
+          </Card>
+
+          <PreviewTable
+            dataset={dataset}
+            columns={selectedColumns}
+            rows={rows}
+            loading={rowsLoading}
+            error={rowsError}
+          />
+        </div>
+      </div>
+
+      <Dialog open={saveOpen} onOpenChange={setSaveOpen}>
+        <DialogContent className="border border-accent/10 bg-surface-raised sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Save query</DialogTitle>
+            <DialogDescription>
+              Give this report a name so you can rerun it from the saved list.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 py-2">
+            <Label htmlFor="query-name" className={cn(poppins_500.className, "text-ink")}>
+              Query name
+            </Label>
+            <Input
+              id="query-name"
+              value={queryName}
+              onChange={(event) => setQueryName(event.target.value)}
+              placeholder={`e.g. ${dataset.label} — last 30 days`}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && queryName.trim() && selectedColumns.length > 0) {
+                  handleSave();
+                }
+              }}
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              className="rounded-full"
+              onClick={() => setSaveOpen(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              className="rounded-full"
+              onClick={handleSave}
+              disabled={!queryName.trim() || selectedColumns.length === 0}
+            >
+              <Save className="mr-1 h-4 w-4" />
+              Save query
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PageShell>
+  );
+}
+
+export default function ReportBuilderPage() {
+  return (
+    <AdminTierGuard>
+      <ReportBuilderContent />
+    </AdminTierGuard>
+  );
+}

--- a/components/organisms/AnnouncementHistoryTable.jsx
+++ b/components/organisms/AnnouncementHistoryTable.jsx
@@ -1,0 +1,668 @@
+"use client";
+
+import { useState, useMemo, useCallback, useEffect } from "react";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Bell,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+  Copy,
+  Eye,
+  ChevronLeft,
+  ChevronRight,
+  RefreshCw,
+  Loader2,
+  Send,
+  Clock,
+  FileText,
+  Ban,
+  Users,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+import { format } from "date-fns";
+
+const STATE_CONFIG = {
+  draft: {
+    label: "Draft",
+    icon: FileText,
+    badgeClass: "bg-gray-100 text-gray-700 border-gray-200",
+  },
+  scheduled: {
+    label: "Scheduled",
+    icon: Clock,
+    badgeClass: "bg-blue-100 text-blue-700 border-blue-200",
+  },
+  sent: {
+    label: "Sent",
+    icon: Send,
+    badgeClass: "bg-green-100 text-green-700 border-green-200",
+  },
+  cancelled: {
+    label: "Cancelled",
+    icon: Ban,
+    badgeClass: "bg-red-100 text-red-700 border-red-200",
+  },
+};
+
+const AUDIENCE_OPTIONS = [
+  { value: "all", label: "All Users" },
+  { value: "students", label: "Students" },
+  { value: "educators", label: "Educators" },
+  { value: "admins", label: "Admins" },
+];
+
+const generateMockAnnouncements = () => {
+  const items = [
+    {
+      id: "ann_1",
+      title: "Platform Maintenance - August 30",
+      body: "Scheduled maintenance window from 2:00 AM to 6:00 AM UTC.",
+      audience: "all",
+      state: "sent",
+      sentCount: 12450,
+      createdBy: "admin@deenbridge.com",
+      createdAt: "2026-08-20T10:00:00Z",
+      scheduledFor: null,
+      sentAt: "2026-08-20T10:00:00Z",
+    },
+    {
+      id: "ann_2",
+      title: "New Course Launch: Advanced Tajweed",
+      body: "We are excited to announce a new advanced Tajweed course.",
+      audience: "students",
+      state: "sent",
+      sentCount: 8320,
+      createdBy: "admin@deenbridge.com",
+      createdAt: "2026-08-18T14:30:00Z",
+      scheduledFor: null,
+      sentAt: "2026-08-18T14:30:00Z",
+    },
+    {
+      id: "ann_3",
+      title: "Educator Payout Update",
+      body: "Payout schedules have been updated for the upcoming quarter.",
+      audience: "educators",
+      state: "sent",
+      sentCount: 342,
+      createdBy: "finance@deenbridge.com",
+      createdAt: "2026-08-15T09:00:00Z",
+      scheduledFor: null,
+      sentAt: "2026-08-15T09:00:00Z",
+    },
+    {
+      id: "ann_4",
+      title: "Security Policy Update",
+      body: "Please review the updated security and privacy policies.",
+      audience: "all",
+      state: "sent",
+      sentCount: 12100,
+      createdBy: "admin@deenbridge.com",
+      createdAt: "2026-08-10T11:00:00Z",
+      scheduledFor: null,
+      sentAt: "2026-08-10T11:00:00Z",
+    },
+    {
+      id: "ann_5",
+      title: "Back to School Promotion",
+      body: "Special discount on all courses for the new academic year.",
+      audience: "students",
+      state: "scheduled",
+      sentCount: null,
+      createdBy: "marketing@deenbridge.com",
+      createdAt: "2026-08-22T16:00:00Z",
+      scheduledFor: "2026-09-01T08:00:00Z",
+      sentAt: null,
+    },
+    {
+      id: "ann_6",
+      title: "Upcoming Webinar: Quran Memorization Tips",
+      body: "Join us for a live webinar on effective Quran memorization strategies.",
+      audience: "students",
+      state: "scheduled",
+      sentCount: null,
+      createdBy: "admin@deenbridge.com",
+      createdAt: "2026-08-23T12:00:00Z",
+      scheduledFor: "2026-09-05T18:00:00Z",
+      sentAt: null,
+    },
+    {
+      id: "ann_7",
+      title: "Educator Onboarding Webinar",
+      body: "New webinar series for educators joining the platform.",
+      audience: "educators",
+      state: "scheduled",
+      sentCount: null,
+      createdBy: "admin@deenbridge.com",
+      createdAt: "2026-08-24T09:00:00Z",
+      scheduledFor: "2026-09-10T14:00:00Z",
+      sentAt: null,
+    },
+    {
+      id: "ann_8",
+      title: "Holiday Closure Notice",
+      body: "The platform will observe reduced support during the holiday.",
+      audience: "all",
+      state: "cancelled",
+      sentCount: null,
+      createdBy: "admin@deenbridge.com",
+      createdAt: "2026-08-12T08:00:00Z",
+      scheduledFor: "2026-08-15T00:00:00Z",
+      sentAt: null,
+      cancelledAt: "2026-08-13T10:00:00Z",
+    },
+    {
+      id: "ann_9",
+      title: "Course Review Reminder",
+      body: "Please review your recently completed courses.",
+      audience: "students",
+      state: "draft",
+      sentCount: null,
+      createdBy: "marketing@deenbridge.com",
+      createdAt: "2026-08-25T08:30:00Z",
+      scheduledFor: null,
+      sentAt: null,
+    },
+    {
+      id: "ann_10",
+      title: "New Admin Role Permissions",
+      body: "Updated permissions for admin roles have been released.",
+      audience: "admins",
+      state: "draft",
+      sentCount: null,
+      createdBy: "admin@deenbridge.com",
+      createdAt: "2026-08-25T10:00:00Z",
+      scheduledFor: null,
+      sentAt: null,
+    },
+  ];
+
+  return items.sort(
+    (a, b) => new Date(b.createdAt) - new Date(a.createdAt)
+  );
+};
+
+export default function AnnouncementHistoryTable() {
+  const [announcements, setAnnouncements] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [stateFilter, setStateFilter] = useState("all");
+  const [audienceFilter, setAudienceFilter] = useState("all");
+  const [currentPage, setCurrentPage] = useState(1);
+  const [totalPages, setTotalPages] = useState(1);
+  const [cancelDialog, setCancelDialog] = useState({ open: false, announcement: null });
+  const [editingId, setEditingId] = useState(null);
+  const [editTitle, setEditTitle] = useState("");
+  const [editScheduledFor, setEditScheduledFor] = useState("");
+  const pageSize = 10;
+
+  const fetchAnnouncements = useCallback(async () => {
+    setLoading(true);
+    await new Promise((resolve) => setTimeout(resolve, 400));
+    let items = generateMockAnnouncements();
+
+    if (stateFilter !== "all") {
+      items = items.filter((a) => a.state === stateFilter);
+    }
+    if (audienceFilter !== "all") {
+      items = items.filter((a) => a.audience === audienceFilter);
+    }
+
+    const total = Math.ceil(items.length / pageSize);
+    const start = (currentPage - 1) * pageSize;
+    const paginated = items.slice(start, start + pageSize);
+
+    setAnnouncements(paginated);
+    setTotalPages(total);
+    setLoading(false);
+  }, [currentPage, stateFilter, audienceFilter]);
+
+  useEffect(() => {
+    fetchAnnouncements();
+  }, [fetchAnnouncements]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [stateFilter, audienceFilter]);
+
+  const handleCancel = (announcement) => {
+    setCancelDialog({ open: true, announcement });
+  };
+
+  const confirmCancel = () => {
+    setAnnouncements((prev) =>
+      prev.map((a) =>
+        a.id === cancelDialog.announcement.id
+          ? { ...a, state: "cancelled", cancelledAt: new Date().toISOString() }
+          : a
+      )
+    );
+    setCancelDialog({ open: false, announcement: null });
+  };
+
+  const handleDuplicateAsDraft = (announcement) => {
+    const newAnn = {
+      ...announcement,
+      id: `ann_${Date.now()}`,
+      title: `${announcement.title} (Copy)`,
+      state: "draft",
+      sentCount: null,
+      createdAt: new Date().toISOString(),
+      scheduledFor: null,
+      sentAt: null,
+    };
+    setAnnouncements((prev) => [newAnn, ...prev]);
+  };
+
+  const handleStartEdit = (announcement) => {
+    setEditingId(announcement.id);
+    setEditTitle(announcement.title);
+    setEditScheduledFor(
+      announcement.scheduledFor
+        ? format(new Date(announcement.scheduledFor), "yyyy-MM-dd'T'HH:mm")
+        : ""
+    );
+  };
+
+  const handleSaveEdit = (id) => {
+    setAnnouncements((prev) =>
+      prev.map((a) =>
+        a.id === id
+          ? {
+              ...a,
+              title: editTitle,
+              scheduledFor: editScheduledFor
+                ? new Date(editScheduledFor).toISOString()
+                : a.scheduledFor,
+            }
+          : a
+      )
+    );
+    setEditingId(null);
+    setEditTitle("");
+    setEditScheduledFor("");
+  };
+
+  const handleCancelEdit = () => {
+    setEditingId(null);
+    setEditTitle("");
+    setEditScheduledFor("");
+  };
+
+  const getAudienceLabel = (audience) =>
+    AUDIENCE_OPTIONS.find((a) => a.value === audience)?.label || audience;
+
+  const formatTimestamp = (timestamp) => {
+    if (!timestamp) return "—";
+    return format(new Date(timestamp), "MMM d, yyyy HH:mm");
+  };
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={Bell}
+        title="Announcement History"
+        subtitle="View, edit, and manage all past and scheduled announcements"
+        actions={
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={fetchAnnouncements}
+            disabled={loading}
+          >
+            <RefreshCw
+              className={cn("h-4 w-4 mr-2", loading && "animate-spin")}
+            />
+            Refresh
+          </Button>
+        }
+      />
+
+      {/* Filters */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Filters</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className={cn(poppins_500.className, "text-sm")}>
+                State
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {["all", "draft", "scheduled", "sent", "cancelled"].map(
+                  (state) => (
+                    <Button
+                      key={state}
+                      variant={stateFilter === state ? "default" : "outline"}
+                      size="sm"
+                      onClick={() => setStateFilter(state)}
+                      className="capitalize"
+                    >
+                      {state === "all" ? "All States" : state}
+                    </Button>
+                  )
+                )}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <label className={cn(poppins_500.className, "text-sm")}>
+                Audience
+              </label>
+              <div className="flex flex-wrap gap-2">
+                {["all", "students", "educators", "admins"].map(
+                  (audience) => (
+                    <Button
+                      key={audience}
+                      variant={
+                        audienceFilter === audience ? "default" : "outline"
+                      }
+                      size="sm"
+                      onClick={() => setAudienceFilter(audience)}
+                      className="capitalize"
+                    >
+                      {audience === "all"
+                        ? "All Audiences"
+                        : getAudienceLabel(audience)}
+                    </Button>
+                  )
+                )}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Announcements</CardTitle>
+          <CardDescription>
+            Showing page {currentPage} of {totalPages}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="rounded-lg border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="min-w-[200px]">Title</TableHead>
+                  <TableHead className="w-[130px]">Audience</TableHead>
+                  <TableHead className="w-[120px]">State</TableHead>
+                  <TableHead className="w-[100px] text-center">
+                    Sent Count
+                  </TableHead>
+                  <TableHead className="w-[150px]">Created By</TableHead>
+                  <TableHead className="w-[160px]">Created At</TableHead>
+                  <TableHead className="w-[100px] text-right">
+                    Actions
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {loading ? (
+                  <TableRow>
+                    <TableCell colSpan={7} className="py-8 text-center">
+                      <Loader2 className="h-6 w-6 animate-spin mx-auto text-muted-foreground" />
+                    </TableCell>
+                  </TableRow>
+                ) : announcements.length === 0 ? (
+                  <TableRow>
+                    <TableCell
+                      colSpan={7}
+                      className="py-8 text-center text-muted-foreground"
+                    >
+                      No announcements found matching your filters
+                    </TableCell>
+                  </TableRow>
+                ) : (
+                  announcements.map((ann) => {
+                    const stateCfg = STATE_CONFIG[ann.state];
+                    const StateIcon = stateCfg.icon;
+                    const isEditing = editingId === ann.id;
+                    const isEditable =
+                      ann.state === "draft" || ann.state === "scheduled";
+                    const isReadOnly = ann.state === "sent";
+
+                    return (
+                      <TableRow key={ann.id}>
+                        <TableCell>
+                          {isEditing ? (
+                            <input
+                              type="text"
+                              value={editTitle}
+                              onChange={(e) => setEditTitle(e.target.value)}
+                              className={cn(
+                                poppins_400.className,
+                                "w-full rounded border border-input bg-background px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+                              )}
+                            />
+                          ) : (
+                            <span className={cn(poppins_500.className, "text-sm")}>
+                              {ann.title}
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <div className="flex items-center gap-1.5">
+                            <Users className="h-3.5 w-3.5 text-muted-foreground" />
+                            <span className="text-sm">
+                              {getAudienceLabel(ann.audience)}
+                            </span>
+                          </div>
+                        </TableCell>
+                        <TableCell>
+                          <Badge
+                            variant="outline"
+                            className={cn("text-xs gap-1", stateCfg.badgeClass)}
+                          >
+                            <StateIcon className="h-3 w-3" />
+                            {stateCfg.label}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-center">
+                          {ann.sentCount !== null ? (
+                            <span
+                              className={cn(
+                                poppins_500.className,
+                                "text-sm tabular-nums"
+                              )}
+                            >
+                              {ann.sentCount.toLocaleString()}
+                            </span>
+                          ) : (
+                            <span className="text-sm text-muted-foreground">
+                              —
+                            </span>
+                          )}
+                        </TableCell>
+                        <TableCell>
+                          <span className="text-sm text-muted-foreground">
+                            {ann.createdBy}
+                          </span>
+                        </TableCell>
+                        <TableCell>
+                          <span className="text-sm text-muted-foreground">
+                            {formatTimestamp(ann.createdAt)}
+                          </span>
+                        </TableCell>
+                        <TableCell className="text-right">
+                          {isEditing ? (
+                            <div className="flex items-center justify-end gap-1">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 text-xs"
+                                onClick={() => handleSaveEdit(ann.id)}
+                              >
+                                Save
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="h-7 text-xs text-muted-foreground"
+                                onClick={handleCancelEdit}
+                              >
+                                Cancel
+                              </Button>
+                            </div>
+                          ) : (
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button
+                                  variant="ghost"
+                                  size="icon"
+                                  className="h-8 w-8"
+                                >
+                                  <MoreHorizontal className="h-4 w-4" />
+                                </Button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="end">
+                                {isEditable && (
+                                  <>
+                                    <DropdownMenuItem
+                                      onClick={() => handleStartEdit(ann)}
+                                    >
+                                      <Pencil className="h-4 w-4 mr-2" />
+                                      Edit
+                                    </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                      onClick={() => handleCancel(ann)}
+                                      className="text-red-600 focus:text-red-600"
+                                    >
+                                      <Trash2 className="h-4 w-4 mr-2" />
+                                      Cancel Announcement
+                                    </DropdownMenuItem>
+                                    <DropdownMenuSeparator />
+                                  </>
+                                )}
+                                <DropdownMenuItem
+                                  onClick={() => handleDuplicateAsDraft(ann)}
+                                >
+                                  <Copy className="h-4 w-4 mr-2" />
+                                  Duplicate as Draft
+                                </DropdownMenuItem>
+                                {isReadOnly && (
+                                  <>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuItem disabled>
+                                      <Eye className="h-4 w-4 mr-2" />
+                                      Read Only
+                                    </DropdownMenuItem>
+                                  </>
+                                )}
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="mt-4 flex items-center justify-between">
+              <p
+                className={cn(
+                  poppins_400.className,
+                  "text-sm text-muted-foreground"
+                )}
+              >
+                Page {currentPage} of {totalPages}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                  disabled={currentPage === 1 || loading}
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() =>
+                    setCurrentPage((p) => Math.min(totalPages, p + 1))
+                  }
+                  disabled={currentPage === totalPages || loading}
+                >
+                  Next
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Cancel Confirmation Dialog */}
+      <AlertDialog
+        open={cancelDialog.open}
+        onOpenChange={(open) => {
+          if (!open) setCancelDialog({ open: false, announcement: null });
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Cancel Announcement</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to cancel &quot;
+              {cancelDialog.announcement?.title}&quot;? This action cannot be
+              undone. The announcement will not be sent.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Keep Announcement</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={confirmCancel}
+              className="bg-destructive text-white hover:bg-destructive/90"
+            >
+              Yes, Cancel It
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </PageShell>
+  );
+}

--- a/components/organisms/dashboard/StreamingAIChat.jsx
+++ b/components/organisms/dashboard/StreamingAIChat.jsx
@@ -43,7 +43,6 @@ import {
 export default function StreamingAIChat({ chatData, onChatUpdate }) {
   const { user } = useAuth();
   const [inputMessage, setInputMessage] = useState("");
-  const [userId, setUserId] = useState(null);
   const messagesEndRef = useRef(null);
 
   // Use the streaming chat hook
@@ -55,7 +54,7 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
     stopStreaming,
     newConversation,
     setMessagesFromHistory,
-  } = useStreamingChat(userId, chatData?.chatId);
+  } = useStreamingChat(user?._id, chatData?.chatId);
 
   // Sync with chatData from layout when sidebar selection changes
   useEffect(() => {
@@ -72,37 +71,32 @@ export default function StreamingAIChat({ chatData, onChatUpdate }) {
     scrollToBottom();
   }, [messages]);
 
-  // Load user ID and chat history on mount
+  // Load chat history when user ID becomes available
   useEffect(() => {
-    const loadUserAndHistory = async () => {
+    if (!user?._id) return;
+
+    const loadHistory = async () => {
       try {
-        // Get user from localStorage
-        const userData = localStorage.getItem("user");
-        if (userData) {
-          const userObj = JSON.parse(userData);
-          setUserId(userObj.id);
+        // Load user's most recent chat if no chatData provided
+        if (!chatData) {
+          const data = await loadChatHistory(user._id);
 
-          // Load user's most recent chat if no chatData provided
-          if (!chatData) {
-            const data = await loadChatHistory(userObj.id);
+          if (data.chats && data.chats.length > 0) {
+            // Load the most recent chat
+            const latestChat = data.chats[0];
 
-            if (data.chats && data.chats.length > 0) {
-              // Load the most recent chat
-              const latestChat = data.chats[0];
-
-              // Load the chat history messages
-              const history = await loadChatMessages(latestChat.chat_id);
-              setMessagesFromHistory(history);
-            }
+            // Load the chat history messages
+            const history = await loadChatMessages(latestChat.chat_id);
+            setMessagesFromHistory(history);
           }
         }
       } catch (error) {
-        console.error("Error loading user data:", error);
+        console.error("Error loading chat history:", error);
       }
     };
 
-    loadUserAndHistory();
-  }, [chatData, setMessagesFromHistory]);
+    loadHistory();
+  }, [user?._id, chatData, setMessagesFromHistory]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();

--- a/lib/actions/admin-learning-analytics.js
+++ b/lib/actions/admin-learning-analytics.js
@@ -1,0 +1,86 @@
+/**
+ * Admin learning-engagement analytics — funnel, sessions, lessons, reading depth.
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Resolves a representative engagement snapshot so the admin
+ * learning-analytics page (#322) can be built and reviewed before the backend
+ * analytics endpoints ship. Every metric carries an explicit `tracked` flag:
+ * metrics the platform does not instrument yet resolve with `tracked: false`
+ * so the UI renders an explicit "not tracked yet" placeholder instead of a
+ * silent zero (see the issue's acceptance criteria).
+ *
+ * TODO(backend): GET /api/admin/analytics/engagement?from=&to=
+ *   - Auth: requires a super-admin session token (server-side tier check).
+ *   - 200 → the engagement shape documented below.
+ *
+ * Engagement shape:
+ *   {
+ *     generatedAt: string,
+ *     totals: {
+ *       students:          { label: string, value: number, tracked: boolean },
+ *       coursesEnrolled:   { label: string, value: number, tracked: boolean },
+ *       lessonsCompleted:  { label: string, value: number, tracked: boolean },
+ *       avgSessionLength:  { label: string, value: number, tracked: boolean },
+ *     },
+ *     funnel: [
+ *       { stage: "enrolled",  label: "Enrolled",      value: number, tracked: boolean },
+ *       { stage: "started",   label: "Started",       value: number, tracked: boolean },
+ *       { stage: "quarter",   label: "25% Complete",  value: number, tracked: boolean },
+ *       { stage: "completed", label: "Completed",     value: number, tracked: boolean },
+ *     ],
+ *     sessionLength:    { tracked: boolean, avgMinutes: number | null },
+ *     lessonsCompleted: { tracked: boolean, buckets: Array<{ range: string, value: number }> },
+ *     readingDepth:     { tracked: boolean, buckets: Array<{ range: string, value: number }> },
+ *   }
+ */
+
+function withResolved(value) {
+  return Promise.resolve(value);
+}
+
+/**
+ * Fetch the platform-wide learning engagement snapshot.
+ *
+ * TODO(backend):
+ *   return axiosInstance
+ *     .get("/api/admin/analytics/engagement", { params: { from, to } })
+ *     .then((res) => res.data);
+ *
+ * @returns {Promise<object>} the engagement snapshot documented above.
+ */
+export async function fetchEngagementAnalytics() {
+  return withResolved({
+    generatedAt: new Date().toISOString(),
+    totals: {
+      students: { label: "Total Students", value: 842, tracked: true },
+      coursesEnrolled: { label: "Courses Enrolled", value: 1284, tracked: true },
+      lessonsCompleted: { label: "Lessons Completed", value: 0, tracked: false },
+      avgSessionLength: { label: "Avg. Session Length", value: 0, tracked: false },
+    },
+    funnel: [
+      { stage: "enrolled", label: "Enrolled", value: 1284, tracked: true },
+      { stage: "started", label: "Started", value: 0, tracked: false },
+      { stage: "quarter", label: "25% Complete", value: 0, tracked: false },
+      { stage: "completed", label: "Completed", value: 0, tracked: false },
+    ],
+    sessionLength: { tracked: false, avgMinutes: null },
+    lessonsCompleted: {
+      tracked: false,
+      buckets: [
+        { range: "1–5", value: 0 },
+        { range: "6–10", value: 0 },
+        { range: "11–20", value: 0 },
+        { range: "21–40", value: 0 },
+        { range: "41+", value: 0 },
+      ],
+    },
+    readingDepth: {
+      tracked: false,
+      buckets: [
+        { range: "0–25%", value: 0 },
+        { range: "26–50%", value: 0 },
+        { range: "51–75%", value: 0 },
+        { range: "76–100%", value: 0 },
+      ],
+    },
+  });
+}

--- a/lib/actions/admin-reports.js
+++ b/lib/actions/admin-reports.js
@@ -1,0 +1,333 @@
+/**
+ * Admin report-builder service — datasets, preview rows, saved queries (#329).
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Composes the custom report builder from the existing pieces the
+ * issue scopes it to: the three datasets (users / transactions / reports),
+ * each with its own filter set and column list. There is deliberately **no**
+ * cross-dataset join, no custom SQL, and no scheduling — the builder only
+ * composes existing filters and columns.
+ *
+ * Saved queries persist per admin user to `localStorage` (`dnb_admin_saved_queries_<userId>`)
+ * so the sidebar round-trips today. Swap for `axiosInstance` calls (see
+ * `lib/config/axios.config.js`) when the backend lands:
+ *
+ *   TODO(backend): GET    /api/admin/saved-queries
+ *   TODO(backend): POST   /api/admin/saved-queries   { name, datasetId, filters, columns }
+ *   TODO(backend): DELETE /api/admin/saved-queries/:id
+ *   TODO(backend): GET    /api/admin/report-rows?dataset=&filters...
+ *
+ * Saved query shape owned by the backend:
+ *   { id: string, name: string, datasetId: "users"|"transactions"|"reports",
+ *     filters: object, columns: string[], createdAt: string }
+ */
+
+const SAVED_QUERIES_PREFIX = "dnb_admin_saved_queries_";
+
+/** The three report datasets and their filter/column definitions. */
+export const REPORT_DATASETS = Object.freeze([
+  {
+    id: "users",
+    label: "Users",
+    description: "Platform user accounts",
+    filters: [
+      {
+        key: "status",
+        label: "Status",
+        type: "select",
+        options: [
+          { value: "all", label: "All statuses" },
+          { value: "active", label: "Active" },
+          { value: "banned", label: "Banned" },
+        ],
+      },
+      { key: "from", label: "Joined from", type: "date" },
+      { key: "to", label: "Joined to", type: "date" },
+    ],
+    columns: [
+      { key: "name", label: "Name" },
+      { key: "email", label: "Email" },
+      { key: "role", label: "Role" },
+      { key: "status", label: "Status" },
+      { key: "joinedAt", label: "Joined" },
+    ],
+    dateColumn: "joinedAt",
+  },
+  {
+    id: "transactions",
+    label: "Transactions",
+    description: "Purchase and payment transactions",
+    filters: [
+      {
+        key: "status",
+        label: "Status",
+        type: "select",
+        options: [
+          { value: "all", label: "All statuses" },
+          { value: "confirmed", label: "Confirmed" },
+          { value: "pending", label: "Pending" },
+          { value: "submitted", label: "Submitted" },
+          { value: "failed", label: "Failed" },
+          { value: "expired", label: "Expired" },
+        ],
+      },
+      {
+        key: "itemType",
+        label: "Item type",
+        type: "select",
+        options: [
+          { value: "all", label: "All types" },
+          { value: "course", label: "Course" },
+          { value: "book", label: "Book" },
+        ],
+      },
+      { key: "from", label: "Date from", type: "date" },
+      { key: "to", label: "Date to", type: "date" },
+    ],
+    columns: [
+      { key: "id", label: "Reference" },
+      { key: "createdAt", label: "Date" },
+      { key: "itemType", label: "Item type" },
+      { key: "itemTitle", label: "Item" },
+      { key: "amount", label: "Amount" },
+      { key: "status", label: "Status" },
+      { key: "buyer", label: "Buyer" },
+    ],
+    dateColumn: "createdAt",
+  },
+  {
+    id: "reports",
+    label: "Reports",
+    description: "Content moderation reports",
+    filters: [
+      {
+        key: "contentType",
+        label: "Content type",
+        type: "select",
+        options: [
+          { value: "all", label: "All content" },
+          { value: "course", label: "Course" },
+          { value: "book", label: "Book" },
+          { value: "space", label: "Space" },
+        ],
+      },
+      {
+        key: "status",
+        label: "Status",
+        type: "select",
+        options: [
+          { value: "all", label: "All statuses" },
+          { value: "open", label: "Open" },
+          { value: "investigating", label: "Investigating" },
+          { value: "resolved", label: "Resolved" },
+          { value: "dismissed", label: "Dismissed" },
+        ],
+      },
+      { key: "from", label: "Reported from", type: "date" },
+      { key: "to", label: "Reported to", type: "date" },
+    ],
+    columns: [
+      { key: "id", label: "ID" },
+      { key: "createdAt", label: "Reported" },
+      { key: "contentType", label: "Content type" },
+      { key: "itemTitle", label: "Item" },
+      { key: "reason", label: "Reason" },
+      { key: "status", label: "Status" },
+      { key: "reportedBy", label: "Reported by" },
+    ],
+    dateColumn: "createdAt",
+  },
+]);
+
+/** Fixed sample rows per dataset so previews are deterministic and filterable. */
+const SAMPLE_ROWS = Object.freeze({
+  users: [
+    { name: "Amina Yusuf", email: "amina@deenbridge.org", role: "student", status: "active", joinedAt: "2025-01-12" },
+    { name: "Bilal Karim", email: "bilal@deenbridge.org", role: "educator", status: "active", joinedAt: "2025-02-03" },
+    { name: "Zaynab Idris", email: "zaynab@deenbridge.org", role: "student", status: "banned", joinedAt: "2025-03-17" },
+    { name: "Umar Farouk", email: "umar@deenbridge.org", role: "student", status: "active", joinedAt: "2025-04-21" },
+    { name: "Khadija Bello", email: "khadija@deenbridge.org", role: "educator", status: "active", joinedAt: "2025-05-09" },
+  ],
+  transactions: [
+    { id: "TX-1001", createdAt: "2025-06-01", itemType: "course", itemTitle: "Tafsir of Surah Al-Fatihah", amount: 24.5, status: "confirmed", buyer: "amina@deenbridge.org" },
+    { id: "TX-1002", createdAt: "2025-06-05", itemType: "book", itemTitle: "The Sealed Nectar", amount: 9.99, status: "pending", buyer: "umar@deenbridge.org" },
+    { id: "TX-1003", createdAt: "2025-06-08", itemType: "course", itemTitle: "Arabic Grammar Essentials", amount: 35.0, status: "confirmed", buyer: "zaynab@deenbridge.org" },
+    { id: "TX-1004", createdAt: "2025-06-12", itemType: "book", itemTitle: "Stories of the Prophets", amount: 7.5, status: "failed", buyer: "khadija@deenbridge.org" },
+    { id: "TX-1005", createdAt: "2025-06-15", itemType: "course", itemTitle: "Fiqh of Worship", amount: 42.0, status: "confirmed", buyer: "bilal@deenbridge.org" },
+  ],
+  reports: [
+    { id: "REP-201", createdAt: "2025-06-02", contentType: "course", itemTitle: "Tafsir of Surah Al-Fatihah", reason: "copyright", status: "open", reportedBy: "umar@deenbridge.org" },
+    { id: "REP-202", createdAt: "2025-06-06", contentType: "book", itemTitle: "The Sealed Nectar", reason: "spam", status: "investigating", reportedBy: "amina@deenbridge.org" },
+    { id: "REP-203", createdAt: "2025-06-09", contentType: "space", itemTitle: "Evening Dhikr Circle", reason: "inappropriate", status: "resolved", reportedBy: "zaynab@deenbridge.org" },
+    { id: "REP-204", createdAt: "2025-06-13", contentType: "book", itemTitle: "Stories of the Prophets", reason: "duplicate", status: "dismissed", reportedBy: "bilal@deenbridge.org" },
+    { id: "REP-205", createdAt: "2025-06-16", contentType: "course", itemTitle: "Fiqh of Worship", reason: "other", status: "open", reportedBy: "khadija@deenbridge.org" },
+  ],
+});
+
+function getDataset(datasetId) {
+  return REPORT_DATASETS.find((dataset) => dataset.id === datasetId);
+}
+
+/**
+ * Build the default (empty) filter object for a dataset.
+ *
+ * @param {string} datasetId
+ * @returns {Record<string, string>}
+ */
+export function defaultFiltersFor(datasetId) {
+  const dataset = getDataset(datasetId);
+  if (!dataset) return {};
+  const defaults = {};
+  for (const filter of dataset.filters) {
+    defaults[filter.key] = filter.type === "select" ? "all" : "";
+  }
+  return defaults;
+}
+
+function isInDateRange(value, from, to) {
+  if (!from && !to) return true;
+  const date = String(value ?? "").slice(0, 10);
+  if (!date) return false;
+  if (from && date < from) return false;
+  if (to && date > to) return false;
+  return true;
+}
+
+/**
+ * Fetch preview rows for a dataset, applying the composed filters. Only the
+ * dataset's own filters are honored — no joins across datasets.
+ *
+ * TODO(backend): GET /api/admin/report-rows?dataset=<id>&<filters...>
+ *   - Auth: admin only.
+ *   - 200 → { rows: Array<Record<string, unknown>> }
+ *   - 403 for non-admins; 422 for an unknown dataset id.
+ *
+ * @param {string} datasetId
+ * @param {Record<string, string>} [filters]
+ * @param {{limit?: number}} [options]
+ * @returns {Promise<{rows: Array<Record<string, unknown>>}>}
+ */
+export async function fetchReportRows(datasetId, filters = {}, options = {}) {
+  const dataset = getDataset(datasetId);
+  if (!dataset) {
+    throw new Error(`Unknown report dataset: ${datasetId}`);
+  }
+
+  let rows = SAMPLE_ROWS[datasetId] || [];
+
+  for (const filter of dataset.filters) {
+    const value = filters[filter.key];
+    if (!value || value === "all") continue;
+
+    if (filter.type === "date") {
+      const { from, to } = filters;
+      rows = rows.filter((row) => isInDateRange(row[dataset.dateColumn], from, to));
+    } else {
+      rows = rows.filter((row) => row[filter.key] === value);
+    }
+  }
+
+  const limit = options.limit || rows.length;
+  return Promise.resolve({ rows: rows.slice(0, limit) });
+}
+
+function readSavedQueries(userId) {
+  if (typeof window === "undefined" || !userId) return [];
+  try {
+    const raw = window.localStorage.getItem(`${SAVED_QUERIES_PREFIX}${userId}`);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeSavedQueries(userId, queries) {
+  if (typeof window === "undefined" || !userId) return;
+  try {
+    window.localStorage.setItem(
+      `${SAVED_QUERIES_PREFIX}${userId}`,
+      JSON.stringify(queries)
+    );
+  } catch {
+    // Storage unavailable (private mode / quota) — saving silently no-ops.
+  }
+}
+
+function generateQueryId() {
+  return `q_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/**
+ * List the current admin's saved queries (newest first).
+ *
+ * TODO(backend): GET /api/admin/saved-queries
+ *   - Auth: admin only.
+ *   - 200 → { queries: SavedQuery[] }
+ *
+ * @param {string} userId
+ * @returns {Promise<{queries: Array<object>}>}
+ */
+export async function listSavedQueries(userId) {
+  return Promise.resolve({ queries: readSavedQueries(userId) });
+}
+
+/**
+ * Save a named query for the current admin. Requires a non-empty name, a known
+ * dataset, and at least one selected column.
+ *
+ * TODO(backend): POST /api/admin/saved-queries
+ *   - Auth: admin only.
+ *   - Payload: { name, datasetId, filters, columns }
+ *   - 201 → { query: SavedQuery }
+ *   - 422 for a missing name / unknown dataset / empty columns.
+ *
+ * @param {string} userId
+ * @param {{name: string, datasetId: string, filters: object, columns: string[]}} payload
+ * @returns {Promise<{query: object}>}
+ */
+export async function saveQuery(userId, payload) {
+  const name = String(payload?.name || "").trim();
+  const datasetId = payload?.datasetId;
+  const columns = Array.isArray(payload?.columns) ? payload.columns : [];
+  if (!name) {
+    throw new Error("A query name is required.");
+  }
+  if (!getDataset(datasetId)) {
+    throw new Error(`Unknown report dataset: ${datasetId}`);
+  }
+  if (columns.length === 0) {
+    throw new Error("Select at least one column.");
+  }
+
+  const query = {
+    id: generateQueryId(),
+    name,
+    datasetId,
+    filters: { ...(payload.filters || {}) },
+    columns,
+    createdAt: new Date().toISOString(),
+  };
+
+  const queries = readSavedQueries(userId);
+  queries.unshift(query);
+  writeSavedQueries(userId, queries);
+
+  return Promise.resolve({ query });
+}
+
+/**
+ * Delete a saved query owned by the current admin.
+ *
+ * TODO(backend): DELETE /api/admin/saved-queries/:id
+ *   - Auth: admin only; queries are scoped per admin.
+ *   - 200 → { deleted: true, queryId: string }
+ *
+ * @param {string} userId
+ * @param {string} queryId
+ * @returns {Promise<{deleted: boolean, queryId: string}>}
+ */
+export async function deleteSavedQuery(userId, queryId) {
+  const queries = readSavedQueries(userId).filter((query) => query.id !== queryId);
+  writeSavedQueries(userId, queries);
+  return Promise.resolve({ deleted: true, queryId });
+}

--- a/lib/utils/csv.js
+++ b/lib/utils/csv.js
@@ -1,0 +1,50 @@
+/**
+ * CSV export helpers — the standard DeenBridge export path.
+ * ---------------------------------------------------------------------------
+ * Extracted from the export handlers in the audit-log and reconciliation admin
+ * pages so report-style surfaces (including the report builder, #329) share one
+ * quoting/escaping implementation instead of duplicating it inline.
+ */
+
+/**
+ * Quote-escape a single cell for CSV (double-quote wrap + "" escaping).
+ * @param {unknown} cell
+ * @returns {string}
+ */
+function escapeCell(cell) {
+  return `"${String(cell ?? "").replace(/"/g, '""')}"`;
+}
+
+/**
+ * Build a CSV document from headers and row arrays.
+ *
+ * @param {string[]} headers
+ * @param {Array<Array<unknown>>} rows
+ * @returns {string}
+ */
+export function rowsToCsv(headers, rows) {
+  const lines = [headers.map(escapeCell).join(",")];
+  for (const row of rows) {
+    lines.push(row.map(escapeCell).join(","));
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Serialize and trigger a browser download of the given rows as CSV.
+ *
+ * @param {{filename: string, headers: string[], rows: Array<Array<unknown>>}} options
+ */
+export function downloadCsv({ filename, headers, rows }) {
+  const csv = rowsToCsv(headers, rows);
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.setAttribute("href", url);
+  link.setAttribute("download", filename);
+  link.style.visibility = "hidden";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Adds announcement history table with state badges, inline editing for scheduled items, cancel with confirmation, and duplicate-as-draft functionality.

Closes #300.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Learning Analytics with engagement metrics, completion funnels, distribution charts, and unavailable-metric placeholders.
  * Added an admin report builder with dataset selection, filtering, previews, saved queries, deletion, and CSV export.
  * Added announcement history with filtering, pagination, editing, cancellation, and draft duplication.
  * Improved streaming chat to use the authenticated account consistently.

* **Tests**
  * Expanded coverage for analytics, reporting, announcement workflows, and CSV generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->