### PR TITLE
feat(admin): add email broadcast stubs with template selection

### DIFF
--- a/__tests__/admin/EmailBroadcastPage.test.jsx
+++ b/__tests__/admin/EmailBroadcastPage.test.jsx
@@ -1,0 +1,142 @@
+/**
+ * Email broadcast page — templates, mapping, recipient estimate, send (#302).
+ * ---------------------------------------------------------------------------
+ * UI-only scope: the page maps composer content onto a selected template,
+ * shows an honest recipient estimate ("—" for unknown, never zero), and
+ * delegates sending to a backend job. These tests mock the service and assert
+ * the presentational branching.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// jsdom does not implement pointer capture, which radix-ui Select relies on.
+// Stub the missing methods so the template picker can open.
+if (typeof Element !== "undefined" && !Element.prototype.hasPointerCapture) {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => {};
+  Element.prototype.releasePointerCapture = () => {};
+}
+if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
+  Element.prototype.scrollIntoView = () => {};
+}
+
+vi.mock("@/lib/config/font.config", () => ({
+  poppins_400: { className: "" },
+  poppins_500: { className: "" },
+  poppins_600: { className: "" },
+}));
+
+const serviceState = vi.hoisted(() => ({
+  listTemplates: null,
+  estimate: null,
+  send: null,
+}));
+vi.mock("@/lib/actions/admin-emails", async () => {
+  const actual = await vi.importActual("@/lib/actions/admin-emails");
+  return {
+    ...actual,
+    listEmailTemplates: () =>
+      serviceState.listTemplates
+        ? serviceState.listTemplates()
+        : Promise.resolve({
+            templates: actual.EMAIL_TEMPLATES.map((template) => ({ ...template })),
+          }),
+    estimateEmailRecipients: (...args) => serviceState.estimate(...args),
+    sendEmailBroadcast: (...args) => serviceState.send(...args),
+  };
+});
+
+import EmailBroadcastPage from "@/app/[locale]/admin/emails/page";
+
+beforeEach(() => {
+  serviceState.listTemplates = null;
+  serviceState.estimate = () => Promise.resolve({ estimate: 12480, known: true });
+  serviceState.send = () =>
+    Promise.resolve({
+      job: {
+        id: "email_test_1",
+        status: "queued",
+        templateId: "announcement",
+        subject: "[Deen Bridge] Seerah launch",
+        audience: "everyone",
+        estimatedRecipients: 12480,
+        createdAt: "2026-08-25T00:00:00.000Z",
+      },
+    });
+});
+
+describe("EmailBroadcastPage", () => {
+  it("renders the template picker with all three templates", async () => {
+    const user = userEvent.setup();
+    render(<EmailBroadcastPage />);
+
+    expect(
+      await screen.findByText("Platform news and updates for your audience")
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("combobox"));
+    expect(await screen.findByRole("option", { name: "Maintenance" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Compliance" })).toBeInTheDocument();
+  });
+
+  it("maps composer content onto the email subject and body", async () => {
+    const user = userEvent.setup();
+    render(<EmailBroadcastPage />);
+
+    await screen.findByText("Platform news and updates for your audience");
+
+    await user.type(screen.getByLabelText("Title"), "Seerah launch");
+    await user.type(screen.getByLabelText("Content"), "Join the new course.");
+
+    expect(screen.getByText("[Deen Bridge] Seerah launch")).toBeInTheDocument();
+    // The typed content appears in the preview body (not just the textarea).
+    const bodyMatches = screen.getAllByText(/Join the new course\./);
+    expect(
+      bodyMatches.some((node) => node.textContent.includes("The Deen Bridge team"))
+    ).toBe(true);
+  });
+
+  it("shows the estimated recipient count for a known audience", async () => {
+    render(<EmailBroadcastPage />);
+
+    expect(await screen.findByText("12,480")).toBeInTheDocument();
+    expect(screen.getByText("recipients")).toBeInTheDocument();
+  });
+
+  it("shows an honest '—' for an unknown recipient count", async () => {
+    const user = userEvent.setup();
+    serviceState.estimate = () => Promise.resolve({ estimate: null, known: false });
+    render(<EmailBroadcastPage />);
+
+    await screen.findByText("Platform news and updates for your audience");
+
+    await user.click(screen.getByLabelText("Specific Users"));
+
+    expect(await screen.findByText("unknown")).toBeInTheDocument();
+    expect(screen.queryByText("12,480")).toBeNull();
+  });
+
+  it("delegates sending to the backend and shows the queued job", async () => {
+    const user = userEvent.setup();
+    render(<EmailBroadcastPage />);
+
+    await screen.findByText("Platform news and updates for your audience");
+
+    await user.type(screen.getByLabelText("Title"), "Seerah launch");
+    await user.type(screen.getByLabelText("Content"), "Join the new course.");
+    await user.click(screen.getByRole("button", { name: /send email/i }));
+
+    expect(
+      await screen.findByText(/queued — job email_test_1 · backend will deliver/i)
+    ).toBeInTheDocument();
+  });
+
+  it("disables send until there is subject and body content", async () => {
+    render(<EmailBroadcastPage />);
+
+    await screen.findByText("Platform news and updates for your audience");
+
+    expect(screen.getByRole("button", { name: /send email/i })).toBeDisabled();
+  });
+});

--- a/__tests__/admin/admin-emails.service.test.js
+++ b/__tests__/admin/admin-emails.service.test.js
@@ -1,0 +1,126 @@
+/**
+ * Admin email broadcast service — templates, recipient estimation, send (#302).
+ * ---------------------------------------------------------------------------
+ * The UI-only scope delegates actual sending to a backend job. These tests pin
+ * the template list, the composer-content → subject/body mapping, the honest
+ * recipient estimation (unknown → null, never a fabricated zero), and the
+ * queued-job send contract.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  listEmailTemplates,
+  EMAIL_TEMPLATES,
+  AUDIENCE_COUNTS,
+  applyEmailTemplate,
+  estimateEmailRecipients,
+  sendEmailBroadcast,
+} from "@/lib/actions/admin-emails";
+
+describe("listEmailTemplates", () => {
+  it("exposes the three placeholder templates", async () => {
+    const { templates } = await listEmailTemplates();
+
+    expect(templates.map((template) => template.id)).toEqual([
+      "announcement",
+      "maintenance",
+      "compliance",
+    ]);
+    for (const template of templates) {
+      expect(template).toMatchObject({
+        id: expect.any(String),
+        label: expect.any(String),
+        subjectTemplate: expect.any(String),
+        bodyTemplate: expect.any(String),
+      });
+    }
+  });
+});
+
+describe("applyEmailTemplate", () => {
+  it("maps composer title and content into subject and body", () => {
+    const { subject, body } = applyEmailTemplate(EMAIL_TEMPLATES[0], {
+      title: "Seerah launch",
+      content: "Join the new course.",
+    });
+
+    expect(subject).toContain("Seerah launch");
+    expect(body).toContain("Join the new course.");
+  });
+
+  it("leaves no placeholders when composer content is empty", () => {
+    const { subject, body } = applyEmailTemplate(EMAIL_TEMPLATES[1]);
+
+    expect(subject).not.toContain("{title}");
+    expect(body).not.toContain("{content}");
+  });
+});
+
+describe("estimateEmailRecipients", () => {
+  it("returns a known estimate for 'everyone'", async () => {
+    const result = await estimateEmailRecipients({ audience: "everyone" });
+
+    expect(result.known).toBe(true);
+    expect(result.estimate).toBeGreaterThan(0);
+  });
+
+  it("returns unknown for role audience with no roles selected", async () => {
+    const result = await estimateEmailRecipients({ audience: "role", roles: [] });
+
+    expect(result).toEqual({ estimate: null, known: false });
+  });
+
+  it("sums per-role counts for the selected roles", async () => {
+    const result = await estimateEmailRecipients({
+      audience: "role",
+      roles: ["student", "educator"],
+    });
+
+    expect(result.known).toBe(true);
+    expect(result.estimate).toBe(AUDIENCE_COUNTS.student + AUDIENCE_COUNTS.educator);
+  });
+
+  it("returns a count for specific users when IDs are provided", async () => {
+    const result = await estimateEmailRecipients({
+      audience: "specific",
+      userIds: "a@x.com, b@x.com, c@x.com",
+    });
+
+    expect(result).toEqual({ estimate: 3, known: true });
+  });
+
+  it("returns unknown for specific users with no IDs — honest gap, not zero", async () => {
+    const result = await estimateEmailRecipients({ audience: "specific", userIds: "" });
+
+    expect(result).toEqual({ estimate: null, known: false });
+  });
+});
+
+describe("sendEmailBroadcast", () => {
+  it("enqueues a backend job with the mapped content", async () => {
+    const { job } = await sendEmailBroadcast({
+      templateId: "announcement",
+      subject: "[Deen Bridge] Seerah launch",
+      body: "Join the new course.",
+      audience: "everyone",
+      estimatedRecipients: 12480,
+    });
+
+    expect(job.status).toBe("queued");
+    expect(job.id).toMatch(/^email_/);
+    expect(job.templateId).toBe("announcement");
+    expect(job.subject).toBe("[Deen Bridge] Seerah launch");
+    expect(job.audience).toBe("everyone");
+    expect(job.estimatedRecipients).toBe(12480);
+  });
+
+  it("keeps an unknown recipient count honest (null, not zero)", async () => {
+    const { job } = await sendEmailBroadcast({
+      templateId: "compliance",
+      subject: "Update",
+      audience: "specific",
+      estimatedRecipients: null,
+    });
+
+    expect(job.estimatedRecipients).toBeNull();
+  });
+});

--- a/app/[locale]/admin/emails/page.jsx
+++ b/app/[locale]/admin/emails/page.jsx
@@ -1,0 +1,423 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Mail,
+  Send,
+  Users,
+  User,
+  Globe,
+  Loader2,
+  Check,
+  AlertTriangle,
+  FileText,
+  Braces,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { poppins_400, poppins_500, poppins_600 } from "@/lib/config/font.config";
+import {
+  listEmailTemplates,
+  applyEmailTemplate,
+  estimateEmailRecipients,
+  sendEmailBroadcast,
+} from "@/lib/actions/admin-emails";
+
+const ROLES = [
+  { id: "student", label: "Student" },
+  { id: "educator", label: "Educator" },
+  { id: "admin", label: "Admin" },
+  { id: "moderator", label: "Moderator" },
+];
+
+function RecipientEstimate({ estimate, loading }) {
+  if (loading) return <Skeleton className="h-6 w-28 rounded-md" />;
+  if (!estimate.known) {
+    return (
+      <span className="inline-flex items-baseline gap-1 text-foreground">
+        <span className="text-2xl">—</span>
+        <span className="text-xs text-muted-foreground">unknown</span>
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-baseline gap-1 text-foreground">
+      <span className="text-2xl">{estimate.estimate.toLocaleString()}</span>
+      <span className="text-xs text-muted-foreground">recipients</span>
+    </span>
+  );
+}
+
+export default function EmailBroadcastPage() {
+  const [templates, setTemplates] = useState([]);
+  const [templatesLoading, setTemplatesLoading] = useState(true);
+  const [templateId, setTemplateId] = useState("announcement");
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [audience, setAudience] = useState("everyone");
+  const [selectedRoles, setSelectedRoles] = useState([]);
+  const [selectedUsers, setSelectedUsers] = useState("");
+  const [estimate, setEstimate] = useState({ estimate: null, known: false });
+  const [estimateLoading, setEstimateLoading] = useState(false);
+  const [sending, setSending] = useState(false);
+  const [sentJob, setSentJob] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    listEmailTemplates()
+      .then(({ templates }) => {
+        if (active) {
+          setTemplates(templates);
+          setTemplatesLoading(false);
+        }
+      })
+      .catch(() => {
+        if (active) setTemplatesLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  // Recipient estimate is re-fetched whenever the audience segment changes,
+  // so the count (or an honest "—") is always shown before send.
+  useEffect(() => {
+    let active = true;
+    setEstimateLoading(true);
+    estimateEmailRecipients({
+      audience,
+      roles: selectedRoles,
+      userIds: selectedUsers,
+    })
+      .then((result) => {
+        if (active) {
+          setEstimate(result);
+          setEstimateLoading(false);
+        }
+      })
+      .catch(() => {
+        if (active) {
+          setEstimate({ estimate: null, known: false });
+          setEstimateLoading(false);
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [audience, selectedRoles, selectedUsers]);
+
+  const selectedTemplate = useMemo(
+    () =>
+      templates.find((template) => template.id === templateId) ||
+      templates[0] ||
+      null,
+    [templates, templateId]
+  );
+
+  // Subject/body mapping straight from composer content via the template.
+  const mapped = useMemo(
+    () =>
+      selectedTemplate
+        ? applyEmailTemplate(selectedTemplate, { title, content })
+        : { subject: "", body: "" },
+    [selectedTemplate, title, content]
+  );
+
+  const toggleRole = (roleId) => {
+    setSelectedRoles((prev) =>
+      prev.includes(roleId)
+        ? prev.filter((role) => role !== roleId)
+        : [...prev, roleId]
+    );
+  };
+
+  const handleSend = async () => {
+    if (!selectedTemplate) return;
+    setSending(true);
+    setError(null);
+    try {
+      const result = await sendEmailBroadcast({
+        templateId: selectedTemplate.id,
+        subject: mapped.subject,
+        body: mapped.body,
+        audience,
+        roles: selectedRoles,
+        userIds: selectedUsers,
+        estimatedRecipients: estimate.known ? estimate.estimate : null,
+      });
+      setSentJob(result.job);
+    } catch (err) {
+      setError(err?.message || "Failed to send email broadcast");
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <PageShell>
+      <PageHeader
+        icon={Mail}
+        title="Email Broadcast"
+        subtitle="Send templated emails to your audience — delivery is handled by the backend"
+      />
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        {/* Left column — compose + template */}
+        <div className="space-y-6 lg:col-span-2">
+          {/* Composer content */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <FileText className="h-4 w-4" />
+                Compose Content
+              </CardTitle>
+              <CardDescription>
+                Title and content map onto the selected template&apos;s subject
+                and body.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="email-title">Title</Label>
+                <Input
+                  id="email-title"
+                  placeholder="Enter announcement title..."
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="email-content">Content</Label>
+                <Textarea
+                  id="email-content"
+                  placeholder="Write the email body content..."
+                  rows={6}
+                  value={content}
+                  onChange={(e) => setContent(e.target.value)}
+                />
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Template picker */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Braces className="h-4 w-4" />
+                Email Template
+              </CardTitle>
+              <CardDescription>
+                Choose a template — its placeholders fill from your content.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {templatesLoading ? (
+                <Skeleton className="h-10 w-full rounded-md" />
+              ) : (
+                <Select value={templateId} onValueChange={setTemplateId}>
+                  <SelectTrigger id="email-template" className="w-full">
+                    <SelectValue placeholder="Select a template" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {templates.map((template) => (
+                      <SelectItem key={template.id} value={template.id}>
+                        {template.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+              {selectedTemplate && (
+                <div className="rounded-lg bg-muted/50 p-3">
+                  <p className={cn(poppins_500.className, "text-sm")}>
+                    {selectedTemplate.label}
+                  </p>
+                  <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+                    {selectedTemplate.description}
+                  </p>
+                </div>
+              )}
+              <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+                Placeholders: {"{title}"} → subject · {"{content}"} → body
+              </p>
+            </CardContent>
+          </Card>
+
+          {/* Audience + recipient estimate */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Users className="h-4 w-4" />
+                Audience
+              </CardTitle>
+              <CardDescription>
+                Who should receive this email?
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <RadioGroup
+                value={audience}
+                onValueChange={setAudience}
+                className="space-y-3"
+              >
+                <div className="flex items-center gap-3">
+                  <RadioGroupItem value="everyone" id="email-everyone" />
+                  <Label htmlFor="email-everyone" className="flex items-center gap-2 cursor-pointer">
+                    <Globe className="h-4 w-4 text-muted-foreground" />
+                    Everyone
+                  </Label>
+                </div>
+                <div className="flex items-center gap-3">
+                  <RadioGroupItem value="role" id="email-by-role" />
+                  <Label htmlFor="email-by-role" className="flex items-center gap-2 cursor-pointer">
+                    <Users className="h-4 w-4 text-muted-foreground" />
+                    By Role
+                  </Label>
+                </div>
+                {audience === "role" && (
+                  <div className="ml-7 flex flex-wrap gap-2">
+                    {ROLES.map((role) => (
+                      <div key={role.id} className="flex items-center gap-2">
+                        <Checkbox
+                          id={`email-role-${role.id}`}
+                          checked={selectedRoles.includes(role.id)}
+                          onCheckedChange={() => toggleRole(role.id)}
+                        />
+                        <Label htmlFor={`email-role-${role.id}`} className="text-sm cursor-pointer">
+                          {role.label}
+                        </Label>
+                      </div>
+                    ))}
+                  </div>
+                )}
+                <div className="flex items-center gap-3">
+                  <RadioGroupItem value="specific" id="email-specific" />
+                  <Label htmlFor="email-specific" className="flex items-center gap-2 cursor-pointer">
+                    <User className="h-4 w-4 text-muted-foreground" />
+                    Specific Users
+                  </Label>
+                </div>
+                {audience === "specific" && (
+                  <div className="ml-7">
+                    <Input
+                      placeholder="Enter user IDs or emails, separated by commas"
+                      value={selectedUsers}
+                      onChange={(e) => setSelectedUsers(e.target.value)}
+                    />
+                  </div>
+                )}
+              </RadioGroup>
+
+              <div className="flex items-center justify-between rounded-lg bg-muted/50 p-3">
+                <div className="space-y-0.5">
+                  <p className={cn(poppins_500.className, "text-sm")}>
+                    Estimated Recipients
+                  </p>
+                  <p className={cn(poppins_400.className, "text-xs text-muted-foreground")}>
+                    Unknown counts show "—", never a fabricated zero
+                  </p>
+                </div>
+                <RecipientEstimate estimate={estimate} loading={estimateLoading} />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+
+        {/* Right column — preview + send */}
+        <div className="space-y-6">
+          {/* Email preview (subject/body mapping) */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <Mail className="h-4 w-4" />
+                Email Preview
+              </CardTitle>
+              <CardDescription>
+                How the email will look to recipients
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <p className={cn(poppins_500.className, "text-xs uppercase tracking-wider text-muted-foreground")}>
+                  Subject
+                </p>
+                <p className={cn(poppins_600.className, "mt-1 text-sm")}>
+                  {mapped.subject || "—"}
+                </p>
+              </div>
+              <div>
+                <p className={cn(poppins_500.className, "text-xs uppercase tracking-wider text-muted-foreground")}>
+                  Body
+                </p>
+                <div className="mt-1 whitespace-pre-line rounded-lg border bg-muted/30 p-3">
+                  <p className={cn(poppins_400.className, "text-sm text-muted-foreground")}>
+                    {mapped.body || "—"}
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* Send */}
+          <Card>
+            <CardContent className="space-y-3 p-5">
+              {error && (
+                <div className="flex items-center gap-2 rounded-lg border border-destructive/30 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+                  <AlertTriangle className="h-4 w-4 shrink-0" />
+                  {error}
+                </div>
+              )}
+              {sentJob && (
+                <div className="flex items-center gap-2 rounded-lg border border-green-600/30 bg-green-500/10 px-3 py-2 text-sm text-green-700">
+                  <Check className="h-4 w-4 shrink-0" />
+                  Queued — job {sentJob.id} · backend will deliver
+                </div>
+              )}
+              <Button
+                className="w-full"
+                onClick={handleSend}
+                disabled={
+                  sending || !selectedTemplate || !title.trim() || !content.trim()
+                }
+              >
+                {sending ? (
+                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                ) : (
+                  <Send className="h-4 w-4 mr-2" />
+                )}
+                Send Email
+              </Button>
+              <p className={cn(poppins_400.className, "text-center text-xs text-muted-foreground")}>
+                Sending is delegated to a backend job — the UI only enqueues it.
+              </p>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </PageShell>
+  );
+}

--- a/lib/actions/admin-emails.js
+++ b/lib/actions/admin-emails.js
@@ -1,0 +1,197 @@
+/**
+ * Admin email broadcast service — templates, recipient estimation, send (#302).
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** UI-only scope: actual sending is delegated to a backend job.
+ * This module mocks the three expected endpoints so the admin email broadcast
+ * UI can be built and reviewed before the backend lands. Swap the mock bodies
+ * for `axiosInstance` calls (see `lib/config/axios.config.js`).
+ *
+ * Proposed backend endpoints:
+ *   GET  /api/admin/emails/templates    → { templates: EmailTemplate[] }
+ *   POST /api/admin/emails/estimate     → { estimate: number|null, known: boolean }
+ *   POST /api/admin/emails              → 202 { job: {...} } — enqueues the email
+ *                                          job; sending happens server-side
+ *
+ * Email template shape:
+ *   {
+ *     id: string,               // "announcement" | "maintenance" | "compliance"
+ *     label: string,
+ *     description: string,
+ *     subjectTemplate: string,  // supports {title} and {content} placeholders
+ *     bodyTemplate: string,     // supports {title} and {content} placeholders
+ *   }
+ */
+
+import { logAuditEvent, AUDIT_ACTIONS } from "@/lib/admin/audit";
+
+const MOCK_DELAY_MS = 300;
+
+function withMockDelay(value) {
+  return new Promise((resolve) => setTimeout(() => resolve(value), MOCK_DELAY_MS));
+}
+
+/** Placeholder templates surfaced in the admin template picker. */
+export const EMAIL_TEMPLATES = Object.freeze([
+  {
+    id: "announcement",
+    label: "Announcement",
+    description: "Platform news and updates for your audience",
+    subjectTemplate: "[Deen Bridge] {title}",
+    bodyTemplate:
+      "Hello,\n\n{content}\n\n— The Deen Bridge team",
+  },
+  {
+    id: "maintenance",
+    label: "Maintenance",
+    description: "Scheduled downtime and service notices",
+    subjectTemplate: "[Deen Bridge] Scheduled maintenance: {title}",
+    bodyTemplate:
+      "Hello,\n\n{content}\n\nPlease plan accordingly.\n\n— The Deen Bridge team",
+  },
+  {
+    id: "compliance",
+    label: "Compliance",
+    description: "Policy, terms, or data-handling updates",
+    subjectTemplate: "[Deen Bridge] Important update: {title}",
+    bodyTemplate:
+      "Hello,\n\n{content}\n\nYou can review the full policy in your account settings.\n\n— The Deen Bridge team",
+  },
+]);
+
+/** Audience size estimates for the "everyone" and per-role estimates. */
+export const AUDIENCE_COUNTS = Object.freeze({
+  everyone: 12480,
+  student: 8420,
+  educator: 3120,
+  admin: 48,
+  moderator: 12,
+});
+
+/**
+ * List the email templates available in the picker.
+ *
+ * TODO(backend): GET /api/admin/emails/templates
+ *   - Auth: admin session (server-side tier check).
+ *   - 200 → { templates: EmailTemplate[] }
+ *
+ * @returns {Promise<{ templates: Array<{ id: string, label: string, description: string, subjectTemplate: string, bodyTemplate: string }> }>}
+ */
+export async function listEmailTemplates() {
+  // TODO(backend):
+  //   return axiosInstance
+  //     .get("/api/admin/emails/templates")
+  //     .then((res) => res.data);
+  return withMockDelay({
+    templates: EMAIL_TEMPLATES.map((template) => ({ ...template })),
+  });
+}
+
+/**
+ * Map composer content (title + content) onto an email template's placeholders.
+ * Pure and synchronous so the preview can recompute live as the admin types.
+ *
+ * @param {{ subjectTemplate: string, bodyTemplate: string }} template
+ * @param {{ title?: string, content?: string }} [composer]
+ * @returns {{ subject: string, body: string }}
+ */
+export function applyEmailTemplate(template, { title = "", content = "" } = {}) {
+  const fill = (text) =>
+    (text || "").replace(/\{title\}/g, title).replace(/\{content\}/g, content);
+  return {
+    subject: fill(template.subjectTemplate),
+    body: fill(template.bodyTemplate),
+  };
+}
+
+/**
+ * Estimate how many recipients an audience segment reaches. Unknown segments
+ * resolve with `estimate: null` and `known: false` so the UI can render a
+ * honest "—" instead of a fabricated zero.
+ *
+ * TODO(backend): POST /api/admin/emails/estimate
+ *   - Auth: admin session.
+ *   - Payload: { audience: string, roles?: string[], userIds?: string }
+ *   - 200 → { estimate: number|null, known: boolean }
+ *
+ * @param {{ audience?: string, roles?: string[], userIds?: string }} [segment]
+ * @returns {Promise<{ estimate: number|null, known: boolean }>}
+ */
+export async function estimateEmailRecipients({
+  audience = "everyone",
+  roles = [],
+  userIds = "",
+} = {}) {
+  if (audience === "everyone") {
+    return withMockDelay({ estimate: AUDIENCE_COUNTS.everyone, known: true });
+  }
+
+  if (audience === "role") {
+    if (!roles.length) return withMockDelay({ estimate: null, known: false });
+    const estimate = roles.reduce(
+      (total, role) => total + (AUDIENCE_COUNTS[role] || 0),
+      0
+    );
+    return withMockDelay({ estimate, known: true });
+  }
+
+  // specific users — only a real count when user IDs are supplied
+  const ids = userIds
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+  if (!ids.length) return withMockDelay({ estimate: null, known: false });
+  return withMockDelay({ estimate: ids.length, known: true });
+}
+
+/**
+ * Send an email broadcast. The backend enqueues a job and performs the actual
+ * delivery — the UI never sends emails itself. Returns the queued job.
+ *
+ * TODO(backend): POST /api/admin/emails
+ *   - Auth: admin session (server-side tier check).
+ *   - Payload: { templateId, subject, body, audience, roles, userIds,
+ *                estimatedRecipients }
+ *   - 202 → { job: { id, status: "queued", templateId, subject, audience,
+ *                     estimatedRecipients, createdAt } }
+ *
+ * @param {{ templateId?: string, subject?: string, body?: string, audience?: string, roles?: string[], userIds?: string, estimatedRecipients?: number|null }} payload
+ * @returns {Promise<{ job: { id: string, status: string, templateId: string, subject: string, audience: string, estimatedRecipients: number|null, createdAt: string } }>}
+ */
+export async function sendEmailBroadcast({
+  templateId = "",
+  subject = "",
+  body = "",
+  audience = "all",
+  roles = [],
+  userIds = "",
+  estimatedRecipients = null,
+} = {}) {
+  // TODO(backend):
+  //   const { data } = await axiosInstance.post("/api/admin/emails", {
+  //     templateId, subject, body, audience, roles, userIds, estimatedRecipients,
+  //   });
+  const job = {
+    id: `email_${Math.random().toString(36).slice(2, 10)}`,
+    status: "queued",
+    templateId,
+    subject,
+    audience,
+    estimatedRecipients,
+    createdAt: new Date().toISOString(),
+  };
+  const result = await withMockDelay({ job });
+
+  // Fire-and-forget audit trail — never awaited, never blocks the caller.
+  logAuditEvent({
+    action: AUDIT_ACTIONS.BROADCAST,
+    target: { label: subject || "Email broadcast", href: null },
+    metadata: {
+      templateId,
+      audience,
+      estimatedRecipients,
+      hasBody: Boolean(body),
+    },
+  });
+
+  return result;
+}


### PR DESCRIPTION
## Overview

This PR adds **Email Broadcast stubs with template selection** to the admin panel. Admins can pick a template (Announcement / Maintenance / Compliance), map composer content onto the email subject and body, see an honest estimated recipient count per audience before sending, and enqueue delivery — while actual sending is fully delegated to a backend job.

## Related Issue

Closes [#302](https://github.com/Deen-Bridge/dnb-frontend/issues/302)

## Changes

### 📧 Email broadcast UI

- **\[ADD\]** `app/[locale]/admin/emails/page.jsx` — new **Email Broadcast** admin page:
  - Template picker with the three placeholder templates (Announcement, Maintenance, Compliance)
  - Compose card (title + content) that maps cleanly onto the template's subject and body
  - **Email Preview** showing the live mapped subject and body
  - Audience selector (Everyone / By Role / Specific Users) with an **Estimated Recipients** display per audience before send
  - Send action that enqueues a backend job and reports the queued status

### 🔌 Stubbed service (delegation to backend)

- **\[ADD\]** `lib/actions/admin-emails.js` — stubbed service documenting the backend contract:
  - `listEmailTemplates()` → GET `/api/admin/emails/templates`
  - `applyEmailTemplate()` — pure composer-content → subject/body mapping
  - `estimateEmailRecipients()` → POST `/api/admin/emails/estimate`; **unknown segments return `null`/`known:false` so the UI renders an honest "—" instead of a fabricated zero**
  - `sendEmailBroadcast()` → POST `/api/admin/emails` — returns `{ job: { status: "queued" } }`; the UI never sends emails itself, plus a fire-and-forget audit event

### 🧪 Tests

- **\[ADD\]** `__tests__/admin/EmailBroadcastPage.test.jsx` — template picker, subject/body mapping, recipient estimate, honest "—" for unknown, backend-delegated send, disabled-until-content
- **\[ADD\]** `__tests__/admin/admin-emails.service.test.js` — templates, mapping, honest estimation, queued-job contract

## Verification Results

```
npm test -- __tests__/admin/EmailBroadcastPage.test.jsx __tests__/admin/admin-emails.service.test.js
✅ 16/16 passed

npm run lint   ✅
npm run a11y   ✅
```

## Acceptance Criteria

| Acceptance Criteria | Status |
| --- | --- |
| Template picker implemented with all placeholders | ✅ |
| Subject mapping from composer content | ✅ |
| Body mapping from composer content | ✅ |
| Estimated recipient count shown before send | ✅ |
| Unknown counts display as "—" (not zero) | ✅ |
| Send action wired to backend endpoints | ✅ |
| Stub responses working for development | ✅ |
| Full delegation to backend job | ✅ |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin email broadcast page.
  * Added three email templates with live subject and message previews.
  * Added audience selection for everyone, roles, or specific users.
  * Added recipient estimates, with unknown counts shown clearly.
  * Added queued-send confirmation and error handling.
  * Send remains unavailable until required content is entered.

* **Tests**
  * Added coverage for templates, audience estimates, message mapping, sending, and form validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->