### PR TITLE
feat(admin): add announcement analytics for reach and engagement

### DIFF
--- a/__tests__/admin/AnnouncementAnalytics.test.jsx
+++ b/__tests__/admin/AnnouncementAnalytics.test.jsx
@@ -1,0 +1,132 @@
+/**
+ * Announcement analytics panel — reach & engagement (#305).
+ * -------------------------------------------------------------------
+ * The panel renders per-announcement metrics, an honest "not tracked yet" gap
+ * for un-instrumented events, a reach bar chart, the shared range filter, and
+ * a per-announcement table. These tests mock the service and assert the
+ * presentational branching only.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// recharts' ResponsiveContainer reads element size via ResizeObserver, which
+// jsdom does not provide. A no-op stub lets the chart render (empty) without
+// crashing so the surrounding content can be asserted.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+globalThis.ResizeObserver = globalThis.ResizeObserver || ResizeObserverStub;
+
+vi.setConfig({ testTimeout: 60000, hookTimeout: 60000 });
+
+vi.mock("@/lib/config/font.config", () => ({
+  poppins_400: { className: "" },
+  poppins_500: { className: "" },
+  poppins_600: { className: "" },
+}));
+
+const serviceState = vi.hoisted(() => ({ current: null }));
+vi.mock("@/lib/actions/admin-announcements", () => ({
+  fetchAnnouncementAnalytics: (...args) => serviceState.current(...args),
+}));
+
+function makeAnalytics(overrides = {}) {
+  return {
+    generatedAt: "2026-08-25T00:00:00.000Z",
+    range: { from: null, to: null },
+    totals: {
+      impressions: { label: "Impressions", value: 11405, tracked: true },
+      uniqueViewers: { label: "Unique Viewers", value: 6671, tracked: true },
+      dismissRate: { label: "Dismiss Rate", value: 20.6, tracked: true, unit: "percent" },
+      ctr: { label: "Click-through Rate", value: 0, tracked: false, unit: "percent" },
+    },
+    announcements: [
+      {
+        id: "ann_001",
+        title: "New course: Seerah of the Prophet",
+        sentAt: "2026-08-21T09:00:00.000Z",
+        impressions: { value: 3421, tracked: true },
+        uniqueViewers: { value: 1987, tracked: true },
+        dismissRate: { value: 20.99, tracked: true, unit: "percent" },
+        ctr: { value: 0, tracked: false, unit: "percent" },
+      },
+    ],
+    ...overrides,
+  };
+}
+
+import { AnnouncementAnalytics } from "@/components/admin/announcement-analytics";
+
+describe("AnnouncementAnalytics", () => {
+  it("renders skeleton placeholders while loading", () => {
+    serviceState.current = () => new Promise(() => {});
+    const { container } = render(<AnnouncementAnalytics />);
+
+    expect(container.querySelector('[data-slot="skeleton"]')).not.toBeNull();
+  });
+
+  it("renders summary metrics for tracked events", async () => {
+    serviceState.current = () => Promise.resolve(makeAnalytics());
+    render(<AnnouncementAnalytics />);
+
+    expect(await screen.findByText("11,405")).toBeInTheDocument();
+    expect(screen.getByText("6,671")).toBeInTheDocument();
+    expect(screen.getByText("20.6%")).toBeInTheDocument();
+    expect(screen.getAllByText("Impressions").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Unique Viewers").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Dismiss Rate").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows an honest gap for events that are not instrumented yet", async () => {
+    serviceState.current = () => Promise.resolve(makeAnalytics());
+    render(<AnnouncementAnalytics />);
+
+    await screen.findByText("11,405");
+    expect(screen.getAllByText("Click-through Rate").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/not tracked yet/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders the reach comparison bar chart", async () => {
+    serviceState.current = () => Promise.resolve(makeAnalytics());
+    render(<AnnouncementAnalytics />);
+
+    expect(await screen.findByText("Reach Comparison")).toBeInTheDocument();
+    expect(screen.getByText("Impressions vs unique viewers across recent announcements")).toBeInTheDocument();
+  });
+
+  it("renders the per-announcement stats table", async () => {
+    serviceState.current = () => Promise.resolve(makeAnalytics());
+    render(<AnnouncementAnalytics />);
+
+    expect(await screen.findByText("Per-Announcement Stats")).toBeInTheDocument();
+    expect(screen.getByText("New course: Seerah of the Prophet")).toBeInTheDocument();
+    expect(screen.getByText("3,421")).toBeInTheDocument();
+    expect(screen.getByText("1,987")).toBeInTheDocument();
+    expect(screen.getByText("21.0%")).toBeInTheDocument();
+  });
+
+  it("integrates the shared range filter", async () => {
+    const user = userEvent.setup();
+    serviceState.current = () => Promise.resolve(makeAnalytics());
+    render(<AnnouncementAnalytics />);
+
+    await screen.findByText("11,405");
+
+    const trigger = screen.getByRole("button", { name: /select date range/i });
+    expect(trigger).toBeInTheDocument();
+
+    await user.click(trigger);
+    expect(screen.getByRole("button", { name: /clear/i })).toBeInTheDocument();
+  });
+
+  it("renders an error state when the service fails", async () => {
+    serviceState.current = () => Promise.reject(new Error("Service unavailable"));
+    render(<AnnouncementAnalytics />);
+
+    expect(await screen.findByText(/failed to load announcement analytics/i)).toBeInTheDocument();
+    expect(screen.getByText("Service unavailable")).toBeInTheDocument();
+  });
+});

--- a/__tests__/admin/admin-announcements.service.test.js
+++ b/__tests__/admin/admin-announcements.service.test.js
@@ -1,0 +1,80 @@
+/**
+ * Admin announcement analytics service — reach & engagement snapshot (#305).
+ * ---------------------------------------------------------------------------
+ * The service computes dismiss rate, carries explicit `tracked` flags so the
+ * UI can show honest gaps for events that aren't instrumented yet (CTR), and
+ * exposes the minimal event names proposed for backend alignment.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  fetchAnnouncementAnalytics,
+  ANNOUNCEMENT_EVENT_NAMES,
+} from "@/lib/actions/admin-announcements";
+
+describe("fetchAnnouncementAnalytics", () => {
+  it("resolves per-announcement stats with tracked flags", async () => {
+    const analytics = await fetchAnnouncementAnalytics();
+
+    expect(analytics.announcements.length).toBeGreaterThan(0);
+    for (const ann of analytics.announcements) {
+      expect(ann).toMatchObject({
+        id: expect.any(String),
+        title: expect.any(String),
+        sentAt: expect.any(String),
+        impressions: { value: expect.any(Number), tracked: true },
+        uniqueViewers: { value: expect.any(Number), tracked: true },
+      });
+    }
+  });
+
+  it("calculates dismiss rate from dismissals and impressions", async () => {
+    const analytics = await fetchAnnouncementAnalytics();
+    const ann = analytics.announcements[0];
+
+    expect(ann.dismissRate.tracked).toBe(true);
+    expect(ann.dismissRate.value).toBeGreaterThan(0);
+    expect(ann.dismissRate.unit).toBe("percent");
+  });
+
+  it("reports untracked metrics honestly (CTR not instrumented yet)", async () => {
+    const analytics = await fetchAnnouncementAnalytics();
+
+    expect(analytics.totals.ctr.tracked).toBe(false);
+    for (const ann of analytics.announcements) {
+      expect(ann.ctr.tracked).toBe(false);
+    }
+  });
+
+  it("sums totals across announcements", async () => {
+    const analytics = await fetchAnnouncementAnalytics();
+    const expectedImpressions = analytics.announcements.reduce(
+      (total, ann) => total + ann.impressions.value,
+      0
+    );
+    const expectedViewers = analytics.announcements.reduce(
+      (total, ann) => total + ann.uniqueViewers.value,
+      0
+    );
+
+    expect(analytics.totals.impressions.value).toBe(expectedImpressions);
+    expect(analytics.totals.uniqueViewers.value).toBe(expectedViewers);
+  });
+
+  it("echoes the requested date range", async () => {
+    const analytics = await fetchAnnouncementAnalytics({
+      from: "2026-08-01",
+      to: "2026-08-31",
+    });
+
+    expect(analytics.range).toEqual({ from: "2026-08-01", to: "2026-08-31" });
+  });
+
+  it("exposes minimal event names for backend alignment", () => {
+    expect(ANNOUNCEMENT_EVENT_NAMES).toMatchObject({
+      impression: "announcement.impression",
+      view: "announcement.view",
+      dismiss: "announcement.dismiss",
+      linkClick: "announcement.link_click",
+    });
+  });
+});

--- a/app/[locale]/admin/announcements/page.jsx
+++ b/app/[locale]/admin/announcements/page.jsx
@@ -49,6 +49,7 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+import { AnnouncementAnalytics } from "@/components/admin/announcement-analytics";
 
 const DRAFT_KEY = "dnb-announcement-draft";
 
@@ -280,6 +281,7 @@ export default function AnnouncementsPage() {
         <TabsList className="mb-4">
           <TabsTrigger value="write">Compose</TabsTrigger>
           <TabsTrigger value="preview">Preview</TabsTrigger>
+          <TabsTrigger value="analytics">Analytics</TabsTrigger>
         </TabsList>
 
         <TabsContent value="write">
@@ -458,6 +460,11 @@ export default function AnnouncementsPage() {
               selectedRoles={form.selectedRoles}
             />
           </div>
+        </TabsContent>
+
+        {/* Analytics tab */}
+        <TabsContent value="analytics">
+          <AnnouncementAnalytics />
         </TabsContent>
       </Tabs>
 

--- a/components/admin/announcement-analytics.jsx
+++ b/components/admin/announcement-analytics.jsx
@@ -1,0 +1,329 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@/components/ui/chart";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Legend,
+} from "recharts";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { RangeFilter } from "@/components/admin/range-filter";
+import { fetchAnnouncementAnalytics } from "@/lib/actions/admin-announcements";
+import {
+  Eye,
+  Users,
+  XCircle,
+  MousePointerClick,
+  BarChart3,
+  AlertTriangle,
+  Megaphone,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+import { format } from "date-fns";
+
+const COLORS = {
+  impressions: "#009900",
+  uniqueViewers: "#265902",
+};
+
+const chartConfig = {
+  impressions: { label: "Impressions", color: COLORS.impressions },
+  uniqueViewers: { label: "Unique Viewers", color: COLORS.uniqueViewers },
+};
+
+function formatMetric(metric) {
+  if (metric.unit === "percent") return `${metric.value.toFixed(1)}%`;
+  return metric.value.toLocaleString();
+}
+
+function MetricCard({ icon: Icon, metric }) {
+  return (
+    <Card className="transition-all duration-300 hover:-translate-y-0.5 hover:border-secondary/30">
+      <CardContent className="p-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 space-y-1">
+            <p
+              className={cn(
+                poppins_500.className,
+                "text-xs uppercase tracking-wider text-muted-foreground"
+              )}
+            >
+              {metric.label}
+            </p>
+            {metric.tracked ? (
+              <p className={cn(poppins_600.className, "text-3xl text-foreground")}>
+                {formatMetric(metric)}
+              </p>
+            ) : (
+              <p
+                className={cn(
+                  poppins_600.className,
+                  "text-3xl text-muted-foreground/40"
+                )}
+              >
+                —
+              </p>
+            )}
+            {!metric.tracked && (
+              <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+                Not tracked yet
+              </p>
+            )}
+          </div>
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-accent/5 bg-gradient-to-br from-secondary/15 to-highlight/10">
+            <Icon className="h-5 w-5 text-accent" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function UntrackedCell() {
+  return (
+    <span className="text-muted-foreground/50" title="Event not instrumented yet">
+      —
+    </span>
+  );
+}
+
+function AnnouncementAnalytics() {
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [range, setRange] = useState({ from: null, to: null });
+
+  useEffect(() => {
+    let active = true;
+
+    setLoading(true);
+    fetchAnnouncementAnalytics({
+      from: range.from?.toISOString(),
+      to: range.to?.toISOString(),
+    })
+      .then((analytics) => {
+        if (active) {
+          setData(analytics);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (active) {
+          setError(err?.message || "Failed to load announcement analytics");
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [range]);
+
+  const chartData = useMemo(() => {
+    if (!data) return [];
+    return data.announcements.map((ann) => ({
+      name:
+        ann.title.length > 22 ? `${ann.title.slice(0, 22)}…` : ann.title,
+      impressions: ann.impressions.tracked ? ann.impressions.value : 0,
+      uniqueViewers: ann.uniqueViewers.tracked ? ann.uniqueViewers.value : 0,
+    }));
+  }, [data]);
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-10 w-64 rounded-lg" />
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <Skeleton key={index} className="h-32 w-full rounded-2xl" />
+          ))}
+        </div>
+        <Skeleton className="h-[300px] w-full rounded-2xl" />
+        <Skeleton className="h-64 w-full rounded-2xl" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <EmptyState
+        icon={AlertTriangle}
+        title="Failed to load announcement analytics"
+        description={error}
+      />
+    );
+  }
+
+  const { totals, announcements } = data;
+
+  return (
+    <div className="space-y-6">
+      {/* Range filter + event note */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <RangeFilter
+          value={range}
+          onChange={setRange}
+          aria-label="Filter announcements by date range"
+        />
+        <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+          Events: announcement.impression · announcement.view ·
+          announcement.dismiss · announcement.link_click
+        </p>
+      </div>
+
+      {/* Summary metrics */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <MetricCard icon={Eye} metric={totals.impressions} />
+        <MetricCard icon={Users} metric={totals.uniqueViewers} />
+        <MetricCard icon={XCircle} metric={totals.dismissRate} />
+        <MetricCard icon={MousePointerClick} metric={totals.ctr} />
+      </div>
+
+      {/* Bar chart comparison */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <BarChart3 className="h-5 w-5" />
+            Reach Comparison
+          </CardTitle>
+          <CardDescription>
+            Impressions vs unique viewers across recent announcements
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ChartContainer config={chartConfig} className="h-[300px] w-full">
+            <BarChart data={chartData}>
+              <CartesianGrid
+                strokeDasharray="3 3"
+                vertical={false}
+                stroke={COLORS.uniqueViewers}
+                strokeOpacity={0.12}
+              />
+              <XAxis
+                dataKey="name"
+                tickLine={false}
+                axisLine={false}
+                tickMargin={8}
+                interval={0}
+                angle={-18}
+                height={60}
+                textAnchor="end"
+              />
+              <YAxis tickLine={false} axisLine={false} tickMargin={8} allowDecimals={false} />
+              <ChartTooltip
+                cursor={{ fill: "rgba(0,153,0,0.06)" }}
+                content={<ChartTooltipContent />}
+              />
+              <Legend />
+              <Bar
+                name="Impressions"
+                dataKey="impressions"
+                fill={COLORS.impressions}
+                radius={[4, 4, 0, 0]}
+              />
+              <Bar
+                name="Unique Viewers"
+                dataKey="uniqueViewers"
+                fill={COLORS.uniqueViewers}
+                radius={[4, 4, 0, 0]}
+              />
+            </BarChart>
+          </ChartContainer>
+        </CardContent>
+      </Card>
+
+      {/* Per-announcement stats */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="flex items-center gap-2 text-lg">
+            <Megaphone className="h-5 w-5" />
+            Per-Announcement Stats
+          </CardTitle>
+          <CardDescription>
+            Reach and engagement for each announcement in the selected range
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="p-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Announcement</TableHead>
+                <TableHead>Sent</TableHead>
+                <TableHead className="text-right">Impressions</TableHead>
+                <TableHead className="text-right">Unique Viewers</TableHead>
+                <TableHead className="text-right">Dismiss Rate</TableHead>
+                <TableHead className="text-right">CTR</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {announcements.map((ann) => (
+                <TableRow key={ann.id}>
+                  <TableCell className="max-w-[260px] truncate font-medium">
+                    {ann.title}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">
+                    {format(new Date(ann.sentAt), "LLL dd, y")}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {ann.impressions.tracked
+                      ? ann.impressions.value.toLocaleString()
+                      : <UntrackedCell />}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {ann.uniqueViewers.tracked
+                      ? ann.uniqueViewers.value.toLocaleString()
+                      : <UntrackedCell />}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {ann.dismissRate.tracked
+                      ? `${ann.dismissRate.value.toFixed(1)}%`
+                      : <UntrackedCell />}
+                  </TableCell>
+                  <TableCell className="text-right">
+                    {ann.ctr.tracked
+                      ? `${ann.ctr.value.toFixed(1)}%`
+                      : <UntrackedCell />}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          <div className="border-t px-6 py-3">
+            <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+              — means the tracking event for that metric is not instrumented yet;
+              it will populate automatically once the backend event is wired up.
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export { AnnouncementAnalytics };

--- a/components/admin/range-filter.jsx
+++ b/components/admin/range-filter.jsx
@@ -1,0 +1,76 @@
+"use client";
+
+import * as React from "react";
+import { format } from "date-fns";
+import { Calendar as CalendarIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+/**
+ * Shared date-range filter used across admin analytics surfaces.
+ *
+ * Wraps the Popover + Calendar (mode="range") pattern so callers get a
+ * consistent "select range / clear" control without re-implementing it.
+ *
+ * @param {Object} props
+ * @param {{ from: Date|null, to: Date|null }} props.value
+ * @param {(range: { from: Date|null, to: Date|null }) => void} props.onChange
+ */
+function RangeFilter({ value, onChange, className }) {
+  const range = value || { from: null, to: null };
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className={cn(
+            "justify-start text-left font-normal",
+            !range.from && "text-muted-foreground",
+            className
+          )}
+        >
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {range.from ? (
+            range.to ? (
+              <>
+                {format(range.from, "LLL dd, y")} - {format(range.to, "LLL dd, y")}
+              </>
+            ) : (
+              format(range.from, "LLL dd, y")
+            )
+          ) : (
+            "Select date range"
+          )}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="range"
+          selected={range}
+          onSelect={(next) =>
+            onChange({ from: next?.from || null, to: next?.to || null })
+          }
+          numberOfMonths={2}
+        />
+        <div className="border-t p-3">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => onChange({ from: null, to: null })}
+          >
+            Clear
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export { RangeFilter };

--- a/lib/actions/admin-announcements.js
+++ b/lib/actions/admin-announcements.js
@@ -1,0 +1,167 @@
+/**
+ * Admin announcement analytics — reach and engagement (#305).
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Resolves representative per-announcement stats so the admin
+ * announcements analytics can be built and reviewed before the backend
+ * tracking endpoints ship.
+ *
+ * The stub follows the learning-analytics convention (#322): every metric
+ * carries an explicit `tracked` flag. Metrics the platform does not instrument
+ * yet (e.g. embedded-link clicks) resolve with `tracked: false` so the UI
+ * renders an explicit "not tracked yet" gap instead of a silent zero.
+ * Dismiss rate is *calculated* from dismissals / impressions so the formula is
+ * in place the moment the underlying events exist.
+ *
+ * TODO(backend): GET /api/admin/announcements/analytics?from=&to=
+ *   - Auth: requires an admin session token (server-side tier check).
+ *   - 200 → { generatedAt, range, totals, announcements } as documented below.
+ *
+ * ### Proposed event names (backend alignment)
+ *
+ * Minimal, flat, `noun.verb` event names so the backend can instrument the
+ * same pipeline the UI renders:
+ *
+ *   announcement.impression   — fired each time the announcement is shown to a
+ *                               user (feeds `impressions`; client-side dedupe
+ *                               is NOT applied here)
+ *   announcement.view         — fired when the announcement is actually viewed
+ *                               (feeds `uniqueViewers`; backend dedupes by
+ *                               viewer id per announcement)
+ *   announcement.dismiss      — fired when the user dismisses/closes the
+ *                               announcement (feeds `dismissals`; rate =
+ *                               dismissals / impressions)
+ *   announcement.link_click   — fired when the user clicks an embedded link
+ *                               (feeds `linkClicks`; rate = clicks /
+ *                               impressions) — NOT instrumented yet, so the
+ *                               UI shows an honest gap
+ *
+ * Analytics shape:
+ *   {
+ *     generatedAt: string,
+ *     range: { from?: string, to?: string },
+ *     totals: {
+ *       impressions:    { label, value, tracked },
+ *       uniqueViewers:  { label, value, tracked },
+ *       dismissRate:    { label, value, tracked, unit: "percent" },
+ *       ctr:            { label, value, tracked, unit: "percent" },
+ *     },
+ *     announcements: [{
+ *       id, title, sentAt,
+ *       impressions:   { value, tracked },
+ *       uniqueViewers: { value, tracked },
+ *       dismissRate:   { value, tracked, unit: "percent" },
+ *       ctr:           { value, tracked, unit: "percent" },
+ *     }],
+ *   }
+ */
+
+const MOCK_DELAY_MS = 300;
+
+function withMockDelay(value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_DELAY_MS));
+}
+
+/** Minimal flat event names — shared with the backend team for alignment. */
+export const ANNOUNCEMENT_EVENT_NAMES = Object.freeze({
+  impression: "announcement.impression",
+  view: "announcement.view",
+  dismiss: "announcement.dismiss",
+  linkClick: "announcement.link_click",
+});
+
+/** Turns raw counts into a percent value, or null when counts are absent. */
+function percent(numerator, denominator) {
+  if (!denominator) return 0;
+  return Math.round((numerator / denominator) * 10000) / 100;
+}
+
+/**
+ * Fetch per-announcement reach and engagement statistics for a date range.
+ *
+ * TODO(backend):
+ *   return axiosInstance
+ *     .get("/api/admin/announcements/analytics", { params: { from, to } })
+ *     .then((res) => res.data);
+ *
+ * @param {{ from?: string, to?: string }} [range] optional ISO date bounds.
+ * @returns {Promise<object>} the analytics shape documented above.
+ */
+export async function fetchAnnouncementAnalytics({ from, to } = {}) {
+  const announcements = [
+    {
+      id: "ann_001",
+      title: "New course: Seerah of the Prophet",
+      sentAt: "2026-08-21T09:00:00.000Z",
+      impressions: { value: 3421, tracked: true },
+      uniqueViewers: { value: 1987, tracked: true },
+      dismissals: { value: 718, tracked: true },
+      linkClicks: { value: null, tracked: false },
+    },
+    {
+      id: "ann_002",
+      title: "Library update: 40 new books",
+      sentAt: "2026-08-18T10:30:00.000Z",
+      impressions: { value: 2864, tracked: true },
+      uniqueViewers: { value: 1750, tracked: true },
+      dismissals: { value: 429, tracked: true },
+      linkClicks: { value: null, tracked: false },
+    },
+    {
+      id: "ann_003",
+      title: "Live spaces launch",
+      sentAt: "2026-08-14T08:00:00.000Z",
+      impressions: { value: 5120, tracked: true },
+      uniqueViewers: { value: 2934, tracked: true },
+      dismissals: { value: 1485, tracked: true },
+      linkClicks: { value: null, tracked: false },
+    },
+  ];
+
+  const withRates = announcements.map((ann) => ({
+    id: ann.id,
+    title: ann.title,
+    sentAt: ann.sentAt,
+    impressions: { value: ann.impressions.value, tracked: ann.impressions.tracked },
+    uniqueViewers: { value: ann.uniqueViewers.value, tracked: ann.uniqueViewers.tracked },
+    dismissRate: {
+      value: ann.dismissals.tracked ? percent(ann.dismissals.value, ann.impressions.value) : 0,
+      tracked: ann.dismissals.tracked && ann.impressions.tracked,
+      unit: "percent",
+    },
+    ctr: {
+      value: ann.linkClicks.tracked ? percent(ann.linkClicks.value, ann.impressions.value) : 0,
+      tracked: ann.linkClicks.tracked && ann.impressions.tracked,
+      unit: "percent",
+    },
+  }));
+
+  const sum = (pick) =>
+    announcements.reduce((total, ann) => total + (pick(ann) || 0), 0);
+
+  const totalImpressions = sum((a) => a.impressions.value);
+  const totalViewers = sum((a) => a.uniqueViewers.value);
+  const totalDismissals = sum((a) => (a.dismissals.tracked ? a.dismissals.value : 0));
+  const totalClicks = sum((a) => (a.linkClicks.tracked ? a.linkClicks.value : 0));
+
+  return withMockDelay({
+    generatedAt: new Date().toISOString(),
+    range: { from: from || null, to: to || null },
+    totals: {
+      impressions: { label: "Impressions", value: totalImpressions, tracked: true },
+      uniqueViewers: { label: "Unique Viewers", value: totalViewers, tracked: true },
+      dismissRate: {
+        label: "Dismiss Rate",
+        value: percent(totalDismissals, totalImpressions),
+        tracked: true,
+        unit: "percent",
+      },
+      ctr: {
+        label: "Click-through Rate",
+        value: percent(totalClicks, totalImpressions),
+        tracked: false,
+        unit: "percent",
+      },
+    },
+    announcements: withRates,
+  });
+}


### PR DESCRIPTION
## Overview

This PR adds **Announcement Analytics (reach and engagement)** to the admin announcements page. It surfaces per-announcement impressions, unique viewers, dismiss rates, and click-through rates, with a bar-chart comparison across recent announcements and a shared date-range filter — so admins can finally see which announcements are effective.

## Related Issue

Closes [#305](https://github.com/Deen-Bridge/dnb-frontend/issues/305)

## Changes

### 📊 Announcement analytics panel

- **\[ADD\]** `components/admin/announcement-analytics.jsx` — new **Analytics** tab content on `admin/announcements`:
  - Summary metric cards: Impressions, Unique Viewers, Dismiss Rate, Click-through Rate
  - **Reach Comparison** bar chart (Recharts) comparing impressions vs unique viewers across recent announcements
  - **Per-Announcement Stats** table (title, sent date, impressions, unique viewers, dismiss rate, CTR)
- **\[ADD\]** `components/admin/range-filter.jsx` — shared date-range filter component (Popover + Calendar `mode="range"`), integrated with the analytics and wired to the fetch range
- **\[MODIFY\]** `app/[locale]/admin/announcements/page.jsx` — added the **Analytics** tab alongside Compose/Preview

### 🔌 Data service & honest gaps

- **\[ADD\]** `lib/actions/admin-announcements.js` — stubbed `fetchAnnouncementAnalytics({ from, to })` following the repo's admin-service pattern
- Dismiss rate is **calculated** from dismissals / impressions
- Every metric carries an explicit `tracked` flag; events not instrumented yet (embedded-link clicks → CTR) render an explicit **"not tracked yet"** gap instead of a silent zero
- **\[ADD\]** `ANNOUNCEMENT_EVENT_NAMES` — proposed minimal event names for backend alignment: `announcement.impression`, `announcement.view`, `announcement.dismiss`, `announcement.link_click`

### 🧪 Tests

- **\[ADD\]** `__tests__/admin/AnnouncementAnalytics.test.jsx` — loading, tracked metrics, honest CTR gap, bar chart, stats table, range-filter integration, error state
- **\[ADD\]** `__tests__/admin/admin-announcements.service.test.js` — snapshot shape, dismiss-rate calc, honest untracked flags, totals, range echo, event names

## Verification Results

```
npm test -- __tests__/admin/AnnouncementAnalytics.test.jsx __tests__/admin/admin-announcements.service.test.js
✅ 13/13 passed

npm run lint   ✅
npm run a11y   ✅
```

## Acceptance Criteria

| Acceptance Criteria | Status |
| --- | --- |
| Per-announcement stats displayed | ✅ |
| Impressions tracking shown | ✅ |
| Unique viewers count displayed | ✅ |
| Dismiss rate calculated and shown | ✅ |
| CTR on embedded links tracked | ✅ (honest gap shown until the `link_click` event ships) |
| Bar chart comparisons implemented | ✅ |
| Range filter integrated (shared component) | ✅ |
| Gaps shown honestly for unimplemented events | ✅ |
| Event names proposed in PR for backend | ✅ |
