### PR TITLE
refactor(account): align inner dashboard pages with main dashboard design

### DIFF
--- a/app/[locale]/account/notifications/page.jsx
+++ b/app/[locale]/account/notifications/page.jsx
@@ -19,6 +19,8 @@ import {
 import { formatDistanceToNow } from "date-fns";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
 import {
   poppins_400,
   poppins_500,
@@ -116,43 +118,30 @@ export default function NotificationsPage() {
   const rangeEnd = Math.min(page * PAGE_SIZE, total);
 
   return (
-    <div className="min-h-full bg-surface p-3 sm:p-6">
+    <PageShell>
       <div className="mx-auto max-w-5xl space-y-6">
         {/* Header */}
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-              <Bell className="h-5 w-5 text-accent" />
-            </div>
-            <div>
-              <h1
+        <PageHeader
+          icon={Bell}
+          title="Notifications"
+          subtitle={
+            unread > 0 ? `${unread} unread` : "You're all caught up"
+          }
+          actions={
+            unread > 0 && (
+              <button
+                onClick={handleMarkAll}
                 className={cn(
-                  poppins_600,
-                  "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
+                  poppins_500,
+                  "inline-flex items-center gap-1.5 rounded-full border border-accent/15 bg-surface px-4 py-2 text-sm text-ink transition-colors hover:border-secondary/40 hover:text-accent"
                 )}
               >
-                Notifications
-              </h1>
-              <p className={cn(poppins_400, "text-sm text-ink-muted")}>
-                {unread > 0
-                  ? `${unread} unread`
-                  : "You're all caught up"}
-              </p>
-            </div>
-          </div>
-          {unread > 0 && (
-            <button
-              onClick={handleMarkAll}
-              className={cn(
-                poppins_500,
-                "inline-flex items-center gap-1.5 rounded-full border border-accent/15 bg-surface px-4 py-2 text-sm text-ink transition-colors hover:border-secondary/40 hover:text-accent"
-              )}
-            >
-              <CheckCheck className="h-4 w-4 text-accent" />
-              Mark all read
-            </button>
-          )}
-        </div>
+                <CheckCheck className="h-4 w-4 text-accent" />
+                Mark all read
+              </button>
+            )
+          }
+        />
 
         {/* List */}
         <Panel className="overflow-hidden">
@@ -294,6 +283,6 @@ export default function NotificationsPage() {
           )}
         </Panel>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/[locale]/account/profile/[profileid]/page.jsx
+++ b/app/[locale]/account/profile/[profileid]/page.jsx
@@ -12,6 +12,7 @@ import Loader from "@/components/molecules/loaders/rootLoader";
 import { ExternalLink } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { poppins_500 } from "@/lib/config/font.config";
+import { PageShell } from "@/components/ui/page-shell";
 const page = ({ params }) => {
   const { profileid } = use(params);
   const [selectedTab, setSelectedTab] = useState("courses");
@@ -56,7 +57,7 @@ const page = ({ params }) => {
   }
 
   return (
-    <div className="min-h-full bg-surface p-3 sm:p-6">
+    <PageShell>
       <div className="mx-auto max-w-5xl space-y-4">
         <div className="overflow-hidden rounded-2xl border border-accent/10 bg-surface-raised shadow-sm">
           <ProfileHeader avatar={user?.avatar} />
@@ -77,7 +78,7 @@ const page = ({ params }) => {
         <ProfileTabs selectedTab={selectedTab} onChange={setSelectedTab} />
         <ProfileContent selectedTab={selectedTab} profileId={user?._id} />
       </div>
-    </div>
+    </PageShell>
   );
 };
 export default page;

--- a/app/[locale]/account/security/page.jsx
+++ b/app/[locale]/account/security/page.jsx
@@ -17,6 +17,8 @@ import {
 import { formatDistanceToNow } from "date-fns";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
 import {
   poppins_400,
   poppins_500,
@@ -163,27 +165,14 @@ export default function SecurityPage() {
   const otherCount = sessions.filter((s) => !s.isCurrent).length;
 
   return (
-    <div className="min-h-full bg-surface p-3 sm:p-6">
+    <PageShell>
       <div className="mx-auto max-w-5xl space-y-6">
         {/* Header */}
-        <div className="flex items-center gap-3">
-          <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-            <ShieldCheck className="h-5 w-5 text-accent" />
-          </div>
-          <div>
-            <h1
-              className={cn(
-                poppins_600,
-                "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
-              )}
-            >
-              Security
-            </h1>
-            <p className={cn(poppins_400, "text-sm text-ink-muted")}>
-              Keep your account safe — password, 2FA, and active devices
-            </p>
-          </div>
-        </div>
+        <PageHeader
+          icon={ShieldCheck}
+          title="Security"
+          subtitle="Keep your account safe — password, 2FA, and active devices"
+        />
 
         {/* Change password */}
         <Panel>
@@ -365,6 +354,6 @@ export default function SecurityPage() {
           )}
         </Panel>
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/[locale]/account/settings/page.jsx
+++ b/app/[locale]/account/settings/page.jsx
@@ -34,6 +34,8 @@ import {
   Smartphone,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
 import {
   poppins_400,
   poppins_500,
@@ -299,30 +301,16 @@ const SettingsPage = () => {
   );
 
   return (
-    <div className="min-h-screen bg-surface p-3 sm:p-6">
-      <div className="mx-auto max-w-5xl">
+    <PageShell>
+      <div className="mx-auto max-w-5xl space-y-6">
         {/* Header */}
-        <div className="mb-8">
-          <div className="flex items-center gap-3">
-            <div className="flex size-12 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-              <Settings className="h-6 w-6 text-accent" />
-            </div>
-            <div>
-              <h1
-                className={cn(
-                  poppins_600,
-                  "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent sm:text-3xl"
-                )}
-              >
-                Settings
-              </h1>
-              <p className={cn(poppins_400, "text-sm text-ink-muted")}>
-                Manage your account preferences and privacy
-              </p>
-            </div>
-          </div>
+        <PageHeader
+          icon={Settings}
+          title="Settings"
+          subtitle="Manage your account preferences and privacy"
+        />
 
-          {message.text && (
+        {message.text && (
             <div
               className={cn(
                 "mt-6 flex items-center gap-2 rounded-xl border p-4",
@@ -372,7 +360,6 @@ const SettingsPage = () => {
               </div>
             </div>
           )}
-        </div>
 
         <Tabs
           value={activeTab}
@@ -916,7 +903,7 @@ const SettingsPage = () => {
           </TabsContent>
         </Tabs>
       </div>
-    </div>
+    </PageShell>
   );
 };
 

--- a/app/[locale]/account/support/page.jsx
+++ b/app/[locale]/account/support/page.jsx
@@ -16,6 +16,8 @@ import {
   ShieldCheck,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
 import {
   poppins_400,
   poppins_500,
@@ -104,37 +106,15 @@ const ReportIssue = () => {
 
   };
   return (
-    <div className="min-h-full bg-surface p-4 sm:p-6">
+    <PageShell>
       {/* <DashTabs selectedTab={as}/> */}
       <div className="mx-auto max-w-5xl space-y-6">
         {/* Hero header */}
-        <Panel className="relative overflow-hidden bg-gradient-to-br from-secondary/10 via-surface-raised to-highlight/10 p-6 sm:p-8">
-          <div className="pointer-events-none absolute -right-10 -top-10 h-40 w-40 rounded-full bg-secondary/10 blur-3xl" />
-          <div className="relative flex items-center gap-3">
-            <div className="flex size-12 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-              <LifeBuoy className="h-6 w-6 text-accent" />
-            </div>
-            <div>
-              <h1
-                className={cn(
-                  poppins_600,
-                  "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent sm:text-3xl"
-                )}
-              >
-                Support
-              </h1>
-              <p
-                className={cn(
-                  poppins_400,
-                  "mt-1 max-w-xl text-sm leading-relaxed text-ink-muted"
-                )}
-              >
-                Having an issue? Tell us what happened and our team will attend
-                to it as soon as possible.
-              </p>
-            </div>
-          </div>
-        </Panel>
+        <PageHeader
+          icon={LifeBuoy}
+          title="Support"
+          subtitle="Having an issue? Tell us what happened and our team will attend to it as soon as possible."
+        />
 
         {/* Main: form (2/3) + sidebar (1/3) */}
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
@@ -266,7 +246,7 @@ const ReportIssue = () => {
           </div>
         </div>
       </div>
-    </div>
+    </PageShell>
   );
 };
 export default ReportIssue;

--- a/app/[locale]/account/verification/page.jsx
+++ b/app/[locale]/account/verification/page.jsx
@@ -39,6 +39,8 @@ import {
 import { formatDistanceToNow, format } from "date-fns";
 import { toast } from "sonner";
 import { cn } from "@/lib/utils";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
 import {
   poppins_400,
   poppins_500,
@@ -317,50 +319,36 @@ export default function VerificationPage() {
   }, [refresh]);
 
   return (
-    <div className="min-h-full bg-surface p-3 sm:p-6">
+    <PageShell>
       <div className="mx-auto max-w-3xl space-y-6">
 
         {/* ── Header ──────────────────────────────────────────────────── */}
-        <div className="flex flex-wrap items-center justify-between gap-4">
-          <div className="flex items-center gap-3">
-            <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-              <ShieldCheck className="h-5 w-5 text-accent" />
-            </div>
-            <div>
-              <h1
-                className={cn(
-                  poppins_600,
-                  "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
-                )}
+        <PageHeader
+          icon={ShieldCheck}
+          title="Verification"
+          subtitle="Your educator identity and application status"
+          actions={
+            <div className="flex items-center gap-2">
+              {/* Live status badge */}
+              <Badge
+                data-testid="status-badge"
+                className={cn("rounded-full px-3 py-1 text-xs", badgeCfg.className)}
               >
-                Verification
-              </h1>
-              <p className={cn(poppins_400, "text-sm text-ink-muted")}>
-                Your educator identity and application status
-              </p>
+                {badgeCfg.label}
+              </Badge>
+
+              {/* Manual refresh */}
+              <button
+                onClick={handleRefresh}
+                aria-label="Refresh verification status"
+                data-testid="refresh-btn"
+                className="rounded-lg border border-accent/15 bg-surface p-2 text-ink-muted transition-colors hover:border-accent/30 hover:text-accent"
+              >
+                <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              </button>
             </div>
-          </div>
-
-          <div className="flex items-center gap-2">
-            {/* Live status badge */}
-            <Badge
-              data-testid="status-badge"
-              className={cn("rounded-full px-3 py-1 text-xs", badgeCfg.className)}
-            >
-              {badgeCfg.label}
-            </Badge>
-
-            {/* Manual refresh */}
-            <button
-              onClick={handleRefresh}
-              aria-label="Refresh verification status"
-              data-testid="refresh-btn"
-              className="rounded-lg border border-accent/15 bg-surface p-2 text-ink-muted transition-colors hover:border-accent/30 hover:text-accent"
-            >
-              <RefreshCw className="h-4 w-4" aria-hidden="true" />
-            </button>
-          </div>
-        </div>
+          }
+        />
 
         {/* ── Loading skeleton ─────────────────────────────────────────── */}
         {loading && (
@@ -559,6 +547,6 @@ export default function VerificationPage() {
           </>
         )}
       </div>
-    </div>
+    </PageShell>
   );
 }

--- a/app/[locale]/account/wallet/page.jsx
+++ b/app/[locale]/account/wallet/page.jsx
@@ -5,6 +5,8 @@ import { useStellar } from "@/components/stellar/StellarProvider";
 import WalletConnectButton from "@/components/stellar/WalletConnectButton";
 import TransactionHistory from "@/components/stellar/TransactionHistory";
 import { Skeleton } from "@/components/ui/skeleton";
+import { PageShell } from "@/components/ui/page-shell";
+import { PageHeader } from "@/components/ui/page-header";
 import {
   Wallet,
   ExternalLink,
@@ -69,13 +71,13 @@ export default function WalletPage() {
 
   if (authLoading || isLoading) {
     return (
-      <div className="bg-surface p-4 sm:p-6">
-        <div className="mx-auto max-w-4xl space-y-6">
+      <PageShell>
+        <div className="mx-auto max-w-5xl space-y-6">
           <Skeleton className="h-11 w-64 rounded-2xl" />
           <Skeleton className="h-48 w-full rounded-2xl" />
           <Skeleton className="h-64 w-full rounded-2xl" />
         </div>
-      </div>
+      </PageShell>
     );
   }
 
@@ -85,30 +87,15 @@ export default function WalletPage() {
   };
 
   return (
-    <div className="min-h-full bg-surface p-4 sm:p-6">
+    <PageShell>
       <div className="mx-auto max-w-5xl space-y-6">
         {/* ── Header ── */}
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-3">
-            <div className="flex size-11 items-center justify-center rounded-2xl border border-accent/5 bg-gradient-to-br from-secondary/20 to-highlight/10">
-              <Wallet className="h-5 w-5 text-accent" />
-            </div>
-            <div>
-              <h1
-                className={cn(
-                  poppins_600,
-                  "bg-gradient-to-r from-secondary via-highlight to-accent bg-clip-text text-2xl text-transparent"
-                )}
-              >
-                Stellar Wallet
-              </h1>
-              <p className={cn(poppins_400, "text-sm text-ink-muted")}>
-                Manage your Stellar wallet and view transactions
-              </p>
-            </div>
-          </div>
-          <WalletConnectButton />
-        </div>
+        <PageHeader
+          icon={Wallet}
+          title="Stellar Wallet"
+          subtitle="Manage your Stellar wallet and view transactions"
+          actions={<WalletConnectButton />}
+        />
 
         {/* ── Network Info ── */}
         <div className="flex items-center gap-2 rounded-xl border border-accent/10 bg-surface-raised px-4 py-3">
@@ -346,6 +333,6 @@ export default function WalletPage() {
           </div>
         </Panel>
       </div>
-    </div>
+    </PageShell>
   );
 }


### PR DESCRIPTION
## Overview

This PR aligns the inner account pages with the main dashboard design system so users feel like they are in the same application whether they are on `/dashboard` or any settings/account page. Previously the inner pages used hand-rolled wrappers and oversized headings; now they compose from the exact same shared primitives as Courses and Library.

## Related Issue

Closes [#69](https://github.com/Deen-Bridge/dnb-frontend/issues/69)

## Changes

### 🎨 Shared dashboard primitives on every account page

- **\[MODIFY\]** `app/[locale]/account/settings/page.jsx` — wrapper + header → `PageShell` / `PageHeader` (message + install banners preserved)
- **\[MODIFY\]** `app/[locale]/account/wallet/page.jsx` — header + connect action → `PageHeader` `actions`; loading state also uses `PageShell`
- **\[MODIFY\]** `app/[locale]/account/security/page.jsx` — wrapper + header → `PageShell` / `PageHeader`
- **\[MODIFY\]** `app/[locale]/account/notifications/page.jsx` — header + "Mark all read" → `PageHeader` `actions`
- **\[MODIFY\]** `app/[locale]/account/support/page.jsx` — oversized hero panel → standard `PageHeader`
- **\[MODIFY\]** `app/[locale]/account/verification/page.jsx` — status badge + refresh → `PageHeader` `actions`
- **\[MODIFY\]** `app/[locale]/account/profile/[profileid]/page.jsx` — wrapper → `PageShell`

### Consistent design tokens

- **Spacing/padding**: `p-3 sm:p-6` → dashboard's `p-4 sm:p-6` (`PageShell`) and `space-y-6` rhythm
- **Typography scale**: oversized `text-2xl/3xl` headers → dashboard's `text-xl sm:text-2xl` (`PageHeader`)
- **Cards/colors**: already consistent (`rounded-2xl border-accent/10 bg-surface-raised shadow-sm`, gradient icon boxes) — unchanged
- **Accessibility bonus**: skip-link + `#main-content` semantics now present on every account page

## Verification Results

```
npm run lint            ✅
npm run a11y            ✅
npm test -- __tests__/verification/VerificationPage.test.jsx
✅ 15/15 passed

Net diff: -79 lines (removed duplicated wrapper/header markup)
```

## Acceptance Criteria

| Acceptance Criteria | Status |
| --- | --- |
| Consistent card components (border radius + shadows) | ✅ |
| Same typography scale for headings and body | ✅ |
| Matching spacing and padding patterns | ✅ |
| Unified color usage for backgrounds, borders, accents | ✅ |
| Same responsive behavior across breakpoints | ✅ |
| Seamless visual transition between sections | ✅ |
