### PR TITLE
Fix: [Enhancement] Scheduled publishing queue for reels (Auto-Generated)

### DIFF
--- a/__tests__/admin/scheduled-reels.service.test.js
+++ b/__tests__/admin/scheduled-reels.service.test.js
@@ -1,20 +1,41 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { notifyCreator } = vi.hoisted(() => ({
+const { notifyCreator, cookiesMock } = vi.hoisted(() => ({
   notifyCreator: vi.fn().mockResolvedValue({
     success: true,
     notificationId: "stub_notification",
     deliveredBy: "stub",
   }),
+  cookiesMock: vi.fn(),
 }));
 
 vi.mock("@/lib/services/creator-notifications", () => ({
   notifyCreatorOfScheduledReelCancellation: notifyCreator,
 }));
 
+vi.mock("next/headers", () => ({
+  cookies: cookiesMock,
+}));
+
 beforeEach(() => {
   vi.resetModules();
-  notifyCreator.mockClear();
+  vi.clearAllMocks();
+  process.env.NEXT_PUBLIC_API_URL = "https://api.example.com";
+  cookiesMock.mockResolvedValue({
+    toString: () => "session=authenticated-session",
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        user: {
+          id: "admin_from_session",
+          role: "admin",
+        },
+      }),
+    })
+  );
 });
 
 describe("scheduled reels service", () => {
@@ -29,7 +50,9 @@ describe("scheduled reels service", () => {
     expect(reels.length).toBeGreaterThan(0);
     expect(timestamps).toEqual([...timestamps].sort((a, b) => a - b));
     expect(reels.every((reel) => reel.status === "scheduled")).toBe(true);
-    expect(reels.every((reel) => Date.parse(reel.scheduledFor) > Date.now())).toBe(true);
+    expect(
+      reels.every((reel) => Date.parse(reel.scheduledFor) > Date.now())
+    ).toBe(true);
   });
 
   it("cancels an upcoming reel and notifies its creator", async () => {
@@ -58,6 +81,54 @@ describe("scheduled reels service", () => {
 
     const remaining = await listUpcomingScheduledReels();
     expect(remaining.some((item) => item.id === reel.id)).toBe(false);
+  });
+
+  it("derives the cancelling administrator from the authenticated server session", async () => {
+    const { listUpcomingScheduledReels } = await import(
+      "@/lib/services/scheduled-reels"
+    );
+    const [reel] = await listUpcomingScheduledReels();
+    const { cancelScheduledReelAction } = await import(
+      "@/lib/actions/scheduled-reels"
+    );
+
+    const result = await cancelScheduledReelAction(
+      reel.id,
+      "Session-authorized cancellation"
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      "https://api.example.com/api/auth/me",
+      expect.objectContaining({
+        method: "GET",
+        headers: {
+          cookie: "session=authenticated-session",
+        },
+        cache: "no-store",
+      })
+    );
+    expect(result.reel.cancelledBy).toBe("admin_from_session");
+    expect(notifyCreator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reelId: reel.id,
+        cancelledBy: "admin_from_session",
+        reason: "Session-authorized cancellation",
+      })
+    );
+  });
+
+  it("rejects cancellation when no authenticated session is present", async () => {
+    cookiesMock.mockResolvedValueOnce({
+      toString: () => "",
+    });
+    const { cancelScheduledReelAction } = await import(
+      "@/lib/actions/scheduled-reels"
+    );
+
+    await expect(
+      cancelScheduledReelAction("reel_scheduled_101", "Unauthorized")
+    ).rejects.toThrow("Authentication is required to manage scheduled reels.");
+    expect(notifyCreator).not.toHaveBeenCalled();
   });
 
   it("rejects cancellation when the scheduled reel does not exist", async () => {

--- a/__tests__/admin/scheduled-reels.service.test.js
+++ b/__tests__/admin/scheduled-reels.service.test.js
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { notifyCreator } = vi.hoisted(() => ({
+  notifyCreator: vi.fn().mockResolvedValue({
+    success: true,
+    notificationId: "stub_notification",
+    deliveredBy: "stub",
+  }),
+}));
+
+vi.mock("@/lib/services/creator-notifications", () => ({
+  notifyCreatorOfScheduledReelCancellation: notifyCreator,
+}));
+
+beforeEach(() => {
+  vi.resetModules();
+  notifyCreator.mockClear();
+});
+
+describe("scheduled reels service", () => {
+  it("returns upcoming scheduled reels sorted by go-live time", async () => {
+    const { listUpcomingScheduledReels } = await import(
+      "@/lib/services/scheduled-reels"
+    );
+
+    const reels = await listUpcomingScheduledReels();
+    const timestamps = reels.map((reel) => Date.parse(reel.scheduledFor));
+
+    expect(reels.length).toBeGreaterThan(0);
+    expect(timestamps).toEqual([...timestamps].sort((a, b) => a - b));
+    expect(reels.every((reel) => reel.status === "scheduled")).toBe(true);
+    expect(reels.every((reel) => Date.parse(reel.scheduledFor) > Date.now())).toBe(true);
+  });
+
+  it("cancels an upcoming reel and notifies its creator", async () => {
+    const { cancelScheduledReel, listUpcomingScheduledReels } = await import(
+      "@/lib/services/scheduled-reels"
+    );
+    const [reel] = await listUpcomingScheduledReels();
+
+    const result = await cancelScheduledReel(reel.id, {
+      cancelledBy: "admin_test",
+      reason: "Editorial review",
+    });
+
+    expect(result.reel.status).toBe("cancelled");
+    expect(result.reel.cancelledBy).toBe("admin_test");
+    expect(result.reel.cancellationReason).toBe("Editorial review");
+    expect(notifyCreator).toHaveBeenCalledOnce();
+    expect(notifyCreator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creatorId: reel.creator.id,
+        reelId: reel.id,
+        cancelledBy: "admin_test",
+        reason: "Editorial review",
+      })
+    );
+
+    const remaining = await listUpcomingScheduledReels();
+    expect(remaining.some((item) => item.id === reel.id)).toBe(false);
+  });
+
+  it("rejects cancellation when the scheduled reel does not exist", async () => {
+    const { cancelScheduledReel } = await import(
+      "@/lib/services/scheduled-reels"
+    );
+
+    await expect(
+      cancelScheduledReel("missing_reel", { cancelledBy: "admin_test" })
+    ).rejects.toThrow("Scheduled reel was not found.");
+    expect(notifyCreator).not.toHaveBeenCalled();
+  });
+
+  it("exports the expected scheduling fields for platform integration", async () => {
+    const { SCHEDULED_REEL_FIELDS } = await import(
+      "@/lib/services/scheduled-reels"
+    );
+
+    expect(SCHEDULED_REEL_FIELDS).toEqual(
+      expect.objectContaining({
+        id: expect.any(String),
+        creator: expect.any(String),
+        scheduledFor: expect.any(String),
+        timezone: expect.any(String),
+        status: expect.any(String),
+        cancelledAt: expect.any(String),
+        cancelledBy: expect.any(String),
+        cancellationReason: expect.any(String),
+      })
+    );
+  });
+});

--- a/app/[locale]/admin/page.jsx
+++ b/app/[locale]/admin/page.jsx
@@ -1,12 +1,24 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { CalendarClock, Clock3, Film, Loader2, RefreshCw, XCircle } from "lucide-react";
-import { format } from "date-fns";
+import {
+  CalendarClock,
+  Clock3,
+  Film,
+  Loader2,
+  RefreshCw,
+  XCircle,
+} from "lucide-react";
 import { toast } from "sonner";
 import { PageShell } from "@/components/ui/page-shell";
 import { PageHeader } from "@/components/ui/page-header";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
@@ -30,9 +42,9 @@ import {
 } from "@/components/ui/table";
 import { EmptyState } from "@/components/ui/empty-state";
 import {
-  cancelScheduledReel,
-  listUpcomingScheduledReels,
-} from "@/lib/services/scheduled-reels";
+  cancelScheduledReelAction,
+  listUpcomingScheduledReelsAction,
+} from "@/lib/actions/scheduled-reels";
 
 function creatorInitials(name) {
   return name
@@ -44,11 +56,26 @@ function creatorInitials(name) {
     .toUpperCase();
 }
 
-function formatGoLive(timestamp) {
+export function formatGoLive(timestamp, timezone) {
   const date = new Date(timestamp);
-  return Number.isNaN(date.getTime())
-    ? "Invalid schedule"
-    : format(date, "MMM d, yyyy 'at' h:mm a");
+
+  if (Number.isNaN(date.getTime())) {
+    return "Invalid schedule";
+  }
+
+  try {
+    return new Intl.DateTimeFormat("en-US", {
+      timeZone: timezone,
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+      hour12: true,
+    }).format(date);
+  } catch {
+    return "Invalid schedule";
+  }
 }
 
 export default function ScheduledReelsQueuePage() {
@@ -64,11 +91,15 @@ export default function ScheduledReelsQueuePage() {
     setLoadError("");
 
     try {
-      const upcomingReels = await listUpcomingScheduledReels();
+      const upcomingReels = await listUpcomingScheduledReelsAction();
       setReels(upcomingReels);
-    } catch {
+    } catch (error) {
       setReels([]);
-      setLoadError("The scheduled reels queue could not be loaded.");
+      setLoadError(
+        error instanceof Error
+          ? error.message
+          : "The scheduled reels queue could not be loaded."
+      );
     } finally {
       setLoading(false);
     }
@@ -89,18 +120,17 @@ export default function ScheduledReelsQueuePage() {
 
     setCancelling(true);
     try {
-      await cancelScheduledReel(selectedReel.id, {
-        cancelledBy: "current-admin",
-        reason,
-      });
-      setReels((current) =>
-        current.filter((reel) => reel.id !== selectedReel.id)
-      );
+      await cancelScheduledReelAction(selectedReel.id, reason);
+      await loadQueue();
       setSelectedReel(null);
       setReason("");
       toast.success("Scheduled reel cancelled and creator notified.");
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : "The reel could not be cancelled.");
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : "The reel could not be cancelled."
+      );
     } finally {
       setCancelling(false);
     }
@@ -113,7 +143,12 @@ export default function ScheduledReelsQueuePage() {
         description="Review and manage reels waiting to be published. Upcoming items are ordered by go-live time."
         icon={CalendarClock}
         actions={
-          <Button variant="outline" onClick={loadQueue} disabled={loading}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={loadQueue}
+            disabled={loading || cancelling}
+          >
             <RefreshCw className={loading ? "animate-spin" : ""} />
             Refresh
           </Button>
@@ -131,13 +166,16 @@ export default function ScheduledReelsQueuePage() {
             </CardDescription>
           </div>
           <Badge variant="secondary" className="shrink-0">
-            <Clock3 className="mr-1 h-3.5 w-3.5" />
+            <Clock3 className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
             Earliest first
           </Badge>
         </CardHeader>
         <CardContent>
           {loading ? (
-            <div className="flex min-h-64 items-center justify-center" role="status">
+            <div
+              className="flex min-h-64 items-center justify-center"
+              role="status"
+            >
               <Loader2 className="h-7 w-7 animate-spin text-accent" />
               <span className="sr-only">Loading scheduled reels</span>
             </div>
@@ -147,7 +185,7 @@ export default function ScheduledReelsQueuePage() {
               title="Unable to load the queue"
               description={loadError}
               action={
-                <Button variant="outline" onClick={loadQueue}>
+                <Button type="button" variant="outline" onClick={loadQueue}>
                   Try again
                 </Button>
               }
@@ -176,42 +214,56 @@ export default function ScheduledReelsQueuePage() {
                       <TableCell className="min-w-72">
                         <div className="flex items-center gap-3">
                           <div className="flex h-12 w-16 shrink-0 items-center justify-center rounded-lg bg-secondary/10">
-                            <Film className="h-5 w-5 text-accent" aria-hidden="true" />
+                            <Film
+                              className="h-5 w-5 text-accent"
+                              aria-hidden="true"
+                            />
                           </div>
                           <div>
                             <p className="line-clamp-2 max-w-sm font-medium text-ink">
                               {reel.caption}
                             </p>
-                            <p className="mt-1 text-xs text-ink-muted">{reel.id}</p>
+                            <p className="mt-1 text-xs text-ink-muted">
+                              {reel.id}
+                            </p>
                           </div>
                         </div>
                       </TableCell>
                       <TableCell>
                         <div className="flex min-w-52 items-center gap-3">
                           <Avatar className="h-9 w-9">
-                            <AvatarFallback>{creatorInitials(reel.creator.name)}</AvatarFallback>
+                            <AvatarFallback>
+                              {creatorInitials(reel.creator.name)}
+                            </AvatarFallback>
                           </Avatar>
                           <div>
-                            <p className="font-medium text-ink">{reel.creator.name}</p>
-                            <p className="text-xs text-ink-muted">{reel.creator.email}</p>
+                            <p className="font-medium text-ink">
+                              {reel.creator.name}
+                            </p>
+                            <p className="text-xs text-ink-muted">
+                              {reel.creator.email}
+                            </p>
                           </div>
                         </div>
                       </TableCell>
                       <TableCell className="min-w-56">
-                        <p className="font-medium text-ink">{formatGoLive(reel.scheduledFor)}</p>
-                        <p className="mt-1 text-xs text-ink-muted">{reel.timezone}</p>
+                        <p className="font-medium text-ink">
+                          {formatGoLive(reel.scheduledFor, reel.timezone)}
+                        </p>
+                        <p className="mt-1 text-xs text-ink-muted">
+                          {reel.timezone}
+                        </p>
                       </TableCell>
                       <TableCell>
                         <Badge variant="outline">Scheduled</Badge>
                       </TableCell>
                       <TableCell className="text-right">
                         <Button
+                          type="button"
                           variant="destructive"
                           size="sm"
                           onClick={() => setSelectedReel(reel)}
-                          aria-label={`Cancel scheduled reel by ${reel.creator.name}`}
                         >
-                          <XCircle />
                           Cancel
                         </Button>
                       </TableCell>
@@ -224,44 +276,71 @@ export default function ScheduledReelsQueuePage() {
         </CardContent>
       </Card>
 
-      <Dialog open={Boolean(selectedReel)} onOpenChange={(open) => !open && closeCancelDialog()}>
+      <Dialog
+        open={Boolean(selectedReel)}
+        onOpenChange={(open) => {
+          if (!open) closeCancelDialog();
+        }}
+      >
         <DialogContent>
           <DialogHeader>
             <DialogTitle>Cancel scheduled reel?</DialogTitle>
             <DialogDescription>
-              This removes the reel from the publishing queue. The creator will be notified about the cancellation.
+              This removes the reel from the upcoming publishing queue and
+              notifies its creator. The reel will not be published at its
+              scheduled time.
             </DialogDescription>
           </DialogHeader>
 
-          {selectedReel && (
-            <div className="space-y-4">
-              <div className="rounded-lg border bg-muted/30 p-4">
-                <p className="font-medium text-ink">{selectedReel.caption}</p>
-                <p className="mt-2 text-sm text-ink-muted">
-                  By {selectedReel.creator.name} · {formatGoLive(selectedReel.scheduledFor)}
+          {selectedReel ? (
+            <div className="space-y-4 py-2">
+              <div className="rounded-lg border bg-muted/30 p-3">
+                <p className="line-clamp-2 font-medium text-ink">
+                  {selectedReel.caption}
+                </p>
+                <p className="mt-1 text-sm text-ink-muted">
+                  {selectedReel.creator.name} · {formatGoLive(
+                    selectedReel.scheduledFor,
+                    selectedReel.timezone
+                  )} {selectedReel.timezone}
                 </p>
               </div>
+
               <div className="space-y-2">
-                <Label htmlFor="cancellation-reason">Reason for cancellation (optional)</Label>
+                <Label htmlFor="cancellation-reason">
+                  Reason for cancellation (optional)
+                </Label>
                 <Textarea
                   id="cancellation-reason"
                   value={reason}
                   onChange={(event) => setReason(event.target.value)}
                   placeholder="Add context for the creator"
-                  maxLength={500}
                   disabled={cancelling}
+                  maxLength={500}
                 />
               </div>
             </div>
-          )}
+          ) : null}
 
           <DialogFooter>
-            <Button variant="outline" onClick={closeCancelDialog} disabled={cancelling}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={closeCancelDialog}
+              disabled={cancelling}
+            >
               Keep scheduled
             </Button>
-            <Button variant="destructive" onClick={confirmCancellation} disabled={cancelling}>
-              {cancelling ? <Loader2 className="animate-spin" /> : <XCircle />}
-              {cancelling ? "Cancelling…" : "Cancel reel"}
+            <Button
+              type="button"
+              variant="destructive"
+              onClick={confirmCancellation}
+              disabled={cancelling}
+            >
+              {cancelling ? (
+                <Loader2 className="animate-spin" aria-hidden="true" />
+              ) : null}
+              {cancelling ? "Cancelling..." : "Cancel reel"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/[locale]/admin/page.jsx
+++ b/app/[locale]/admin/page.jsx
@@ -1,0 +1,271 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { CalendarClock, Clock3, Film, Loader2, RefreshCw, XCircle } from "lucide-react";
+import { format } from "date-fns";
+import { toast } from "sonner";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback } from "@/components/ui/avatar";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  cancelScheduledReel,
+  listUpcomingScheduledReels,
+} from "@/lib/services/scheduled-reels";
+
+function creatorInitials(name) {
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part[0])
+    .join("")
+    .toUpperCase();
+}
+
+function formatGoLive(timestamp) {
+  const date = new Date(timestamp);
+  return Number.isNaN(date.getTime())
+    ? "Invalid schedule"
+    : format(date, "MMM d, yyyy 'at' h:mm a");
+}
+
+export default function ScheduledReelsQueuePage() {
+  const [reels, setReels] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  const [selectedReel, setSelectedReel] = useState(null);
+  const [reason, setReason] = useState("");
+  const [cancelling, setCancelling] = useState(false);
+
+  const loadQueue = useCallback(async () => {
+    setLoading(true);
+    setLoadError("");
+
+    try {
+      const upcomingReels = await listUpcomingScheduledReels();
+      setReels(upcomingReels);
+    } catch {
+      setReels([]);
+      setLoadError("The scheduled reels queue could not be loaded.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadQueue();
+  }, [loadQueue]);
+
+  const closeCancelDialog = () => {
+    if (cancelling) return;
+    setSelectedReel(null);
+    setReason("");
+  };
+
+  const confirmCancellation = async () => {
+    if (!selectedReel) return;
+
+    setCancelling(true);
+    try {
+      await cancelScheduledReel(selectedReel.id, {
+        cancelledBy: "current-admin",
+        reason,
+      });
+      setReels((current) =>
+        current.filter((reel) => reel.id !== selectedReel.id)
+      );
+      setSelectedReel(null);
+      setReason("");
+      toast.success("Scheduled reel cancelled and creator notified.");
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "The reel could not be cancelled.");
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  return (
+    <PageShell>
+      <PageHeader
+        title="Scheduled reels"
+        description="Review and manage reels waiting to be published. Upcoming items are ordered by go-live time."
+        icon={CalendarClock}
+        actions={
+          <Button variant="outline" onClick={loadQueue} disabled={loading}>
+            <RefreshCw className={loading ? "animate-spin" : ""} />
+            Refresh
+          </Button>
+        }
+      />
+
+      <Card>
+        <CardHeader className="flex flex-row items-start justify-between gap-4">
+          <div>
+            <CardTitle>Upcoming publishing queue</CardTitle>
+            <CardDescription>
+              {reels.length === 1
+                ? "1 reel is scheduled to publish."
+                : `${reels.length} reels are scheduled to publish.`}
+            </CardDescription>
+          </div>
+          <Badge variant="secondary" className="shrink-0">
+            <Clock3 className="mr-1 h-3.5 w-3.5" />
+            Earliest first
+          </Badge>
+        </CardHeader>
+        <CardContent>
+          {loading ? (
+            <div className="flex min-h-64 items-center justify-center" role="status">
+              <Loader2 className="h-7 w-7 animate-spin text-accent" />
+              <span className="sr-only">Loading scheduled reels</span>
+            </div>
+          ) : loadError ? (
+            <EmptyState
+              icon={XCircle}
+              title="Unable to load the queue"
+              description={loadError}
+              action={
+                <Button variant="outline" onClick={loadQueue}>
+                  Try again
+                </Button>
+              }
+            />
+          ) : reels.length === 0 ? (
+            <EmptyState
+              icon={Film}
+              title="No scheduled reels"
+              description="There are no upcoming reels waiting to be published. New scheduled items will appear here automatically."
+            />
+          ) : (
+            <div className="overflow-x-auto rounded-lg border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Reel</TableHead>
+                    <TableHead>Creator</TableHead>
+                    <TableHead>Go-live time</TableHead>
+                    <TableHead>Status</TableHead>
+                    <TableHead className="text-right">Actions</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {reels.map((reel) => (
+                    <TableRow key={reel.id}>
+                      <TableCell className="min-w-72">
+                        <div className="flex items-center gap-3">
+                          <div className="flex h-12 w-16 shrink-0 items-center justify-center rounded-lg bg-secondary/10">
+                            <Film className="h-5 w-5 text-accent" aria-hidden="true" />
+                          </div>
+                          <div>
+                            <p className="line-clamp-2 max-w-sm font-medium text-ink">
+                              {reel.caption}
+                            </p>
+                            <p className="mt-1 text-xs text-ink-muted">{reel.id}</p>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex min-w-52 items-center gap-3">
+                          <Avatar className="h-9 w-9">
+                            <AvatarFallback>{creatorInitials(reel.creator.name)}</AvatarFallback>
+                          </Avatar>
+                          <div>
+                            <p className="font-medium text-ink">{reel.creator.name}</p>
+                            <p className="text-xs text-ink-muted">{reel.creator.email}</p>
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell className="min-w-56">
+                        <p className="font-medium text-ink">{formatGoLive(reel.scheduledFor)}</p>
+                        <p className="mt-1 text-xs text-ink-muted">{reel.timezone}</p>
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="outline">Scheduled</Badge>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => setSelectedReel(reel)}
+                          aria-label={`Cancel scheduled reel by ${reel.creator.name}`}
+                        >
+                          <XCircle />
+                          Cancel
+                        </Button>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={Boolean(selectedReel)} onOpenChange={(open) => !open && closeCancelDialog()}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Cancel scheduled reel?</DialogTitle>
+            <DialogDescription>
+              This removes the reel from the publishing queue. The creator will be notified about the cancellation.
+            </DialogDescription>
+          </DialogHeader>
+
+          {selectedReel && (
+            <div className="space-y-4">
+              <div className="rounded-lg border bg-muted/30 p-4">
+                <p className="font-medium text-ink">{selectedReel.caption}</p>
+                <p className="mt-2 text-sm text-ink-muted">
+                  By {selectedReel.creator.name} · {formatGoLive(selectedReel.scheduledFor)}
+                </p>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="cancellation-reason">Reason for cancellation (optional)</Label>
+                <Textarea
+                  id="cancellation-reason"
+                  value={reason}
+                  onChange={(event) => setReason(event.target.value)}
+                  placeholder="Add context for the creator"
+                  maxLength={500}
+                  disabled={cancelling}
+                />
+              </div>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={closeCancelDialog} disabled={cancelling}>
+              Keep scheduled
+            </Button>
+            <Button variant="destructive" onClick={confirmCancellation} disabled={cancelling}>
+              {cancelling ? <Loader2 className="animate-spin" /> : <XCircle />}
+              {cancelling ? "Cancelling…" : "Cancel reel"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </PageShell>
+  );
+}

--- a/lib/actions/scheduled-reels.js
+++ b/lib/actions/scheduled-reels.js
@@ -1,0 +1,86 @@
+"use server";
+
+import { cookies } from "next/headers";
+import {
+  cancelScheduledReel,
+  listUpcomingScheduledReels,
+} from "@/lib/services/scheduled-reels";
+
+const ADMIN_ROLES = new Set([
+  "admin",
+  "super-admin",
+  "super_admin",
+  "superadmin",
+]);
+
+function getApiBaseUrl() {
+  return process.env.API_URL || process.env.NEXT_PUBLIC_API_URL || "";
+}
+
+async function requireAdminSession() {
+  const cookieStore = await cookies();
+  const cookieHeader = cookieStore.toString();
+  const apiBaseUrl = getApiBaseUrl().replace(/\/$/, "");
+
+  if (!cookieHeader) {
+    throw new Error("Authentication is required to manage scheduled reels.");
+  }
+
+  if (!apiBaseUrl) {
+    throw new Error("Administrator session verification is unavailable.");
+  }
+
+  let response;
+  try {
+    response = await fetch(`${apiBaseUrl}/api/auth/me`, {
+      method: "GET",
+      headers: {
+        cookie: cookieHeader,
+      },
+      cache: "no-store",
+    });
+  } catch {
+    throw new Error("Administrator session verification is unavailable.");
+  }
+
+  if (!response.ok) {
+    throw new Error("Authentication is required to manage scheduled reels.");
+  }
+
+  const payload = await response.json();
+  const user = payload?.user ?? payload?.data?.user ?? payload?.data ?? payload;
+  const role =
+    typeof user?.role === "string" ? user.role : user?.role?.name;
+  const normalizedRole = role?.toLowerCase();
+
+  if (!normalizedRole || !ADMIN_ROLES.has(normalizedRole)) {
+    throw new Error("Administrator access is required to manage scheduled reels.");
+  }
+
+  const administratorId = user?.id ?? user?._id ?? user?.email;
+  if (!administratorId) {
+    throw new Error("The authenticated administrator could not be identified.");
+  }
+
+  return {
+    administratorId: String(administratorId),
+  };
+}
+
+export async function listUpcomingScheduledReelsAction() {
+  await requireAdminSession();
+  return listUpcomingScheduledReels();
+}
+
+export async function cancelScheduledReelAction(reelId, reason) {
+  const { administratorId } = await requireAdminSession();
+
+  if (typeof reelId !== "string" || !reelId.trim()) {
+    throw new Error("A scheduled reel identifier is required.");
+  }
+
+  return cancelScheduledReel(reelId, {
+    cancelledBy: administratorId,
+    reason: typeof reason === "string" ? reason : "",
+  });
+}

--- a/lib/services/creator-notifications.js
+++ b/lib/services/creator-notifications.js
@@ -1,0 +1,29 @@
+/**
+ * Stub notification adapter for creator-facing publishing notifications.
+ * Replace this implementation with the platform notification API when it is
+ * available without changing callers of this service.
+ */
+
+/**
+ * Notify a creator that an administrator cancelled one of their scheduled reels.
+ *
+ * @param {Object} notification
+ * @param {string} notification.creatorId
+ * @param {string} notification.reelId
+ * @param {string} notification.reelCaption
+ * @param {string} notification.scheduledFor
+ * @param {string} notification.cancelledBy
+ * @param {string} [notification.reason]
+ * @returns {Promise<{success: boolean, notificationId: string, deliveredBy: string}>}
+ */
+export async function notifyCreatorOfScheduledReelCancellation(notification) {
+  if (!notification?.creatorId || !notification?.reelId) {
+    throw new Error("Creator and reel identifiers are required for notification.");
+  }
+
+  return {
+    success: true,
+    notificationId: `stub_reel_cancelled_${notification.reelId}`,
+    deliveredBy: "stub",
+  };
+}

--- a/lib/services/scheduled-reels.js
+++ b/lib/services/scheduled-reels.js
@@ -1,0 +1,176 @@
+import { notifyCreatorOfScheduledReelCancellation } from "@/lib/services/creator-notifications";
+
+/**
+ * Expected scheduled reel contract for future platform integration.
+ *
+ * @typedef {Object} ScheduledReel
+ * @property {string} id Stable reel identifier.
+ * @property {string} caption Creator-provided reel caption.
+ * @property {string|null} thumbnailUrl Optional preview image URL.
+ * @property {{id: string, name: string, email: string}} creator Reel owner.
+ * @property {string} scheduledFor ISO-8601 go-live timestamp.
+ * @property {string} timezone IANA timezone selected by the creator.
+ * @property {"scheduled"|"publishing"|"published"|"cancelled"} status Publishing state.
+ * @property {string} createdAt ISO-8601 creation timestamp.
+ * @property {string} updatedAt ISO-8601 last-update timestamp.
+ * @property {string|null} cancelledAt ISO-8601 cancellation timestamp when cancelled.
+ * @property {string|null} cancelledBy Administrator identifier when cancelled.
+ * @property {string|null} cancellationReason Optional administrator-provided reason.
+ */
+
+export const SCHEDULED_REEL_FIELDS = Object.freeze({
+  id: "Stable reel identifier",
+  caption: "Creator-provided reel caption",
+  thumbnailUrl: "Optional preview image URL",
+  creator: "Creator object containing id, name, and email",
+  scheduledFor: "ISO-8601 go-live timestamp",
+  timezone: "IANA timezone selected by the creator",
+  status: "scheduled, publishing, published, or cancelled",
+  createdAt: "ISO-8601 creation timestamp",
+  updatedAt: "ISO-8601 last-update timestamp",
+  cancelledAt: "ISO-8601 cancellation timestamp or null",
+  cancelledBy: "Cancelling administrator identifier or null",
+  cancellationReason: "Optional cancellation reason or null",
+});
+
+const hoursFromNow = (hours) =>
+  new Date(Date.now() + hours * 60 * 60 * 1000).toISOString();
+
+/** @type {ScheduledReel[]} */
+let scheduledReels = [
+  {
+    id: "reel_scheduled_103",
+    caption: "A reminder about maintaining good character in daily life.",
+    thumbnailUrl: null,
+    creator: {
+      id: "creator_103",
+      name: "Ustadha Maryam J.",
+      email: "maryam@example.com",
+    },
+    scheduledFor: hoursFromNow(72),
+    timezone: "Europe/London",
+    status: "scheduled",
+    createdAt: hoursFromNow(-12),
+    updatedAt: hoursFromNow(-12),
+    cancelledAt: null,
+    cancelledBy: null,
+    cancellationReason: null,
+  },
+  {
+    id: "reel_scheduled_101",
+    caption: "Three practical ways to prepare for the Friday prayer.",
+    thumbnailUrl: null,
+    creator: {
+      id: "creator_101",
+      name: "Sheikh Ibrahim",
+      email: "ibrahim@example.com",
+    },
+    scheduledFor: hoursFromNow(8),
+    timezone: "Africa/Lagos",
+    status: "scheduled",
+    createdAt: hoursFromNow(-30),
+    updatedAt: hoursFromNow(-4),
+    cancelledAt: null,
+    cancelledBy: null,
+    cancellationReason: null,
+  },
+  {
+    id: "reel_scheduled_102",
+    caption: "A short reflection on gratitude and using our time well.",
+    thumbnailUrl: null,
+    creator: {
+      id: "creator_102",
+      name: "Dr. Amina Yusuf",
+      email: "amina@example.com",
+    },
+    scheduledFor: hoursFromNow(30),
+    timezone: "America/New_York",
+    status: "scheduled",
+    createdAt: hoursFromNow(-20),
+    updatedAt: hoursFromNow(-6),
+    cancelledAt: null,
+    cancelledBy: null,
+    cancellationReason: null,
+  },
+];
+
+const cloneReel = (reel) => ({
+  ...reel,
+  creator: { ...reel.creator },
+});
+
+/**
+ * Return only future reels that remain scheduled, sorted by earliest go-live time.
+ * This in-memory adapter can be replaced by a platform request while preserving
+ * the return shape.
+ *
+ * @returns {Promise<ScheduledReel[]>}
+ */
+export async function listUpcomingScheduledReels() {
+  const now = Date.now();
+
+  return scheduledReels
+    .filter(
+      (reel) =>
+        reel.status === "scheduled" &&
+        Number.isFinite(Date.parse(reel.scheduledFor)) &&
+        Date.parse(reel.scheduledFor) > now
+    )
+    .sort(
+      (first, second) =>
+        Date.parse(first.scheduledFor) - Date.parse(second.scheduledFor)
+    )
+    .map(cloneReel);
+}
+
+/**
+ * Cancel a reel before publishing and notify its creator through the stub adapter.
+ *
+ * @param {string} reelId
+ * @param {{cancelledBy: string, reason?: string}} cancellation
+ * @returns {Promise<{reel: ScheduledReel, notification: {success: boolean, notificationId: string, deliveredBy: string}}>} 
+ */
+export async function cancelScheduledReel(reelId, cancellation) {
+  const reelIndex = scheduledReels.findIndex((reel) => reel.id === reelId);
+
+  if (reelIndex === -1) {
+    throw new Error("Scheduled reel was not found.");
+  }
+
+  const reel = scheduledReels[reelIndex];
+  if (reel.status !== "scheduled" || Date.parse(reel.scheduledFor) <= Date.now()) {
+    throw new Error("This reel can no longer be cancelled before publishing.");
+  }
+
+  if (!cancellation?.cancelledBy) {
+    throw new Error("The cancelling administrator is required.");
+  }
+
+  const cancelledAt = new Date().toISOString();
+  const cancelledReel = {
+    ...reel,
+    status: "cancelled",
+    updatedAt: cancelledAt,
+    cancelledAt,
+    cancelledBy: cancellation.cancelledBy,
+    cancellationReason: cancellation.reason?.trim() || null,
+  };
+
+  scheduledReels = scheduledReels.map((item) =>
+    item.id === reelId ? cancelledReel : item
+  );
+
+  const notification = await notifyCreatorOfScheduledReelCancellation({
+    creatorId: reel.creator.id,
+    reelId: reel.id,
+    reelCaption: reel.caption,
+    scheduledFor: reel.scheduledFor,
+    cancelledBy: cancellation.cancelledBy,
+    reason: cancellation.reason?.trim() || "",
+  });
+
+  return {
+    reel: cloneReel(cancelledReel),
+    notification,
+  };
+}


### PR DESCRIPTION
Closes #267

This pull request was generated automatically and scoped strictly to issue #267.

### Changes
Added an admin scheduled reels queue at the existing /[locale]/admin route. The queue loads upcoming scheduled reels in go-live order, handles empty data, provides a confirmation workflow for pre-publish cancellation, and refreshes after successful cancellation. Added a scheduled reels service with an explicit future platform integration contract and a creator cancellation notification stub service. Cancellation validates that an item is still scheduled and has not reached its publish time before notifying the creator.

### Verification
⚠️ Not verified locally (no build system detected, or the required toolchain isn't installed on the worker). **GitHub CI is the source of truth** — please check the CI status on this PR before merging.

_Linked with `Closes #267` so the Drips Wave bot resolves the issue on merge._

<!-- dt-auto -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin queue for viewing upcoming scheduled reels in go-live order.
  * Added loading, error, and empty states for the scheduled reels queue.
  * Added the ability to cancel scheduled reels with an optional reason.
  * Added creator notifications when a scheduled reel is cancelled.
* **Tests**
  * Added coverage for listing, ordering, cancellation, validation, and notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->