### PR TITLE
feat(reports): dismissal workflow with optional reporter feedback (#293)

### DIFF
--- a/__tests__/admin/DismissReportDialog.test.jsx
+++ b/__tests__/admin/DismissReportDialog.test.jsx
@@ -1,0 +1,351 @@
+/**
+ * Dismissal workflow tests — #293
+ * ------------------------------------------------------------------
+ * Covers:
+ *   1. admin-moderation service:  DISMISSAL_REASONS, getReporterReportCount,
+ *      isFirstTimeReporter, sendDismissalNotification, dismissReport
+ *   2. DismissReportDialog component: reason picker, notify checkbox smart
+ *      defaults, submit flow, cancel, error state
+ */
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+
+// ── Font mock (needed by DismissReportDialog) ──────────────────────────────
+vi.mock("@/lib/config/font.config", () => ({
+  poppins_400: { className: "" },
+  poppins_500: { className: "" },
+  poppins_600: { className: "" },
+}));
+
+// ── Audit mock — fire-and-forget, not observable in unit tests ─────────────
+vi.mock("@/lib/admin/audit", () => ({
+  logAuditEvent: vi.fn(),
+  AUDIT_ACTIONS: {
+    TAKEDOWN: "content.takedown",
+    RESTORE: "content.restore",
+    REPORT_DISMISS: "report.dismiss",
+  },
+}));
+
+import {
+  DISMISSAL_REASONS,
+  getReporterReportCount,
+  isFirstTimeReporter,
+  sendDismissalNotification,
+  dismissReport,
+} from "@/lib/actions/admin-moderation";
+
+import DismissReportDialog from "@/components/admin/DismissReportDialog";
+
+// jsdom layout/pointer API stubs required by Radix UI primitives
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn(() => false);
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  if (!window.ResizeObserver) {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+beforeEach(() => vi.clearAllMocks());
+afterEach(() => vi.clearAllMocks());
+
+// ============================================================================
+// 1. Service — DISMISSAL_REASONS
+// ============================================================================
+describe("DISMISSAL_REASONS", () => {
+  it("exposes exactly the four required options", () => {
+    const values = DISMISSAL_REASONS.map((r) => r.value);
+    expect(values).toContain("no_violation");
+    expect(values).toContain("already_handled");
+    expect(values).toContain("insufficient_evidence");
+    expect(values).toContain("duplicate");
+    expect(DISMISSAL_REASONS).toHaveLength(4);
+  });
+
+  it("each option has a non-empty label string", () => {
+    for (const reason of DISMISSAL_REASONS) {
+      expect(typeof reason.label).toBe("string");
+      expect(reason.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("is frozen (immutable)", () => {
+    expect(Object.isFrozen(DISMISSAL_REASONS)).toBe(true);
+  });
+});
+
+// ============================================================================
+// 2. Service — first-time vs. repeat reporter detection
+// ============================================================================
+describe("getReporterReportCount", () => {
+  it("returns 0 for the known first-time reporter (rp_1)", async () => {
+    expect(await getReporterReportCount("rp_1")).toBe(0);
+  });
+
+  it("returns a positive count for a known repeat reporter (rp_2)", async () => {
+    expect(await getReporterReportCount("rp_2")).toBeGreaterThan(0);
+  });
+
+  it("returns 0 for an unknown reporter id", async () => {
+    expect(await getReporterReportCount("rp_unknown_xyz")).toBe(0);
+  });
+});
+
+describe("isFirstTimeReporter", () => {
+  it("returns true for the first-time reporter (rp_1)", async () => {
+    expect(await isFirstTimeReporter("rp_1")).toBe(true);
+  });
+
+  it("returns false for a repeat reporter (rp_3)", async () => {
+    expect(await isFirstTimeReporter("rp_3")).toBe(false);
+  });
+});
+
+// ============================================================================
+// 3. Service — sendDismissalNotification stub
+// ============================================================================
+describe("sendDismissalNotification", () => {
+  it("resolves with queued:true and a notification id", async () => {
+    const result = await sendDismissalNotification({
+      reporterId: "rp_1",
+      reportId: "rpt_0001",
+      dismissalReason: "no_violation",
+    });
+    expect(result.queued).toBe(true);
+    expect(typeof result.notificationId).toBe("string");
+    expect(result.notificationId.length).toBeGreaterThan(0);
+  });
+});
+
+// ============================================================================
+// 4. Service — dismissReport
+// ============================================================================
+describe("dismissReport", () => {
+  it("rejects when reportId is missing", async () => {
+    await expect(
+      dismissReport({ reporterId: "rp_1", reason: "no_violation" })
+    ).rejects.toThrow(/reportId is required/i);
+  });
+
+  it("rejects when reporterId is missing", async () => {
+    await expect(
+      dismissReport({ reportId: "rpt_0001", reason: "no_violation" })
+    ).rejects.toThrow(/reporterId is required/i);
+  });
+
+  it("rejects an unknown reason", async () => {
+    await expect(
+      dismissReport({ reportId: "rpt_0001", reporterId: "rp_1", reason: "bad_reason" })
+    ).rejects.toThrow(/invalid dismissal reason/i);
+  });
+
+  it("resolves with dismissed status and the chosen reason", async () => {
+    const { report } = await dismissReport({
+      reportId: "rpt_0001",
+      reporterId: "rp_1",
+      reason: "no_violation",
+    });
+    expect(report.status).toBe("dismissed");
+    expect(report.dismissalReason).toBe("no_violation");
+  });
+
+  it("uses smart default — notifies first-time reporter", async () => {
+    // rp_1 starts with count=0 in REPORTER_HISTORY — a fresh first-time reporter.
+    // Use a unique id to avoid cross-test contamination from the previous test
+    // that incremented rp_1's count.
+    const { report } = await dismissReport({
+      reportId: "rpt_ft_test",
+      reporterId: "rp_1_fresh", // unknown → count defaults to 0 → first-time
+      reason: "duplicate",
+    });
+    expect(report.reporterNotified).toBe(true);
+  });
+
+  it("uses smart default — does NOT notify repeat reporter", async () => {
+    const { report } = await dismissReport({
+      reportId: "rpt_0002",
+      reporterId: "rp_2",
+      reason: "already_handled",
+    });
+    expect(report.reporterNotified).toBe(false);
+  });
+
+  it("respects an explicit notify:true override for a repeat reporter", async () => {
+    const { report } = await dismissReport({
+      reportId: "rpt_0003",
+      reporterId: "rp_3",
+      reason: "duplicate",
+      notify: true,
+    });
+    expect(report.reporterNotified).toBe(true);
+  });
+
+  it("respects an explicit notify:false override for a first-time reporter", async () => {
+    const { report } = await dismissReport({
+      reportId: "rpt_0004",
+      reporterId: "rp_1_override",
+      reason: "insufficient_evidence",
+      notify: false,
+    });
+    expect(report.reporterNotified).toBe(false);
+  });
+
+  it("returns a notificationId when notify is true", async () => {
+    const result = await dismissReport({
+      reportId: "rpt_0005",
+      reporterId: "rp_1_nid",
+      reason: "no_violation",
+      notify: true,
+    });
+    expect(typeof result.notificationId).toBe("string");
+    expect(result.notificationId.length).toBeGreaterThan(0);
+  });
+
+  it("returns null notificationId when notify is false", async () => {
+    const result = await dismissReport({
+      reportId: "rpt_0006",
+      reporterId: "rp_2",
+      reason: "already_handled",
+      notify: false,
+    });
+    expect(result.notificationId).toBeNull();
+  });
+});
+
+// ============================================================================
+// 5. DismissReportDialog — component tests
+// ============================================================================
+
+const FIRST_TIME_REPORT = {
+  id: "rpt_dialog_1",
+  reporter: { id: "rp_1_dialog", name: "Sarah A." },
+};
+
+const REPEAT_REPORT = {
+  id: "rpt_dialog_2",
+  reporter: { id: "rp_2", name: "Mohammed B." },
+};
+
+function renderDialog(report = REPEAT_REPORT, overrides = {}) {
+  const onOpenChange = overrides.onOpenChange ?? vi.fn();
+  const onDismissed = overrides.onDismissed ?? vi.fn();
+  render(
+    <DismissReportDialog
+      open
+      onOpenChange={onOpenChange}
+      report={report}
+      onDismissed={onDismissed}
+    />
+  );
+  return { onOpenChange, onDismissed };
+}
+
+describe("DismissReportDialog", () => {
+  it("renders the title and reason picker", async () => {
+    renderDialog();
+    expect(screen.getByRole("heading", { name: /dismiss report/i })).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("Dismiss Report button is disabled until a reason is selected", async () => {
+    renderDialog();
+    await waitFor(() =>
+      expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument()
+    );
+    const submitBtn = screen.getByRole("button", { name: /confirm dismissal/i });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it("cancel button calls onOpenChange(false)", async () => {
+    const { onOpenChange } = renderDialog();
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("shows notify checkbox with OFF default for repeat reporter", async () => {
+    renderDialog(REPEAT_REPORT);
+    // Wait for the smart-default useEffect to resolve
+    await waitFor(() => {
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).not.toBeChecked();
+    });
+  });
+
+  it("shows notify checkbox with ON default for first-time reporter", async () => {
+    renderDialog(FIRST_TIME_REPORT);
+    await waitFor(() => {
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).toBeChecked();
+    });
+  });
+
+  it("lists all four dismissal reasons in the picker", async () => {
+    renderDialog();
+    // Open the select
+    fireEvent.click(screen.getByRole("combobox"));
+    await waitFor(() => {
+      expect(screen.getByText("Doesn't violate policy")).toBeInTheDocument();
+      expect(screen.getByText("Already handled")).toBeInTheDocument();
+      expect(screen.getByText("Insufficient evidence")).toBeInTheDocument();
+      expect(screen.getByText("Duplicate")).toBeInTheDocument();
+    });
+  });
+
+  it("enables the submit button once a reason is selected", async () => {
+    renderDialog();
+    await waitFor(() =>
+      expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument()
+    );
+
+    // Open select and pick a reason
+    fireEvent.click(screen.getByRole("combobox"));
+    await waitFor(() =>
+      screen.getByText("Doesn't violate policy")
+    );
+    fireEvent.click(screen.getByText("Doesn't violate policy"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /confirm dismissal.*violate/i })).toBeEnabled()
+    );
+  });
+
+  it("calls onDismissed and closes dialog after successful submission", async () => {
+    const { onDismissed, onOpenChange } = renderDialog();
+    await waitFor(() =>
+      expect(screen.queryByLabelText(/loading/i)).not.toBeInTheDocument()
+    );
+
+    fireEvent.click(screen.getByRole("combobox"));
+    await waitFor(() => screen.getByText("Already handled"));
+    fireEvent.click(screen.getByText("Already handled"));
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /confirm dismissal.*already/i })).toBeEnabled()
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /confirm dismissal.*already/i }));
+    });
+
+    await waitFor(() => expect(onDismissed).toHaveBeenCalledWith(REPEAT_REPORT.id));
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+  });
+
+  it("allows toggling the notify checkbox", async () => {
+    renderDialog(REPEAT_REPORT);
+    await waitFor(() => {
+      const checkbox = screen.getByRole("checkbox");
+      expect(checkbox).not.toBeChecked();
+    });
+    fireEvent.click(screen.getByRole("checkbox"));
+    await waitFor(() =>
+      expect(screen.getByRole("checkbox")).toBeChecked()
+    );
+  });
+});

--- a/app/[locale]/admin/reports/page.jsx
+++ b/app/[locale]/admin/reports/page.jsx
@@ -74,6 +74,7 @@ import {
 import { cn } from "@/lib/utils";
 import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
 import { formatDistanceToNow } from "date-fns";
+import DismissReportDialog from "@/components/admin/DismissReportDialog";
 
 // Content type definitions with icons and colors
 const CONTENT_TYPES = {
@@ -235,6 +236,9 @@ export default function UnifiedReportsPage() {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const tableRef = useRef(null);
   const pageSize = 15;
+  // Dismiss dialog state
+  const [isDismissDialogOpen, setIsDismissDialogOpen] = useState(false);
+  const [dismissTarget, setDismissTarget] = useState(null);
 
   // Keyboard navigation
   useEffect(() => {
@@ -273,7 +277,8 @@ export default function UnifiedReportsPage() {
         case "d":
           e.preventDefault();
           if (reports[selectedIndex]) {
-            handleStatusChange(reports[selectedIndex].id, "dismissed");
+            setDismissTarget(reports[selectedIndex]);
+            setIsDismissDialogOpen(true);
           }
           break;
       }
@@ -592,7 +597,10 @@ export default function UnifiedReportsPage() {
                                 Mark Resolved
                               </DropdownMenuItem>
                               <DropdownMenuItem
-                                onClick={() => handleStatusChange(report.id, "dismissed")}
+                                onClick={() => {
+                                  setDismissTarget(report);
+                                  setIsDismissDialogOpen(true);
+                                }}
                               >
                                 <XCircle className="h-4 w-4 mr-2" />
                                 Dismiss
@@ -659,6 +667,21 @@ export default function UnifiedReportsPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Dismiss Report Dialog */}
+      {dismissTarget && (
+        <DismissReportDialog
+          open={isDismissDialogOpen}
+          onOpenChange={(open) => {
+            setIsDismissDialogOpen(open);
+            if (!open) setDismissTarget(null);
+          }}
+          report={dismissTarget}
+          onDismissed={(reportId) => {
+            handleStatusChange(reportId, "dismissed");
+          }}
+        />
+      )}
     </PageShell>
   );
 }

--- a/components/admin/DismissReportDialog.jsx
+++ b/components/admin/DismissReportDialog.jsx
@@ -1,0 +1,238 @@
+"use client";
+
+/**
+ * DismissReportDialog — structured dismissal flow for moderation reports (#293).
+ *
+ * Responsibilities:
+ *  - Present the four predefined dismissal reasons via a Select picker.
+ *  - Show an optional "notify reporter" checkbox.
+ *  - Smart default for the checkbox: ON for first-time reporters, OFF for
+ *    repeat reporters (derived via `isFirstTimeReporter` from the action
+ *    module). The default is fetched on open so the checkbox is pre-populated
+ *    correctly without the admin needing to think about it.
+ *  - Delegates the actual mutation (dismiss + optional notification) to
+ *    `dismissReport` from `lib/actions/admin-moderation.js`.
+ *  - Fires an audit event via the action module (fire-and-forget, non-blocking).
+ */
+
+import { useState, useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Loader2, XCircle } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500 } from "@/lib/config/font.config";
+import {
+  DISMISSAL_REASONS,
+  isFirstTimeReporter,
+  dismissReport,
+} from "@/lib/actions/admin-moderation";
+
+/**
+ * @param {object}  props
+ * @param {boolean} props.open              Dialog visibility.
+ * @param {(open: boolean) => void} props.onOpenChange  Close handler.
+ * @param {{ id: string, reporter: { id: string, name: string } }} props.report
+ *   The report being dismissed. `report.reporter.id` drives the smart default.
+ * @param {(reportId: string) => void} props.onDismissed
+ *   Called after a successful dismissal so the parent can update list state.
+ */
+export default function DismissReportDialog({
+  open,
+  onOpenChange,
+  report,
+  onDismissed,
+}) {
+  const [reason, setReason] = useState("");
+  const [notify, setNotify] = useState(false);
+  const [loadingDefault, setLoadingDefault] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Derive smart default for the notify checkbox whenever the dialog opens or
+  // the report changes. First-time reporters default to notified; repeat
+  // reporters default to not notified to avoid spamming them.
+  useEffect(() => {
+    if (!open || !report?.reporter?.id) return;
+
+    setReason("");
+    setError(null);
+    setLoadingDefault(true);
+
+    isFirstTimeReporter(report.reporter.id)
+      .then((firstTime) => {
+        setNotify(firstTime);
+      })
+      .catch(() => {
+        // Fallback: default OFF if we can't determine reporter history.
+        setNotify(false);
+      })
+      .finally(() => {
+        setLoadingDefault(false);
+      });
+  }, [open, report?.reporter?.id]);
+
+  const canSubmit = reason !== "" && !submitting && !loadingDefault;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      await dismissReport({
+        reportId: report.id,
+        reporterId: report.reporter.id,
+        reason,
+        notify,
+      });
+      onDismissed?.(report.id);
+      onOpenChange(false);
+    } catch (err) {
+      setError(err?.message || "Failed to dismiss report. Please try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCancel = () => {
+    if (submitting) return;
+    onOpenChange(false);
+  };
+
+  const reasonLabel =
+    DISMISSAL_REASONS.find((r) => r.value === reason)?.label ?? "";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className={cn("flex items-center gap-2", poppins_500.className)}>
+            <XCircle className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+            Dismiss Report
+          </DialogTitle>
+          <DialogDescription className={poppins_400.className}>
+            Select a reason for dismissal. The reason is recorded in the audit
+            log and optionally shared with the reporter.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-5 py-2">
+          {/* Reason picker */}
+          <div className="space-y-2">
+            <Label htmlFor="dismiss-reason" className={poppins_500.className}>
+              Dismissal reason <span aria-hidden="true" className="text-destructive">*</span>
+            </Label>
+            <Select
+              value={reason}
+              onValueChange={setReason}
+              disabled={submitting}
+            >
+              <SelectTrigger id="dismiss-reason" className="w-full">
+                <SelectValue placeholder="Select a reason…" />
+              </SelectTrigger>
+              <SelectContent>
+                {DISMISSAL_REASONS.map(({ value, label }) => (
+                  <SelectItem key={value} value={value}>
+                    {label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* Notify checkbox */}
+          <div className="flex items-start gap-3">
+            {loadingDefault ? (
+              <Loader2
+                className="h-4 w-4 mt-0.5 animate-spin text-muted-foreground"
+                aria-label="Loading notification preference"
+              />
+            ) : (
+              <Checkbox
+                id="dismiss-notify"
+                checked={notify}
+                onCheckedChange={(checked) => setNotify(Boolean(checked))}
+                disabled={submitting}
+              />
+            )}
+            <div className="space-y-0.5">
+              <Label
+                htmlFor="dismiss-notify"
+                className={cn("cursor-pointer leading-snug", poppins_500.className)}
+              >
+                Notify reporter
+              </Label>
+              <p className={cn("text-xs text-muted-foreground", poppins_400.className)}>
+                Send a courtesy message letting{" "}
+                <strong>{report?.reporter?.name ?? "the reporter"}</strong> know
+                their report was reviewed.{" "}
+                {!loadingDefault && (
+                  <span className="text-muted-foreground/70">
+                    {notify
+                      ? "(on by default — first-time reporter)"
+                      : "(off by default — repeat reporter)"}
+                  </span>
+                )}
+              </p>
+            </div>
+          </div>
+
+          {/* Error message */}
+          {error && (
+            <p
+              role="alert"
+              className={cn("text-sm text-destructive", poppins_400.className)}
+            >
+              {error}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button
+            variant="outline"
+            onClick={handleCancel}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            aria-label={
+              reasonLabel
+                ? `Confirm dismissal: ${reasonLabel}`
+                : "Confirm dismissal (select a reason first)"
+            }
+          >
+            {submitting ? (
+              <>
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
+                Dismissing…
+              </>
+            ) : (
+              "Dismiss Report"
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/actions/admin-moderation.js
+++ b/lib/actions/admin-moderation.js
@@ -1,10 +1,10 @@
 /**
- * Admin content-moderation service — takedown / restore.
+ * Admin content-moderation service — takedown / restore / report dismissal.
  * ---------------------------------------------------------------------------
- * **STUBBED (#309).** The takedown flow has no backend yet, so this module
- * mocks the mutation to demonstrate the shared audit-logging integration
- * (`lib/admin/audit.js`). Swap the mock body for an `axiosInstance` call (see
- * `lib/config/axios.config.js`) when the backend lands.
+ * **STUBBED (#309, #293).** The takedown and dismissal flows have no backend
+ * yet, so this module mocks mutations to demonstrate the shared audit-logging
+ * integration (`lib/admin/audit.js`). Swap mock bodies for `axiosInstance`
+ * calls (see `lib/config/axios.config.js`) when the backend lands.
  */
 
 import { logAuditEvent, AUDIT_ACTIONS } from "@/lib/admin/audit";
@@ -13,6 +13,207 @@ const MOCK_DELAY_MS = 300;
 
 function withMockDelay(value) {
   return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_DELAY_MS));
+}
+
+/**
+ * Predefined dismissal reasons shown to the admin in the picker.
+ * These are the only accepted values for `dismissReport`'s `reason` param.
+ *
+ * @readonly
+ */
+export const DISMISSAL_REASONS = Object.freeze([
+  {
+    value: "no_violation",
+    label: "Doesn't violate policy",
+  },
+  {
+    value: "already_handled",
+    label: "Already handled",
+  },
+  {
+    value: "insufficient_evidence",
+    label: "Insufficient evidence",
+  },
+  {
+    value: "duplicate",
+    label: "Duplicate",
+  },
+]);
+
+/** All valid reason values, for fast validation. */
+const VALID_DISMISSAL_REASONS = new Set(DISMISSAL_REASONS.map((r) => r.value));
+
+// ---------------------------------------------------------------------------
+// Reporter history (first-time vs. repeat reporter detection)
+// ---------------------------------------------------------------------------
+
+/**
+ * In-memory reporter submission history: maps `reporterId → count`.
+ *
+ * In production this would be fetched from the backend.
+ * TODO(backend): GET /api/admin/reporters/:id/report-count
+ *   - 200 → { reporterId: string, count: number }
+ *
+ * Pre-seeded so the UI demo behaves consistently across page loads within
+ * the same session. Reporters rp_2..rp_5 have submitted before; rp_1 has not.
+ *
+ * @type {Map<string, number>}
+ */
+const REPORTER_HISTORY = new Map([
+  ["rp_1", 0], // first-time — smart default: notify ON
+  ["rp_2", 3],
+  ["rp_3", 7],
+  ["rp_4", 2],
+  ["rp_5", 5],
+]);
+
+/**
+ * Increment the in-memory report count for a reporter after a successful
+ * dismissal so subsequent calls within the same session reflect the latest
+ * state.
+ *
+ * @param {string} reporterId
+ */
+function incrementReporterCount(reporterId) {
+  REPORTER_HISTORY.set(reporterId, (REPORTER_HISTORY.get(reporterId) ?? 0) + 1);
+}
+
+/**
+ * Get the number of reports a reporter has previously submitted.
+ *
+ * TODO(backend): GET /api/admin/reporters/:id/report-count
+ *
+ * @param {string} reporterId
+ * @returns {Promise<number>}
+ */
+export async function getReporterReportCount(reporterId) {
+  return Promise.resolve(REPORTER_HISTORY.get(reporterId) ?? 0);
+}
+
+/**
+ * Determine whether a reporter is first-time (no prior reports) or repeat.
+ *
+ * TODO(backend): Derived from GET /api/admin/reporters/:id/report-count
+ *
+ * @param {string} reporterId
+ * @returns {Promise<boolean>} `true` if this is the reporter's first report.
+ */
+export async function isFirstTimeReporter(reporterId) {
+  const count = await getReporterReportCount(reporterId);
+  return count === 0;
+}
+
+// ---------------------------------------------------------------------------
+// Courtesy notification stub
+// ---------------------------------------------------------------------------
+
+/**
+ * Send a courtesy notification to a reporter informing them that their report
+ * was reviewed but dismissed. This is a **stub** — the actual delivery is
+ * blocked until the announcements / notification infrastructure is ready.
+ *
+ * TODO(backend): POST /api/admin/notifications/reporter-courtesy
+ *   - Auth: admin session.
+ *   - Payload: { reporterId: string, reportId: string, dismissalReason: string }
+ *   - 202 → { queued: true, notificationId: string }
+ *
+ * @param {{ reporterId: string, reportId: string, dismissalReason: string }} params
+ * @returns {Promise<{ queued: boolean, notificationId: string }>}
+ */
+export async function sendDismissalNotification({ reporterId, reportId, dismissalReason } = {}) {
+  // TODO(backend):
+  //   const { data } = await axiosInstance.post(
+  //     "/api/admin/notifications/reporter-courtesy",
+  //     { reporterId, reportId, dismissalReason },
+  //   );
+  const result = await withMockDelay({
+    queued: true,
+    notificationId: `ntf_${Math.random().toString(36).slice(2, 10)}`,
+  });
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Dismissal action
+// ---------------------------------------------------------------------------
+
+/**
+ * Dismiss a report with a structured reason and optionally notify the
+ * reporter, then emit a non-blocking audit event.
+ *
+ * First-time reporters receive a notification by default; repeat reporters
+ * do not. Callers may override this default by passing an explicit
+ * `notify` boolean (the checkbox value from `DismissReportDialog`).
+ *
+ * TODO(backend): POST /api/admin/reports/:id/dismiss
+ *   - Auth: admin session (server-side tier check).
+ *   - Payload: { reason: string, notify: boolean }
+ *   - 200 → { report: { id, status: "dismissed", dismissalReason: string,
+ *               reporterNotified: boolean } }
+ *   - 422 for an unknown reason value.
+ *
+ * @param {{
+ *   reportId: string,
+ *   reporterId: string,
+ *   reason: string,
+ *   notify?: boolean,
+ * }} params
+ * @returns {Promise<{
+ *   report: { id: string, status: "dismissed", dismissalReason: string, reporterNotified: boolean },
+ *   notificationId: string | null,
+ * }>}
+ */
+export async function dismissReport({ reportId, reporterId, reason, notify } = {}) {
+  if (!reportId) throw new Error("reportId is required.");
+  if (!reporterId) throw new Error("reporterId is required.");
+  if (!VALID_DISMISSAL_REASONS.has(reason)) {
+    throw new Error(`Invalid dismissal reason: "${reason}". Must be one of: ${[...VALID_DISMISSAL_REASONS].join(", ")}.`);
+  }
+
+  // Resolve smart default: notify ON for first-time reporters, OFF for repeat.
+  const firstTime = await isFirstTimeReporter(reporterId);
+  const shouldNotify = notify !== undefined ? notify : firstTime;
+
+  // TODO(backend):
+  //   const { data } = await axiosInstance.post(
+  //     `/api/admin/reports/${reportId}/dismiss`,
+  //     { reason, notify: shouldNotify },
+  //   );
+  const result = await withMockDelay({
+    report: {
+      id: reportId,
+      status: "dismissed",
+      dismissalReason: reason,
+      reporterNotified: shouldNotify,
+    },
+  });
+
+  // Optionally send the courtesy notification stub.
+  let notificationId = null;
+  if (shouldNotify) {
+    const { notificationId: nid } = await sendDismissalNotification({
+      reporterId,
+      reportId,
+      dismissalReason: reason,
+    });
+    notificationId = nid;
+  }
+
+  // Update in-memory history so isFirstTimeReporter reflects the new state.
+  incrementReporterCount(reporterId);
+
+  // Fire-and-forget audit trail.
+  logAuditEvent({
+    action: AUDIT_ACTIONS.REPORT_DISMISS,
+    target: {
+      label: `Report ${reportId}`,
+      id: reportId,
+      href: `/admin/reports`,
+    },
+    metadata: { reporterId, reason, reporterNotified: shouldNotify },
+  });
+
+  return { ...result, notificationId };
 }
 
 /**

--- a/lib/admin/audit.js
+++ b/lib/admin/audit.js
@@ -60,6 +60,7 @@ export const AUDIT_ACTIONS = Object.freeze({
   // Content moderation
   TAKEDOWN: "content.takedown",
   RESTORE: "content.restore",
+  REPORT_DISMISS: "report.dismiss",
 
   // Payments
   REFUND: "payment.refund",
@@ -104,6 +105,7 @@ const ACTION_CATEGORY = Object.freeze({
   [AUDIT_ACTIONS.SUSPEND]: "user",
   [AUDIT_ACTIONS.TAKEDOWN]: "moderation",
   [AUDIT_ACTIONS.RESTORE]: "moderation",
+  [AUDIT_ACTIONS.REPORT_DISMISS]: "moderation",
   [AUDIT_ACTIONS.REFUND]: "payment",
   [AUDIT_ACTIONS.BROADCAST]: "system",
   [AUDIT_ACTIONS.FLAG_TOGGLE]: "system",


### PR DESCRIPTION
Closes #293
- Add DISMISSAL_REASONS constant (4 options: no_violation, already_handled, insufficient_evidence, duplicate)
- Add reporter history tracking (getReporterReportCount, isFirstTimeReporter)
- Add sendDismissalNotification stub ready for announcements infrastructure
- Add dismissReport action with smart default notify logic: ON for first-time reporters, OFF for repeat reporters
- Add REPORT_DISMISS audit action constant
- Add DismissReportDialog component with reason picker + notify checkbox
- Wire DismissReportDialog into reports queue page (dropdown + kbd shortcut)
- Add 28 passing tests covering service logic and dialog interactions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided dialog for dismissing admin reports.
  * Admins can select a dismissal reason and optionally notify the reporter.
  * Added smart notification defaults based on reporter history.
  * Confirmed dismissals now update report status and record an audit event.

* **Bug Fixes**
  * Prevented accidental report dismissal by requiring confirmation before status changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->