### PR TITLE
Fix: [Enhancement] Re-verification reminders for expiring credentials (Auto-Generated)

### DIFF
--- a/__tests__/admin/admin-credential-expiry.service.test.js
+++ b/__tests__/admin/admin-credential-expiry.service.test.js
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axiosInstance from "@/lib/config/axios.config";
+import {
+  CREDENTIAL_EXPIRY_STATUS,
+  computeCredentialExpiry,
+  fetchExpiringMentorCredentials,
+  matchesCredentialExpiryFilter,
+} from "@/lib/actions/admin-credential-expiry";
+import { sendReverificationReminder } from "@/lib/services/reverification-reminders";
+
+vi.mock("@/lib/config/axios.config", () => ({
+  default: { get: vi.fn() },
+}));
+
+describe("mentor credential expiry", () => {
+  const now = new Date("2026-04-01T12:00:00.000Z");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("computes expired, expiring, valid, and missing statuses", () => {
+    expect(computeCredentialExpiry("2026-03-31", now)).toEqual({
+      status: CREDENTIAL_EXPIRY_STATUS.EXPIRED,
+      daysRemaining: -1,
+    });
+    expect(computeCredentialExpiry("2026-05-01", now)).toEqual({
+      status: CREDENTIAL_EXPIRY_STATUS.EXPIRING,
+      daysRemaining: 30,
+    });
+    expect(computeCredentialExpiry("2026-08-01", now).status).toBe(
+      CREDENTIAL_EXPIRY_STATUS.VALID
+    );
+    expect(computeCredentialExpiry(null, now)).toEqual({
+      status: CREDENTIAL_EXPIRY_STATUS.MISSING,
+      daysRemaining: null,
+    });
+  });
+
+  it("matches future credentials against 30, 60, and 90 day filters", () => {
+    const credential = {
+      expiryStatus: CREDENTIAL_EXPIRY_STATUS.EXPIRING,
+      daysRemaining: 45,
+    };
+    expect(matchesCredentialExpiryFilter(credential, "30")).toBe(false);
+    expect(matchesCredentialExpiryFilter(credential, "60")).toBe(true);
+    expect(matchesCredentialExpiryFilter(credential, "90")).toBe(true);
+  });
+
+  it("keeps expired credentials out of upcoming windows", () => {
+    const credential = {
+      expiryStatus: CREDENTIAL_EXPIRY_STATUS.EXPIRED,
+      daysRemaining: -2,
+    };
+    expect(matchesCredentialExpiryFilter(credential, "90")).toBe(false);
+    expect(matchesCredentialExpiryFilter(credential, "expired")).toBe(true);
+  });
+
+  it("fetches and flattens verified mentor credential records", async () => {
+    axiosInstance.get.mockResolvedValueOnce({
+      data: {
+        mentors: [
+          {
+            id: "mentor_1",
+            name: "Amina Yusuf",
+            email: "amina@example.com",
+            verificationStatus: "verified",
+            credentials: [
+              {
+                id: "credential_1",
+                type: "Teaching certificate",
+                expiresAt: "2026-05-01",
+              },
+            ],
+          },
+          {
+            id: "mentor_2",
+            name: "Unverified Mentor",
+            email: "pending@example.com",
+            verificationStatus: "pending",
+            credentials: [
+              {
+                id: "credential_2",
+                type: "Teaching certificate",
+                expiresAt: "2026-05-01",
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await fetchExpiringMentorCredentials({ now });
+
+    expect(axiosInstance.get).toHaveBeenCalledWith(
+      "/api/admin/mentors/credentials",
+      { params: {} }
+    );
+    expect(result.source).toBe("api");
+    expect(result.credentials).toHaveLength(1);
+    expect(result.credentials[0]).toMatchObject({
+      mentorId: "mentor_1",
+      credentialId: "credential_1",
+      credentialType: "Teaching certificate",
+      expiryStatus: CREDENTIAL_EXPIRY_STATUS.EXPIRING,
+      daysRemaining: 30,
+    });
+  });
+});
+
+describe("sendReverificationReminder", () => {
+  it("returns the notification stub acknowledgement", async () => {
+    const result = await sendReverificationReminder({
+      mentorId: "mentor_1",
+      credentialId: "credential_1",
+      credentialType: "Teaching certificate",
+      expiresAt: "2026-05-01",
+    });
+
+    expect(result.queued).toBe(true);
+    expect(result.notificationId).toContain("mentor_1_credential_1");
+    expect(Number.isNaN(new Date(result.queuedAt).getTime())).toBe(false);
+  });
+
+  it("validates the required reminder identifiers", async () => {
+    await expect(
+      sendReverificationReminder({
+        mentorId: "",
+        credentialId: "credential_1",
+        credentialType: "Teaching certificate",
+        expiresAt: null,
+      })
+    ).rejects.toThrow("mentorId is required");
+  });
+});

--- a/app/[locale]/admin/users/page.jsx
+++ b/app/[locale]/admin/users/page.jsx
@@ -1,0 +1,293 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { AlertTriangle, Award, Bell, Loader2, RefreshCw } from "lucide-react";
+import { toast } from "sonner";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  CREDENTIAL_EXPIRY_STATUS,
+  fetchExpiringMentorCredentials,
+  matchesCredentialExpiryFilter,
+} from "@/lib/actions/admin-credential-expiry";
+import { sendReverificationReminder } from "@/lib/services/reverification-reminders";
+
+const FILTERS = [
+  { value: "all", label: "All credentials" },
+  { value: "30", label: "Expiring within 30 days" },
+  { value: "60", label: "Expiring within 60 days" },
+  { value: "90", label: "Expiring within 90 days" },
+  { value: "expired", label: "Already expired" },
+];
+
+function formatExpiryDate(value) {
+  if (!value) return "Not provided";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Invalid date";
+  return new Intl.DateTimeFormat("en", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  }).format(date);
+}
+
+function statusCopy(credential) {
+  if (credential.expiryStatus === CREDENTIAL_EXPIRY_STATUS.EXPIRED) {
+    const elapsed = Math.abs(credential.daysRemaining);
+    return elapsed === 1 ? "Expired 1 day ago" : `Expired ${elapsed} days ago`;
+  }
+  if (credential.expiryStatus === CREDENTIAL_EXPIRY_STATUS.MISSING) {
+    return "Expiry date missing";
+  }
+  if (credential.daysRemaining === 0) return "Expires today";
+  if (credential.daysRemaining === 1) return "Expires in 1 day";
+  return `Expires in ${credential.daysRemaining} days`;
+}
+
+function statusVariant(status) {
+  if (status === CREDENTIAL_EXPIRY_STATUS.VALID) return "secondary";
+  if (status === CREDENTIAL_EXPIRY_STATUS.MISSING) return "outline";
+  return "destructive";
+}
+
+export default function MentorCredentialExpiryPage() {
+  const [credentials, setCredentials] = useState([]);
+  const [filter, setFilter] = useState("30");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [source, setSource] = useState("api");
+  const [sendingId, setSendingId] = useState(null);
+  const [remindedIds, setRemindedIds] = useState(() => new Set());
+
+  const loadCredentials = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetchExpiringMentorCredentials();
+      setCredentials(result.credentials);
+      setSource(result.source);
+    } catch (loadError) {
+      setError(loadError.message ?? "Failed to load mentor credentials");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadCredentials();
+  }, [loadCredentials]);
+
+  const filteredCredentials = useMemo(
+    () =>
+      credentials.filter((credential) =>
+        matchesCredentialExpiryFilter(credential, filter)
+      ),
+    [credentials, filter]
+  );
+
+  const expiringCount = useMemo(
+    () =>
+      credentials.filter(
+        (credential) =>
+          credential.daysRemaining !== null &&
+          credential.daysRemaining >= 0 &&
+          credential.daysRemaining <= 90
+      ).length,
+    [credentials]
+  );
+
+  const expiredCount = useMemo(
+    () =>
+      credentials.filter(
+        (credential) =>
+          credential.expiryStatus === CREDENTIAL_EXPIRY_STATUS.EXPIRED
+      ).length,
+    [credentials]
+  );
+
+  const handleReminder = useCallback(async (credential) => {
+    setSendingId(credential.credentialId);
+    try {
+      await sendReverificationReminder({
+        mentorId: credential.mentorId,
+        credentialId: credential.credentialId,
+        credentialType: credential.credentialType,
+        expiresAt: credential.expiresAt,
+      });
+      setRemindedIds((current) => {
+        const next = new Set(current);
+        next.add(credential.credentialId);
+        return next;
+      });
+      toast.success(`Re-verification reminder queued for ${credential.mentorName}`);
+    } catch (sendError) {
+      toast.error(sendError.message ?? "Failed to send reminder");
+    } finally {
+      setSendingId(null);
+    }
+  }, []);
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={Award}
+        title="Mentor credential expiry"
+        subtitle="Review expiring credentials and send re-verification reminders"
+        actions={
+          <Button
+            type="button"
+            variant="outline"
+            onClick={loadCredentials}
+            disabled={loading}
+          >
+            <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+            Refresh
+          </Button>
+        }
+      />
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Expiring within 90 days</CardDescription>
+            <CardTitle className="text-3xl">{expiringCount}</CardTitle>
+          </CardHeader>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardDescription>Already expired</CardDescription>
+            <CardTitle className="text-3xl">{expiredCount}</CardTitle>
+          </CardHeader>
+        </Card>
+      </div>
+
+      <Card className="mt-6">
+        <CardHeader className="gap-4 md:flex-row md:items-end md:justify-between">
+          <div>
+            <CardTitle>Verified mentor credentials</CardTitle>
+            <CardDescription className="mt-1">
+              Expiry status is computed from each credential&apos;s ISO-8601 expiry date.
+            </CardDescription>
+          </div>
+          <div className="w-full md:w-64">
+            <label
+              htmlFor="credential-expiry-filter"
+              className="mb-2 block text-sm font-medium"
+            >
+              Expiry window
+            </label>
+            <select
+              id="credential-expiry-filter"
+              value={filter}
+              onChange={(event) => setFilter(event.target.value)}
+              className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm"
+            >
+              {FILTERS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {source === "fallback" && !loading && !error && (
+            <div
+              role="status"
+              className="mb-4 flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100"
+            >
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+              Showing representative credential data while the admin credential endpoint is unavailable.
+            </div>
+          )}
+
+          {loading && (
+            <div role="status" className="flex min-h-48 items-center justify-center gap-2 text-muted-foreground">
+              <Loader2 className="h-5 w-5 animate-spin" />
+              Loading mentor credentials…
+            </div>
+          )}
+
+          {!loading && error && (
+            <div role="alert" className="flex min-h-48 flex-col items-center justify-center gap-3 text-center">
+              <p className="text-sm text-destructive">{error}</p>
+              <Button type="button" variant="outline" onClick={loadCredentials}>
+                Try again
+              </Button>
+            </div>
+          )}
+
+          {!loading && !error && filteredCredentials.length === 0 && (
+            <div className="flex min-h-48 items-center justify-center text-center text-sm text-muted-foreground">
+              No verified mentor credentials match this expiry window.
+            </div>
+          )}
+
+          {!loading && !error && filteredCredentials.length > 0 && (
+            <div className="overflow-x-auto">
+              <table className="w-full min-w-[760px] text-left text-sm">
+                <thead>
+                  <tr className="border-b text-muted-foreground">
+                    <th scope="col" className="px-3 py-3 font-medium">Mentor</th>
+                    <th scope="col" className="px-3 py-3 font-medium">Credential type</th>
+                    <th scope="col" className="px-3 py-3 font-medium">Expiry date</th>
+                    <th scope="col" className="px-3 py-3 font-medium">Status</th>
+                    <th scope="col" className="px-3 py-3 text-right font-medium">Action</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredCredentials.map((credential) => {
+                    const sending = sendingId === credential.credentialId;
+                    const reminded = remindedIds.has(credential.credentialId);
+                    return (
+                      <tr key={credential.credentialId} className="border-b last:border-0">
+                        <td className="px-3 py-4">
+                          <p className="font-medium">{credential.mentorName}</p>
+                          <p className="text-xs text-muted-foreground">{credential.mentorEmail}</p>
+                        </td>
+                        <td className="px-3 py-4">{credential.credentialType}</td>
+                        <td className="px-3 py-4">{formatExpiryDate(credential.expiresAt)}</td>
+                        <td className="px-3 py-4">
+                          <Badge variant={statusVariant(credential.expiryStatus)}>
+                            {statusCopy(credential)}
+                          </Badge>
+                        </td>
+                        <td className="px-3 py-4 text-right">
+                          <Button
+                            type="button"
+                            size="sm"
+                            variant={reminded ? "outline" : "default"}
+                            disabled={sending || reminded}
+                            onClick={() => handleReminder(credential)}
+                            aria-label={`Send re-verification reminder to ${credential.mentorName} for ${credential.credentialType}`}
+                          >
+                            {sending ? (
+                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            ) : (
+                              <Bell className="mr-2 h-4 w-4" />
+                            )}
+                            {reminded ? "Reminder queued" : "Send reminder"}
+                          </Button>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </PageShell>
+  );
+}

--- a/lib/actions/admin-credential-expiry.js
+++ b/lib/actions/admin-credential-expiry.js
@@ -1,0 +1,248 @@
+import axiosInstance from "@/lib/config/axios.config";
+
+export const CREDENTIAL_EXPIRY_STATUS = /** @type {const} */ ({
+  EXPIRED: "expired",
+  EXPIRING: "expiring",
+  VALID: "valid",
+  MISSING: "missing",
+});
+
+/**
+ * Backend contract expected by the admin credential-expiry UI:
+ *
+ * GET /api/admin/mentors/credentials
+ * {
+ *   mentors: Array<{
+ *     id: string,
+ *     name: string,
+ *     email: string,
+ *     verificationStatus: "verified",
+ *     credentials: Array<{
+ *       id: string,
+ *       type: string,
+ *       expiresAt: string | null // ISO-8601 date or timestamp
+ *     }>
+ *   }>
+ * }
+ *
+ * Credentials are flattened into one row per mentor credential so each expiry
+ * can be filtered and reminded independently.
+ */
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function toUtcDay(value) {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+/**
+ * Compute the calendar-day expiry state for a credential.
+ *
+ * @param {string|null|undefined} expiresAt
+ * @param {Date|string} [now]
+ * @returns {{ status: string, daysRemaining: number|null }}
+ */
+export function computeCredentialExpiry(expiresAt, now = new Date()) {
+  if (!expiresAt) {
+    return {
+      status: CREDENTIAL_EXPIRY_STATUS.MISSING,
+      daysRemaining: null,
+    };
+  }
+
+  const expiryDay = toUtcDay(expiresAt);
+  const currentDay = toUtcDay(now);
+
+  if (expiryDay === null || currentDay === null) {
+    return {
+      status: CREDENTIAL_EXPIRY_STATUS.MISSING,
+      daysRemaining: null,
+    };
+  }
+
+  const daysRemaining = Math.round((expiryDay - currentDay) / DAY_MS);
+
+  if (daysRemaining < 0) {
+    return { status: CREDENTIAL_EXPIRY_STATUS.EXPIRED, daysRemaining };
+  }
+
+  if (daysRemaining <= 90) {
+    return { status: CREDENTIAL_EXPIRY_STATUS.EXPIRING, daysRemaining };
+  }
+
+  return { status: CREDENTIAL_EXPIRY_STATUS.VALID, daysRemaining };
+}
+
+/**
+ * Return whether a computed credential row matches an admin expiry filter.
+ * Expiry-window filters include today and future expirations, but not already
+ * expired credentials.
+ *
+ * @param {{ expiryStatus: string, daysRemaining: number|null }} credential
+ * @param {"all"|"30"|"60"|"90"|"expired"} filter
+ */
+export function matchesCredentialExpiryFilter(credential, filter) {
+  if (filter === "all") return true;
+  if (filter === "expired") {
+    return credential.expiryStatus === CREDENTIAL_EXPIRY_STATUS.EXPIRED;
+  }
+
+  const windowDays = Number(filter);
+  return (
+    Number.isFinite(windowDays) &&
+    credential.daysRemaining !== null &&
+    credential.daysRemaining >= 0 &&
+    credential.daysRemaining <= windowDays
+  );
+}
+
+function dateFromNow(days) {
+  const date = new Date();
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString();
+}
+
+function fallbackMentors() {
+  return [
+    {
+      id: "mentor_001",
+      name: "Dr. Bilal Karim",
+      email: "bilal@deenbridge.org",
+      verificationStatus: "verified",
+      credentials: [
+        {
+          id: "credential_001",
+          type: "Teaching certificate",
+          expiresAt: dateFromNow(18),
+        },
+      ],
+    },
+    {
+      id: "mentor_002",
+      name: "Zaynab Idris",
+      email: "zaynab@deenbridge.org",
+      verificationStatus: "verified",
+      credentials: [
+        {
+          id: "credential_002",
+          type: "Ijazah verification",
+          expiresAt: dateFromNow(52),
+        },
+      ],
+    },
+    {
+      id: "mentor_003",
+      name: "Amina Yusuf",
+      email: "amina@deenbridge.org",
+      verificationStatus: "verified",
+      credentials: [
+        {
+          id: "credential_003",
+          type: "Safeguarding certificate",
+          expiresAt: dateFromNow(84),
+        },
+      ],
+    },
+    {
+      id: "mentor_004",
+      name: "Omar Rahman",
+      email: "omar@deenbridge.org",
+      verificationStatus: "verified",
+      credentials: [
+        {
+          id: "credential_004",
+          type: "Teaching certificate",
+          expiresAt: dateFromNow(-7),
+        },
+      ],
+    },
+  ];
+}
+
+function normaliseMentors(rawMentors, now) {
+  if (!Array.isArray(rawMentors)) return [];
+
+  return rawMentors
+    .filter(
+      (mentor) =>
+        mentor?.verificationStatus === "verified" || mentor?.isVerified === true
+    )
+    .flatMap((mentor) => {
+      const mentorId = mentor.id ?? mentor._id;
+      const credentials = Array.isArray(mentor.credentials)
+        ? mentor.credentials
+        : mentor.credentialType || mentor.credentialExpiryDate
+          ? [
+              {
+                id: mentor.credentialId,
+                type: mentor.credentialType,
+                expiresAt: mentor.credentialExpiryDate,
+              },
+            ]
+          : [];
+
+      return credentials.map((credential, index) => {
+        const expiry = computeCredentialExpiry(credential.expiresAt, now);
+        return {
+          mentorId: String(mentorId ?? ""),
+          mentorName: mentor.name ?? "Unknown mentor",
+          mentorEmail: mentor.email ?? "",
+          credentialId: String(
+            credential.id ?? `${mentorId ?? "mentor"}-credential-${index}`
+          ),
+          credentialType: credential.type ?? "Unspecified credential",
+          expiresAt: credential.expiresAt ?? null,
+          expiryStatus: expiry.status,
+          daysRemaining: expiry.daysRemaining,
+        };
+      });
+    });
+}
+
+/**
+ * Fetch verified mentors and return one computed row per credential.
+ * Network and 404 responses use representative local data until the backend
+ * endpoint is available; authenticated server errors continue to surface.
+ *
+ * @param {{ expiryWithinDays?: 30|60|90, now?: Date|string }} [options]
+ * @returns {Promise<{ credentials: Array<Object>, generatedAt: string, source: "api"|"fallback" }>}
+ */
+export async function fetchExpiringMentorCredentials(options = {}) {
+  const now = options.now ?? new Date();
+
+  try {
+    const response = await axiosInstance.get("/api/admin/mentors/credentials", {
+      params: options.expiryWithinDays
+        ? { expiryWithinDays: options.expiryWithinDays }
+        : {},
+    });
+    return {
+      credentials: normaliseMentors(response.data?.mentors, now),
+      generatedAt: new Date().toISOString(),
+      source: "api",
+    };
+  } catch (error) {
+    const status = error?.response?.status;
+    const isUnavailable =
+      status === 404 ||
+      error?.code === "ERR_NETWORK" ||
+      error?.message === "Network Error" ||
+      !error?.response;
+
+    if (!isUnavailable) {
+      throw new Error(
+        error?.response?.data?.message ??
+          error?.message ??
+          "Failed to fetch mentor credentials"
+      );
+    }
+
+    return {
+      credentials: normaliseMentors(fallbackMentors(), now),
+      generatedAt: new Date().toISOString(),
+      source: "fallback",
+    };
+  }
+}

--- a/lib/services/reverification-reminders.js
+++ b/lib/services/reverification-reminders.js
@@ -1,0 +1,35 @@
+/**
+ * Re-verification reminder notification seam.
+ *
+ * This intentionally remains behind a service function until the announcements
+ * infrastructure exposes its delivery endpoint. Callers can rely on the
+ * resolved acknowledgement shape without coupling the UI to that future API.
+ */
+
+/**
+ * Queue a re-verification reminder for one mentor credential.
+ *
+ * @param {{ mentorId: string, credentialId: string, credentialType: string, expiresAt: string|null }} reminder
+ * @returns {Promise<{ queued: true, notificationId: string, queuedAt: string }>}
+ */
+export async function sendReverificationReminder(reminder) {
+  if (!reminder?.mentorId) {
+    throw new Error("mentorId is required");
+  }
+  if (!reminder?.credentialId) {
+    throw new Error("credentialId is required");
+  }
+  if (!reminder?.credentialType) {
+    throw new Error("credentialType is required");
+  }
+
+  // TODO: Replace this acknowledgement with the announcements service call
+  // once targeted announcement delivery is available.
+  await Promise.resolve();
+
+  return {
+    queued: true,
+    notificationId: `reverification_${reminder.mentorId}_${reminder.credentialId}_${Date.now()}`,
+    queuedAt: new Date().toISOString(),
+  };
+}


### PR DESCRIPTION
Closes #238

This pull request was generated automatically and scoped strictly to issue #238.

### Changes
Added an admin credential-expiry view at /[locale]/admin/users with 30/60/90-day and expired filters, computed expiry status for each verified mentor credential, and one-click re-verification reminders. Added an admin credential action layer with a documented backend contract and a development fallback dataset. The UI expects verified mentor records shaped as `{ id, name, email, credentials: [{ id, type, expiresAt }] }`, where `expiresAt` is an ISO-8601 date or timestamp. Added a notification service seam that currently returns a queued stub acknowledgement and is explicitly ready to be replaced by the announcements infrastructure.

### Verification
⚠️ Not verified locally (no build system detected, or the required toolchain isn't installed on the worker). **GitHub CI is the source of truth** — please check the CI status on this PR before merging.

_Linked with `Closes #238` so the Drips Wave bot resolves the issue on merge._

<!-- dt-auto -->