### PR TITLE
Fix: [Enhancement] Bulk publish state changes for courses (Auto-Generated)

### DIFF
--- a/components/admin/BulkCoursePublishDialog.jsx
+++ b/components/admin/BulkCoursePublishDialog.jsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from "@/components/ui/dialog";
+import { Button } from "@/components/atoms/form/Button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { toast } from "sonner";
+
+export default function BulkCoursePublishDialog({ open, onOpenChange, courses, onConfirm }) {
+  const [confirmation, setConfirmation] = useState("");
+  const [loading, setLoading] = useState(false);
+  const needsConfirmation = courses.length > 10;
+
+  const handleConfirm = async () => {
+    if (needsConfirmation && confirmation !== "PUBLISH") return;
+    setLoading(true);
+    try {
+      await onConfirm(courses);
+      onOpenChange(false);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Publish {courses.length} courses</DialogTitle>
+          <DialogDescription>
+            Are you sure you want to set these courses to live? This action will make them visible to all students.
+          </DialogDescription>
+        </DialogHeader>
+        
+        <ScrollArea className="max-h-60 border rounded-md p-2 my-2">
+          <ul className="text-sm space-y-1">
+            {courses.map(c => <li key={c.id}>• {c.title}</li>)}
+          </ul>
+        </ScrollArea>
+
+        {needsConfirmation && (
+          <div className="space-y-2">
+            <Label>Type <span className="font-bold">PUBLISH</span> to confirm</Label>
+            <Input value={confirmation} onChange={(e) => setConfirmation(e.target.value)} placeholder="PUBLISH" />
+          </div>
+        )}
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>Cancel</Button>
+          <Button 
+            disabled={loading || (needsConfirmation && confirmation !== "PUBLISH")} 
+            onClick={handleConfirm}
+          >
+            {loading ? "Publishing..." : "Confirm Publish"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/lib/actions/courses/publish.js
+++ b/lib/actions/courses/publish.js
@@ -1,0 +1,17 @@
+import axiosInstance from "@/lib/config/axios.config";
+
+/**
+ * Sequential bulk publish handler for courses.
+ */
+export async function bulkPublishCourses(courseIds) {
+  const results = { success: [], errors: [] };
+  for (const id of courseIds) {
+    try {
+      await axiosInstance.post(`/api/courses/${id}/publish`);
+      results.success.push(id);
+    } catch (e) {
+      results.errors.push({ id, message: e.message });
+    }
+  }
+  return results;
+}


### PR DESCRIPTION
Closes #245

This pull request was generated automatically and scoped strictly to issue #245.

### Changes
Implemented bulk publishing feature for courses. Created a reusable BulkCoursePublishDialog to handle multi-select publishing, including a pre-flight confirmation list and a requirement to type a confirmation word for batches larger than 10, preventing accidental mass-publication.

### Verification
⚠️ Not verified locally (no build system detected, or the required toolchain isn't installed on the worker). **GitHub CI is the source of truth** — please check the CI status on this PR before merging.

_Linked with `Closes #245` so the Drips Wave bot resolves the issue on merge._

<!-- dt-auto -->