### PR TITLE
feat(admin): add empty-database bootstrap experience to overview

### DIFF
--- a/__tests__/admin/AdminOverviewPage.test.jsx
+++ b/__tests__/admin/AdminOverviewPage.test.jsx
@@ -1,0 +1,168 @@
+/**
+ * Admin overview page — empty-database bootstrap experience (#339).
+ * -------------------------------------------------------------------
+ * Fresh deployments must show guided hints and a setup checklist instead of
+ * confusing zeroes, with a dismiss-forever escape hatch. These tests cover the
+ * empty snapshot, the data-driven disappearance of hints once real data
+ * arrives, checklist progress derivation, and the persisted dismissal.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("@/lib/config/font.config", () => ({
+  poppins_400: { className: "" },
+  poppins_500: { className: "" },
+  poppins_600: { className: "" },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children, ...props }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const serviceState = vi.hoisted(() => ({ current: null }));
+vi.mock("@/lib/actions/admin-overview", () => ({
+  fetchAdminOverview: () => serviceState.current(),
+}));
+
+function makeSnapshot({ counts = {}, settings = {}, empty = true } = {}) {
+  return {
+    generatedAt: "2026-08-25T00:00:00.000Z",
+    empty,
+    counts: {
+      mentors: { label: "Mentors", value: 0 },
+      categories: { label: "Categories", value: 0 },
+      courses: { label: "Courses", value: 0 },
+      books: { label: "Books", value: 0 },
+      students: { label: "Students", value: 0 },
+      transactions: { label: "Transactions", value: 0 },
+      ...counts,
+    },
+    settings: {
+      platformName: { label: "Platform name", configured: false },
+      paymentSettings: { label: "Payment settings", configured: false },
+      ...settings,
+    },
+  };
+}
+
+let AdminOverviewPage;
+beforeEach(async () => {
+  localStorage.clear();
+  if (!AdminOverviewPage) {
+    const mod = await import("@/app/[locale]/admin/page");
+    AdminOverviewPage = mod.default;
+  }
+});
+
+describe("AdminOverviewPage — empty database bootstrap", () => {
+  it("renders skeleton placeholders while loading", () => {
+    serviceState.current = () => new Promise(() => {});
+    const { container } = render(<AdminOverviewPage />);
+
+    expect(screen.getByText("Overview")).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+  });
+
+  it("shows guided hints instead of zeros on a fresh deployment", async () => {
+    serviceState.current = () => Promise.resolve(makeSnapshot());
+    render(<AdminOverviewPage />);
+
+    expect(await screen.findByText("Welcome to your new platform")).toBeInTheDocument();
+    expect(screen.getByText("Getting Started")).toBeInTheDocument();
+
+    // Guided widget hints (also present as checklist rows)
+    expect(screen.getAllByText("Invite your first mentor").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Create a category").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Publish your first course").length).toBeGreaterThanOrEqual(1);
+
+    // No silent zeroes anywhere
+    expect(screen.queryByText("0")).toBeNull();
+  });
+
+  it("renders the setup checklist with 0/6 progress on an empty database", async () => {
+    serviceState.current = () => Promise.resolve(makeSnapshot());
+    render(<AdminOverviewPage />);
+
+    expect(await screen.findByText("Getting Started")).toBeInTheDocument();
+    expect(screen.getByText("0/6 complete")).toBeInTheDocument();
+  });
+
+  it("hides guided hints and checklist progress ticks once real data arrives", async () => {
+    serviceState.current = () =>
+      Promise.resolve(
+        makeSnapshot({
+          empty: false,
+          counts: {
+            mentors: { label: "Mentors", value: 12 },
+            categories: { label: "Categories", value: 3 },
+            courses: { label: "Courses", value: 5 },
+            books: { label: "Books", value: 8 },
+            students: { label: "Students", value: 120 },
+            transactions: { label: "Transactions", value: 40 },
+          },
+          settings: {
+            platformName: { label: "Platform name", configured: true },
+            paymentSettings: { label: "Payment settings", configured: true },
+          },
+        })
+      );
+    render(<AdminOverviewPage />);
+
+    expect(await screen.findByText("12")).toBeInTheDocument();
+    expect(screen.queryByText("Welcome to your new platform")).toBeNull();
+    // Widget hint (with CTA) is replaced by the real count; the checklist row
+    // keeps its label but is marked complete.
+    expect(screen.queryByText("Invite mentors")).toBeNull();
+    expect(screen.getByText("6/6 complete")).toBeInTheDocument();
+  });
+
+  it("derives partial checklist progress from settings values and counts", async () => {
+    serviceState.current = () =>
+      Promise.resolve(
+        makeSnapshot({
+          counts: {
+            categories: { label: "Categories", value: 2 },
+          },
+        })
+      );
+    render(<AdminOverviewPage />);
+
+    expect(await screen.findByText("Getting Started")).toBeInTheDocument();
+    expect(screen.getByText("1/6 complete")).toBeInTheDocument();
+  });
+
+  it("dismisses the setup guide forever and persists the choice", async () => {
+    const user = userEvent.setup();
+    serviceState.current = () => Promise.resolve(makeSnapshot());
+    const { unmount } = render(<AdminOverviewPage />);
+
+    await screen.findByText("Getting Started");
+
+    await user.click(screen.getByRole("button", { name: /dismiss setup guide forever/i }));
+
+    expect(screen.queryByText("Getting Started")).toBeNull();
+    expect(screen.queryByText("Welcome to your new platform")).toBeNull();
+    expect(localStorage.getItem("dnb-bootstrap-dismissed")).toBe("true");
+
+    // Remount — the dismissal must survive navigation / refresh.
+    unmount();
+    serviceState.current = () => Promise.resolve(makeSnapshot());
+    render(<AdminOverviewPage />);
+    await act(async () => {});
+
+    expect(screen.queryByText("Getting Started")).toBeNull();
+  });
+
+  it("renders an error state when the overview service fails", async () => {
+    serviceState.current = () => Promise.reject(new Error("Service unavailable"));
+    render(<AdminOverviewPage />);
+
+    expect(await screen.findByText(/failed to load overview/i)).toBeInTheDocument();
+    expect(screen.getByText("Service unavailable")).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin/admin-overview.service.test.js
+++ b/__tests__/admin/admin-overview.service.test.js
@@ -1,0 +1,58 @@
+/**
+ * Admin overview service — empty-database bootstrap snapshot (#339).
+ * -------------------------------------------------------------------
+ * The overview home page is data-driven: widgets switch to guided hints when a
+ * count is zero and the setup checklist derives completion from counts plus
+ * settings values. These tests pin the snapshot shape the page depends on.
+ */
+import { describe, it, expect } from "vitest";
+import { fetchAdminOverview } from "@/lib/actions/admin-overview";
+
+describe("fetchAdminOverview", () => {
+  it("resolves an empty-database snapshot by default", async () => {
+    const snapshot = await fetchAdminOverview();
+
+    expect(snapshot.empty).toBe(true);
+    expect(snapshot.generatedAt).toEqual(expect.any(String));
+    expect(
+      Object.values(snapshot.counts).every((count) => count.value === 0)
+    ).toBe(true);
+    expect(
+      Object.values(snapshot.settings).every(
+        (setting) => setting.configured === false
+      )
+    ).toBe(true);
+  });
+
+  it("exposes every count the overview widgets depend on", async () => {
+    const snapshot = await fetchAdminOverview();
+    const keys = [
+      "mentors",
+      "categories",
+      "courses",
+      "books",
+      "students",
+      "transactions",
+    ];
+
+    for (const key of keys) {
+      expect(snapshot.counts[key]).toMatchObject({
+        label: expect.any(String),
+        value: expect.any(Number),
+      });
+    }
+  });
+
+  it("exposes the settings values the checklist is derived from", async () => {
+    const snapshot = await fetchAdminOverview();
+
+    expect(snapshot.settings.platformName).toMatchObject({
+      label: expect.any(String),
+      configured: expect.any(Boolean),
+    });
+    expect(snapshot.settings.paymentSettings).toMatchObject({
+      label: expect.any(String),
+      configured: expect.any(Boolean),
+    });
+  });
+});

--- a/app/[locale]/admin/page.jsx
+++ b/app/[locale]/admin/page.jsx
@@ -1,0 +1,429 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Progress } from "@/components/ui/progress";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+import { fetchAdminOverview } from "@/lib/actions/admin-overview";
+import {
+  LayoutDashboard,
+  Users,
+  FolderTree,
+  GraduationCap,
+  BookOpen,
+  Sparkles,
+  ArrowRightLeft,
+  ArrowRight,
+  CheckCircle2,
+  Circle,
+  Sparkle,
+  X,
+  Rocket,
+  AlertTriangle,
+} from "lucide-react";
+
+// Persisted in localStorage so the bootstrap guidance can be dismissed
+// permanently once the team is actively using the platform.
+const DISMISS_STORAGE_KEY = "dnb-bootstrap-dismissed";
+
+// Overview widgets. Each one renders a guided hint (and a CTA) while its count
+// is zero, and the real value once data exists — hints disappear naturally as
+// the database fills up. Presentational config only; counts come from the
+// snapshot service.
+const OVERVIEW_WIDGETS = [
+  {
+    key: "mentors",
+    icon: Users,
+    href: "/dashboard/admin/team",
+    hint: "Invite your first mentor",
+    description: "Mentors lead courses and guide learners.",
+    cta: "Invite mentors",
+  },
+  {
+    key: "categories",
+    icon: FolderTree,
+    href: "/dashboard/courses/categories",
+    hint: "Create a category",
+    description: "Organise courses into browsable categories.",
+    cta: "Create category",
+  },
+  {
+    key: "courses",
+    icon: GraduationCap,
+    href: "/dashboard/courses/create",
+    hint: "Publish your first course",
+    description: "Share knowledge with structured lessons.",
+    cta: "Create course",
+  },
+  {
+    key: "books",
+    icon: BookOpen,
+    href: "/admin/books",
+    hint: "Add books to the library",
+    description: "Curate authentic titles for readers.",
+    cta: "Add books",
+  },
+  {
+    key: "students",
+    icon: Sparkles,
+    href: "/dashboard",
+    hint: "Invite your first students",
+    description: "Learners sign up to browse courses and books.",
+    cta: "View dashboard",
+  },
+  {
+    key: "transactions",
+    icon: ArrowRightLeft,
+    href: "/admin/transactions",
+    hint: "Complete your first sale",
+    description: "Transactions appear here as learners purchase.",
+    cta: "View transactions",
+  },
+];
+
+// Setup checklist. Completion is data-driven: either a settings value is
+// configured or a real count is above zero, so items complete on their own as
+// the platform is set up.
+const SETUP_ITEMS = [
+  {
+    key: "platformName",
+    label: "Set your platform name",
+    href: "/admin/settings/branding",
+    complete: (snapshot) => snapshot.settings.platformName.configured,
+  },
+  {
+    key: "firstCategory",
+    label: "Create a category",
+    href: "/dashboard/courses/categories",
+    complete: (snapshot) => snapshot.counts.categories.value > 0,
+  },
+  {
+    key: "firstMentor",
+    label: "Invite your first mentor",
+    href: "/dashboard/admin/team",
+    complete: (snapshot) => snapshot.counts.mentors.value > 0,
+  },
+  {
+    key: "firstCourse",
+    label: "Publish your first course",
+    href: "/dashboard/courses/create",
+    complete: (snapshot) => snapshot.counts.courses.value > 0,
+  },
+  {
+    key: "libraryBooks",
+    label: "Add books to the library",
+    href: "/admin/books",
+    complete: (snapshot) => snapshot.counts.books.value > 0,
+  },
+  {
+    key: "paymentSettings",
+    label: "Configure payment settings",
+    href: "/admin/settings",
+    complete: (snapshot) => snapshot.settings.paymentSettings.configured,
+  },
+];
+
+function OverviewWidget({ widget, metric, guided }) {
+  const Icon = widget.icon;
+  const isEmpty = metric.value === 0;
+
+  return (
+    <Card className="transition-all duration-300 hover:-translate-y-0.5 hover:border-secondary/30">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-1">
+            <p
+              className={cn(
+                poppins_500.className,
+                "text-xs uppercase tracking-wider text-muted-foreground"
+              )}
+            >
+              {metric.label}
+            </p>
+            {isEmpty && guided ? (
+              <>
+                <p className={cn(poppins_600.className, "text-lg text-foreground")}>
+                  {widget.hint}
+                </p>
+                <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+                  {widget.description}
+                </p>
+              </>
+            ) : (
+              <p className={cn(poppins_600.className, "text-3xl text-foreground")}>
+                {metric.value.toLocaleString()}
+              </p>
+            )}
+          </div>
+          <div
+            className={cn(
+              "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10",
+              isEmpty && guided && "animate-pulse"
+            )}
+          >
+            <Icon className="h-5 w-5 text-accent" />
+          </div>
+        </div>
+        {isEmpty && guided && (
+          <Link
+            href={widget.href}
+            className={cn(
+              poppins_500.className,
+              "mt-3 inline-flex items-center gap-1.5 text-sm font-medium text-accent underline-offset-4 hover:underline"
+            )}
+          >
+            {widget.cta}
+            <ArrowRight className="h-3.5 w-3.5" />
+          </Link>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function WelcomeBanner() {
+  return (
+    <div className="relative overflow-hidden rounded-2xl border border-accent/10 bg-gradient-to-br from-secondary/15 via-highlight/10 to-accent/10 p-6 sm:p-8">
+      <div className="relative z-10 max-w-2xl space-y-3">
+        <Badge variant="outline" className="gap-1.5">
+          <Sparkle className="h-3 w-3" />
+          Fresh deployment
+        </Badge>
+        <h2 className={cn(poppins_600.className, "text-2xl text-foreground")}>
+          Welcome to your new platform
+        </h2>
+        <p className={cn(poppins_400.className, "text-sm text-muted-foreground")}>
+          Your database is empty — that&apos;s expected. The cards below show
+          guided next steps instead of confusing zeros, and the checklist tracks
+          your setup progress as you go.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function SetupChecklist({ items, completedCount, progress, onDismiss }) {
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <Rocket className="h-5 w-5" />
+              Getting Started
+            </CardTitle>
+            <CardDescription>
+              Finish these steps to launch your platform
+            </CardDescription>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label="Dismiss setup guide forever"
+            title="Dismiss setup guide forever"
+            onClick={onDismiss}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-muted-foreground">Setup progress</span>
+            <span className={cn(poppins_600.className, "text-foreground")}>
+              {completedCount}/{items.length} complete
+            </span>
+          </div>
+          <Progress value={progress} aria-label="Setup progress" />
+        </div>
+        <ul className="space-y-1">
+          {items.map((item) => (
+            <li key={item.key}>
+              <Link
+                href={item.href}
+                className="flex items-center gap-3 rounded-lg p-2 transition-colors hover:bg-muted/60"
+              >
+                {item.complete ? (
+                  <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600" />
+                ) : (
+                  <Circle className="h-5 w-5 shrink-0 text-muted-foreground/60" />
+                )}
+                <span
+                  className={cn(
+                    poppins_400.className,
+                    "text-sm text-foreground",
+                    item.complete && "text-muted-foreground line-through"
+                  )}
+                >
+                  {item.label}
+                </span>
+                {!item.complete && (
+                  <span
+                    className={cn(
+                      poppins_500.className,
+                      "ml-auto inline-flex items-center gap-1 text-xs font-medium text-accent"
+                    )}
+                  >
+                    Start
+                    <ArrowRight className="h-3 w-3" />
+                  </span>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs text-muted-foreground">
+          Progress is derived from your platform data and settings. Dismiss this
+          guide once your team is actively using the platform.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function AdminOverviewPage() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    try {
+      if (window.localStorage.getItem(DISMISS_STORAGE_KEY) === "true") {
+        setDismissed(true);
+      }
+    } catch {
+      // storage unavailable — treat as not dismissed
+    }
+
+    fetchAdminOverview()
+      .then((overview) => {
+        if (active) {
+          setData(overview);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setError(err?.message || "Failed to load overview");
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const dismissForever = () => {
+    try {
+      window.localStorage.setItem(DISMISS_STORAGE_KEY, "true");
+    } catch {
+      // storage unavailable — dismissal stays session-only
+    }
+    setDismissed(true);
+  };
+
+  const setupItems = useMemo(() => {
+    if (!data) return [];
+    return SETUP_ITEMS.map((item) => ({
+      ...item,
+      complete: item.complete(data),
+    }));
+  }, [data]);
+
+  const completedCount = setupItems.filter((item) => item.complete).length;
+  const progress = setupItems.length
+    ? Math.round((completedCount / setupItems.length) * 100)
+    : 0;
+
+  if (loading) {
+    return (
+      <PageShell>
+        <PageHeader
+          icon={LayoutDashboard}
+          title="Overview"
+          subtitle="Monitor platform activity and complete your setup"
+        />
+        <Skeleton className="h-28 w-full rounded-2xl" />
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, index) => (
+            <Skeleton key={index} className="h-32 w-full rounded-2xl" />
+          ))}
+        </div>
+        <Skeleton className="h-72 w-full rounded-2xl" />
+      </PageShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageShell>
+        <PageHeader
+          icon={LayoutDashboard}
+          title="Overview"
+          subtitle="Monitor platform activity and complete your setup"
+        />
+        <EmptyState
+          icon={AlertTriangle}
+          title="Failed to load overview"
+          description={error}
+        />
+      </PageShell>
+    );
+  }
+
+  const isEmpty = data.empty;
+  const guided = !dismissed;
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={LayoutDashboard}
+        title="Overview"
+        subtitle="Monitor platform activity and complete your setup"
+      />
+
+      {isEmpty && guided && <WelcomeBanner />}
+
+      {/* Overview widgets — guided hints instead of zeros on a fresh database */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {OVERVIEW_WIDGETS.map((widget) => (
+          <OverviewWidget
+            key={widget.key}
+            widget={widget}
+            metric={data.counts[widget.key]}
+            guided={guided}
+          />
+        ))}
+      </div>
+
+      {/* Setup checklist — completion derived from data + settings values */}
+      {guided && (
+        <SetupChecklist
+          items={setupItems}
+          completedCount={completedCount}
+          progress={progress}
+          onDismiss={dismissForever}
+        />
+      )}
+    </PageShell>
+  );
+}

--- a/lib/actions/admin-overview.js
+++ b/lib/actions/admin-overview.js
@@ -1,0 +1,69 @@
+/**
+ * Admin overview service — platform snapshot for the overview home page (#339).
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Resolves a representative snapshot so the admin overview /
+ * empty-database bootstrap experience can be built and reviewed before the
+ * backend endpoints ship.
+ *
+ * The stub deliberately models a **fresh deployment** — every tracked count is
+ * zero and no settings are configured — so the guided first-run experience is
+ * visible in dev. The page is fully data-driven: an overview widget switches to
+ * a guided hint the moment its count is `0`, and the setup checklist derives
+ * completion from these counts plus the settings flags, so real data flowing in
+ * from the backend makes hints and checklist items disappear naturally.
+ *
+ * TODO(backend): GET /api/admin/overview
+ *   - Auth: requires an admin session token (server-side tier check).
+ *   - 200 → the overview shape documented below.
+ *
+ * Overview shape:
+ *   {
+ *     generatedAt: string,        // ISO 8601 snapshot timestamp
+ *     empty: boolean,             // true when every tracked count is zero
+ *     counts: {
+ *       mentors:      { label: string, value: number },
+ *       categories:   { label: string, value: number },
+ *       courses:      { label: string, value: number },
+ *       books:        { label: string, value: number },
+ *       students:     { label: string, value: number },
+ *       transactions: { label: string, value: number },
+ *     },
+ *     settings: {
+ *       platformName:    { label: string, configured: boolean },
+ *       paymentSettings: { label: string, configured: boolean },
+ *     },
+ *   }
+ */
+
+function withResolved(value) {
+  return Promise.resolve(value);
+}
+
+/**
+ * Fetch the platform-wide overview snapshot.
+ *
+ * TODO(backend):
+ *   return axiosInstance
+ *     .get("/api/admin/overview")
+ *     .then((res) => res.data);
+ *
+ * @returns {Promise<object>} the overview snapshot documented above.
+ */
+export async function fetchAdminOverview() {
+  return withResolved({
+    generatedAt: new Date().toISOString(),
+    empty: true,
+    counts: {
+      mentors: { label: "Mentors", value: 0 },
+      categories: { label: "Categories", value: 0 },
+      courses: { label: "Courses", value: 0 },
+      books: { label: "Books", value: 0 },
+      students: { label: "Students", value: 0 },
+      transactions: { label: "Transactions", value: 0 },
+    },
+    settings: {
+      platformName: { label: "Platform name", configured: false },
+      paymentSettings: { label: "Payment settings", configured: false },
+    },
+  });
+}


### PR DESCRIPTION
## Overview

This PR adds a guided **Empty-Database Bootstrap Experience** for fresh Deen Bridge deployments with zero data. Instead of empty widgets filled with confusing zeros, new instances now show helpful hints and a setup checklist that guide the admin through initial configuration — no more "is it broken?" confusion.

## Related Issue

Closes [#339](https://github.com/Deen-Bridge/dnb-frontend/issues/339)

## Changes

### 🚀 Admin overview page

- **\[ADD\]** `app/[locale]/admin/page.jsx` — admin overview home at `/admin` with six data-driven widgets (mentors, categories, courses, books, students, transactions)
- Widgets render a guided hint + CTA link (e.g. **"Invite your first mentor"**, **"Create a category"**) in place of a silent zero whenever their count is empty
- **\[ADD\]** **Getting Started** setup checklist card with a progress bar (`X/6 complete`)
- Checklist completion is derived from settings values (`platformName`, `paymentSettings`) and live counts, so items complete on their own as real data arrives
- **\[ADD\]** Dismissible-forever option (persisted in `localStorage`) once the team is actively using the platform
- Welcome banner shown on fresh deployments

### 🔌 Data service

- **\[ADD\]** `lib/actions/admin-overview.js` — stubbed `fetchAdminOverview()` following the repo's admin service pattern, with the documented backend contract (`GET /api/admin/overview`)

### 🧪 Tests

- **\[ADD\]** `__tests__/admin/AdminOverviewPage.test.jsx` — loading, guided hints, data-driven hint removal, checklist progress, dismiss-forever persistence, error states
- **\[ADD\]** `__tests__/admin/admin-overview.service.test.js` — snapshot shape the page depends on

## Verification Results

```
npm test -- __tests__/admin/AdminOverviewPage.test.jsx __tests__/admin/admin-overview.service.test.js
✅ 10/10 passed

npm run lint   ✅
npm run a11y   ✅
npm run build  ✅ (compiled successfully)
```

## Acceptance Criteria

| Acceptance Criteria | Status |
| --- | --- |
| Overview widgets show guided hints when database is empty | ✅ |
| Helpful prompts like "invite your first mentor" and "create a category" implemented | ✅ |
| Setup checklist card displays completion progress | ✅ |
| Checklist items based on settings values configuration | ✅ |
| Dismissible-forever functionality working | ✅ |
| Hints data-driven and disappear when real data exists | ✅ |
| First-run experience smooth and informative | ✅ |
| No "is it broken?" confusion for fresh deployments | ✅ |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin overview dashboard with metrics for mentors, categories, courses, books, students, and transactions.
  * Added setup guidance, completion checklist, and contextual calls to action for fresh deployments.
  * Added loading, error, and empty-state displays.
  * Added an option to permanently dismiss the setup guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->