### PR TITLE
﻿feat(reels): admin poster/thumbnail management (#265)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,8 @@ NEXT_PUBLIC_VAPID_PUBLIC_KEY=
 NEXT_PUBLIC_CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
 # Cloudinary cloud name for unsigned uploads (required).
 # Unsigned uploads return a PUBLIC secure_url, so this path is for course
-# media only — thumbnails, previews, lesson video.
+# media and reel posters only — thumbnails, previews, lesson video, reel
+# cover images (dnb_reels_posters preset).
 # Verification documents (government ID, certificates) must NEVER go through
 # it. They upload to a private, short-lived signed URL issued by the backend;
 # see lib/actions/educators/uploadDocument.js.

--- a/__tests__/reels/ReelPosterDialog.test.jsx
+++ b/__tests__/reels/ReelPosterDialog.test.jsx
@@ -1,5 +1,5 @@
-/**
- * ReelPosterDialog — frame-capture and custom-upload flows (#265).
+ï»¿/**
+ * ReelPosterDialog - frame-capture and custom-upload flows (#265).
  * -------------------------------------------------------------------------
  * Cloudinary upload and poster persistence are mocked at the hook boundary
  * (useCloudinaryUpload / useReelPoster) since those are already covered by
@@ -7,7 +7,7 @@
  * frame off the <video> via <canvas>, wiring the upload result into
  * setPoster, and the plain file-upload path.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
@@ -17,24 +17,30 @@ const mocks = vi.hoisted(() => ({
   setPoster: vi.fn(),
   uploadFrameFile: vi.fn(),
   uploadCustomFile: vi.fn(),
+  // The component calls useCloudinaryUpload(POSTER_UPLOAD_PRESET, ...) twice
+  // with identical args (frame tab, then upload tab), so there's no argument
+  // to key off of -- but React's rules of hooks guarantee a stable call
+  // order per render, so we alternate by call index instead.
+  cloudinaryCallCount: 0,
 }));
 
 vi.mock("@/hooks/useReelPoster", () => ({
   default: () => ({ poster: null, setPoster: mocks.setPoster, isPending: false, error: null }),
 }));
 
-// The dialog creates two independent useCloudinaryUpload instances (frame tab,
-// upload tab). Distinguish them by the preset argument so each tab's upload
-// can be asserted independently.
 vi.mock("@/hooks/useCloudinaryUpload", () => ({
-  useCloudinaryUpload: () => ({
-    uploadFile: mocks.uploadFrameFile,
-    uploading: false,
-    progress: 0,
-    uploadedUrl: null,
-    error: null,
-    reset: vi.fn(),
-  }),
+  useCloudinaryUpload: () => {
+    const isFrameInstance = mocks.cloudinaryCallCount % 2 === 0;
+    mocks.cloudinaryCallCount += 1;
+    return {
+      uploadFile: isFrameInstance ? mocks.uploadFrameFile : mocks.uploadCustomFile,
+      uploading: false,
+      progress: 0,
+      uploadedUrl: null,
+      error: null,
+      reset: vi.fn(),
+    };
+  },
 }));
 
 import { toast } from "sonner";
@@ -44,6 +50,7 @@ const reel = { id: "reel-1", video: "https://cdn/reel-1.mp4", poster: null };
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mocks.cloudinaryCallCount = 0;
   global.URL.createObjectURL = vi.fn(() => "blob:mock-preview");
 
   // Radix Slider/Tabs need these in jsdom; same polyfill used elsewhere
@@ -59,6 +66,10 @@ beforeEach(() => {
       disconnect() {}
     };
   }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 /**
@@ -102,7 +113,6 @@ describe("captureVideoFrame()", () => {
     expect(drawImage).toHaveBeenCalledWith(video, 0, 0, 640, 1136);
     expect(blob).toBe(fakeBlob);
 
-    document.createElement.mockRestore();
   });
 
   it("rejects when toBlob yields nothing", async () => {
@@ -117,11 +127,10 @@ describe("captureVideoFrame()", () => {
     const video = { videoWidth: 640, videoHeight: 1136 };
     await expect(captureVideoFrame(video)).rejects.toThrow(/couldn't capture/i);
 
-    document.createElement.mockRestore();
   });
 });
 
-describe("<ReelPosterDialog /> — pick-a-frame tab", () => {
+describe("<ReelPosterDialog /> - pick-a-frame tab", () => {
   it("captures the current frame, uploads it, and persists the poster", async () => {
     const user = userEvent.setup();
     const fakeCanvas = {
@@ -171,7 +180,6 @@ describe("<ReelPosterDialog /> — pick-a-frame tab", () => {
     expect(toast.success).toHaveBeenCalled();
     expect(onOpenChange).toHaveBeenCalledWith(false);
 
-    document.createElement.mockRestore();
   });
 
   it("keeps the dialog open and toasts an error if the upload fails", async () => {
@@ -205,13 +213,12 @@ describe("<ReelPosterDialog /> — pick-a-frame tab", () => {
     expect(mocks.setPoster).not.toHaveBeenCalled();
     expect(onOpenChange).not.toHaveBeenCalledWith(false);
 
-    document.createElement.mockRestore();
   });
 });
 
-describe("<ReelPosterDialog /> — upload-image tab", () => {
+describe("<ReelPosterDialog /> - upload-image tab", () => {
   it("uploads the chosen file and persists it as the poster", async () => {
-    mocks.uploadFrameFile.mockResolvedValue(
+    mocks.uploadCustomFile.mockResolvedValue(
       "https://res.cloudinary.com/demo/image/upload/custom.jpg"
     );
     mocks.setPoster.mockResolvedValue(
@@ -235,7 +242,9 @@ describe("<ReelPosterDialog /> — upload-image tab", () => {
     const input = screen.getByLabelText(/custom cover image/i);
     await userEvent.upload(input, file);
 
-    await waitFor(() => expect(mocks.uploadFrameFile).toHaveBeenCalledWith(file));
+    await waitFor(() => expect(mocks.uploadCustomFile).toHaveBeenCalledWith(file));
+    // The frame-tab upload must never fire just because the file tab did.
+    expect(mocks.uploadFrameFile).not.toHaveBeenCalled();
     await waitFor(() =>
       expect(mocks.setPoster).toHaveBeenCalledWith(
         "https://res.cloudinary.com/demo/image/upload/custom.jpg"

--- a/__tests__/reels/ReelPosterDialog.test.jsx
+++ b/__tests__/reels/ReelPosterDialog.test.jsx
@@ -1,0 +1,249 @@
+/**
+ * ReelPosterDialog — frame-capture and custom-upload flows (#265).
+ * -------------------------------------------------------------------------
+ * Cloudinary upload and poster persistence are mocked at the hook boundary
+ * (useCloudinaryUpload / useReelPoster) since those are already covered by
+ * their own unit tests; this file drives the dialog's own logic: reading a
+ * frame off the <video> via <canvas>, wiring the upload result into
+ * setPoster, and the plain file-upload path.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const mocks = vi.hoisted(() => ({
+  setPoster: vi.fn(),
+  uploadFrameFile: vi.fn(),
+  uploadCustomFile: vi.fn(),
+}));
+
+vi.mock("@/hooks/useReelPoster", () => ({
+  default: () => ({ poster: null, setPoster: mocks.setPoster, isPending: false, error: null }),
+}));
+
+// The dialog creates two independent useCloudinaryUpload instances (frame tab,
+// upload tab). Distinguish them by the preset argument so each tab's upload
+// can be asserted independently.
+vi.mock("@/hooks/useCloudinaryUpload", () => ({
+  useCloudinaryUpload: () => ({
+    uploadFile: mocks.uploadFrameFile,
+    uploading: false,
+    progress: 0,
+    uploadedUrl: null,
+    error: null,
+    reset: vi.fn(),
+  }),
+}));
+
+import { toast } from "sonner";
+import ReelPosterDialog, { captureVideoFrame } from "@/components/organisms/reels/ReelPosterDialog";
+
+const reel = { id: "reel-1", video: "https://cdn/reel-1.mp4", poster: null };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  global.URL.createObjectURL = vi.fn(() => "blob:mock-preview");
+
+  // Radix Slider/Tabs need these in jsdom; same polyfill used elsewhere
+  // (__tests__/admin/StepUpConfirmDialog.test.jsx, etc.).
+  Element.prototype.scrollIntoView = vi.fn();
+  Element.prototype.hasPointerCapture = vi.fn();
+  Element.prototype.setPointerCapture = vi.fn();
+  Element.prototype.releasePointerCapture = vi.fn();
+  if (!window.ResizeObserver) {
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+/**
+ * Mock document.createElement("canvas") for a single test while delegating
+ * every other tag to the real implementation, so Radix's portal/dialog DOM
+ * nodes still render normally.
+ */
+function mockCanvas(fakeCanvas) {
+  const realCreateElement = document.createElement.bind(document);
+  return vi
+    .spyOn(document, "createElement")
+    .mockImplementation((tag, options) =>
+      tag === "canvas" ? fakeCanvas : realCreateElement(tag, options)
+    );
+}
+
+describe("captureVideoFrame()", () => {
+  it("rejects when the video has no dimensions yet", async () => {
+    const video = { videoWidth: 0, videoHeight: 0 };
+    await expect(captureVideoFrame(video)).rejects.toThrow(
+      /isn't ready to capture/i
+    );
+  });
+
+  it("draws the current video frame and resolves a Blob", async () => {
+    const drawImage = vi.fn();
+    const fakeBlob = new Blob(["fake"], { type: "image/jpeg" });
+    const fakeCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ({ drawImage })),
+      toBlob: vi.fn((cb) => cb(fakeBlob)),
+    };
+    mockCanvas(fakeCanvas);
+
+    const video = { videoWidth: 640, videoHeight: 1136 };
+    const blob = await captureVideoFrame(video);
+
+    expect(fakeCanvas.width).toBe(640);
+    expect(fakeCanvas.height).toBe(1136);
+    expect(drawImage).toHaveBeenCalledWith(video, 0, 0, 640, 1136);
+    expect(blob).toBe(fakeBlob);
+
+    document.createElement.mockRestore();
+  });
+
+  it("rejects when toBlob yields nothing", async () => {
+    const fakeCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ({ drawImage: vi.fn() })),
+      toBlob: vi.fn((cb) => cb(null)),
+    };
+    mockCanvas(fakeCanvas);
+
+    const video = { videoWidth: 640, videoHeight: 1136 };
+    await expect(captureVideoFrame(video)).rejects.toThrow(/couldn't capture/i);
+
+    document.createElement.mockRestore();
+  });
+});
+
+describe("<ReelPosterDialog /> — pick-a-frame tab", () => {
+  it("captures the current frame, uploads it, and persists the poster", async () => {
+    const user = userEvent.setup();
+    const fakeCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ({ drawImage: vi.fn() })),
+      toBlob: vi.fn((cb) => cb(new Blob(["fake"], { type: "image/jpeg" }))),
+    };
+    mockCanvas(fakeCanvas);
+    mocks.uploadFrameFile.mockResolvedValue(
+      "https://res.cloudinary.com/demo/image/upload/frame.jpg"
+    );
+    mocks.setPoster.mockResolvedValue("https://res.cloudinary.com/demo/image/upload/frame.jpg");
+
+    const onUpdated = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ReelPosterDialog
+        open
+        onOpenChange={onOpenChange}
+        reel={reel}
+        onUpdated={onUpdated}
+      />
+    );
+
+    // Simulate the video reporting its duration/dimensions once metadata loads.
+    const video = document.querySelector("video");
+    Object.defineProperty(video, "videoWidth", { value: 640, configurable: true });
+    Object.defineProperty(video, "videoHeight", { value: 1136, configurable: true });
+    Object.defineProperty(video, "duration", { value: 12, configurable: true });
+    fireEvent.loadedMetadata(video);
+
+    const captureButton = await screen.findByRole("button", {
+      name: /use this frame as poster/i,
+    });
+    await user.click(captureButton);
+
+    await waitFor(() => expect(mocks.uploadFrameFile).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(mocks.setPoster).toHaveBeenCalledWith(
+        "https://res.cloudinary.com/demo/image/upload/frame.jpg"
+      )
+    );
+    expect(onUpdated).toHaveBeenCalledWith(
+      "https://res.cloudinary.com/demo/image/upload/frame.jpg"
+    );
+    expect(toast.success).toHaveBeenCalled();
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+
+    document.createElement.mockRestore();
+  });
+
+  it("keeps the dialog open and toasts an error if the upload fails", async () => {
+    const user = userEvent.setup();
+    const fakeCanvas = {
+      width: 0,
+      height: 0,
+      getContext: vi.fn(() => ({ drawImage: vi.fn() })),
+      toBlob: vi.fn((cb) => cb(new Blob(["fake"], { type: "image/jpeg" }))),
+    };
+    mockCanvas(fakeCanvas);
+    mocks.uploadFrameFile.mockRejectedValue(new Error("Upload failed"));
+
+    const onOpenChange = vi.fn();
+    render(
+      <ReelPosterDialog open onOpenChange={onOpenChange} reel={reel} onUpdated={vi.fn()} />
+    );
+
+    const video = document.querySelector("video");
+    Object.defineProperty(video, "videoWidth", { value: 640, configurable: true });
+    Object.defineProperty(video, "videoHeight", { value: 1136, configurable: true });
+    Object.defineProperty(video, "duration", { value: 12, configurable: true });
+    fireEvent.loadedMetadata(video);
+
+    const captureButton = await screen.findByRole("button", {
+      name: /use this frame as poster/i,
+    });
+    await user.click(captureButton);
+
+    await waitFor(() => expect(mocks.uploadFrameFile).toHaveBeenCalled());
+    expect(mocks.setPoster).not.toHaveBeenCalled();
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+
+    document.createElement.mockRestore();
+  });
+});
+
+describe("<ReelPosterDialog /> — upload-image tab", () => {
+  it("uploads the chosen file and persists it as the poster", async () => {
+    mocks.uploadFrameFile.mockResolvedValue(
+      "https://res.cloudinary.com/demo/image/upload/custom.jpg"
+    );
+    mocks.setPoster.mockResolvedValue(
+      "https://res.cloudinary.com/demo/image/upload/custom.jpg"
+    );
+
+    const onUpdated = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <ReelPosterDialog
+        open
+        onOpenChange={onOpenChange}
+        reel={reel}
+        onUpdated={onUpdated}
+      />
+    );
+
+    await userEvent.click(screen.getByRole("tab", { name: /upload image/i }));
+
+    const file = new File(["fake"], "cover.jpg", { type: "image/jpeg" });
+    const input = screen.getByLabelText(/custom cover image/i);
+    await userEvent.upload(input, file);
+
+    await waitFor(() => expect(mocks.uploadFrameFile).toHaveBeenCalledWith(file));
+    await waitFor(() =>
+      expect(mocks.setPoster).toHaveBeenCalledWith(
+        "https://res.cloudinary.com/demo/image/upload/custom.jpg"
+      )
+    );
+    expect(onUpdated).toHaveBeenCalledWith(
+      "https://res.cloudinary.com/demo/image/upload/custom.jpg"
+    );
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/__tests__/reels/reels-action-poster.test.js
+++ b/__tests__/reels/reels-action-poster.test.js
@@ -1,5 +1,5 @@
-/**
- * lib/actions/reels-action — updateReelPoster (#265) stub contract.
+ï»¿/**
+ * lib/actions/reels-action - updateReelPoster (#265) stub contract.
  * -------------------------------------------------------------------------
  * Mirrors the coverage style of the existing setReelVisibility stub (#335):
  * asserts the resolved shape callers depend on, the validation guard, and

--- a/__tests__/reels/reels-action-poster.test.js
+++ b/__tests__/reels/reels-action-poster.test.js
@@ -1,0 +1,52 @@
+/**
+ * lib/actions/reels-action — updateReelPoster (#265) stub contract.
+ * -------------------------------------------------------------------------
+ * Mirrors the coverage style of the existing setReelVisibility stub (#335):
+ * asserts the resolved shape callers depend on, the validation guard, and
+ * that concurrent calls for different reels don't clobber each other's
+ * in-memory state.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { updateReelPoster } from "@/lib/actions/reels-action";
+
+describe("updateReelPoster()", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  it("resolves with the reel id, poster url, and an updatedAt timestamp", async () => {
+    const promise = updateReelPoster("reel-1", {
+      posterUrl: "https://res.cloudinary.com/demo/image/upload/reel-1.jpg",
+    });
+    await vi.advanceTimersByTimeAsync(500);
+    const result = await promise;
+
+    expect(result.reel.id).toBe("reel-1");
+    expect(result.reel.poster).toBe(
+      "https://res.cloudinary.com/demo/image/upload/reel-1.jpg"
+    );
+    expect(typeof result.reel.updatedAt).toBe("string");
+  });
+
+  it("rejects when posterUrl is missing", async () => {
+    await expect(updateReelPoster("reel-1", {})).rejects.toThrow(
+      /poster url is required/i
+    );
+  });
+
+  it("rejects when posterUrl is not a string", async () => {
+    await expect(
+      updateReelPoster("reel-1", { posterUrl: 12345 })
+    ).rejects.toThrow(/poster url is required/i);
+  });
+
+  it("keeps separate reels' posters independent", async () => {
+    const p1 = updateReelPoster("reel-1", { posterUrl: "https://cdn/one.jpg" });
+    const p2 = updateReelPoster("reel-2", { posterUrl: "https://cdn/two.jpg" });
+    await vi.advanceTimersByTimeAsync(500);
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1.reel.poster).toBe("https://cdn/one.jpg");
+    expect(r2.reel.poster).toBe("https://cdn/two.jpg");
+  });
+});

--- a/__tests__/reels/useReelPoster.test.jsx
+++ b/__tests__/reels/useReelPoster.test.jsx
@@ -1,5 +1,5 @@
-/**
- * useReelPoster — optimistic poster update hook tests (#265).
+ï»¿/**
+ * useReelPoster - optimistic poster update hook tests (#265).
  * -------------------------------------------------------------------------
  * Mirrors the existing useReelModeration coverage style: asserts the
  * optimistic value shows immediately, the committed server value lands, and

--- a/__tests__/reels/useReelPoster.test.jsx
+++ b/__tests__/reels/useReelPoster.test.jsx
@@ -1,0 +1,82 @@
+/**
+ * useReelPoster — optimistic poster update hook tests (#265).
+ * -------------------------------------------------------------------------
+ * Mirrors the existing useReelModeration coverage style: asserts the
+ * optimistic value shows immediately, the committed server value lands, and
+ * a rejected mutation rolls back to the baseline with a toast.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+const mocks = vi.hoisted(() => ({
+  updateReelPoster: vi.fn(),
+}));
+
+vi.mock("@/lib/actions/reels-action", () => ({
+  updateReelPoster: mocks.updateReelPoster,
+}));
+
+import { toast } from "sonner";
+import useReelPoster from "@/hooks/useReelPoster";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useReelPoster()", () => {
+  it("starts with the initial poster", () => {
+    const { result } = renderHook(() => useReelPoster("reel-1", "https://cdn/old.jpg"));
+    expect(result.current.poster).toBe("https://cdn/old.jpg");
+  });
+
+  it("applies the new poster optimistically, then commits the server value", async () => {
+    let resolveUpdate;
+    mocks.updateReelPoster.mockReturnValue(
+      new Promise((resolve) => {
+        resolveUpdate = resolve;
+      })
+    );
+    const { result } = renderHook(() => useReelPoster("reel-1", null));
+
+    let mutation;
+    act(() => {
+      mutation = result.current.setPoster("https://cdn/new.jpg");
+    });
+
+    // Optimistic value shows before the (still-pending) mutation resolves.
+    await waitFor(() => expect(result.current.poster).toBe("https://cdn/new.jpg"));
+
+    act(() => {
+      resolveUpdate({
+        reel: { id: "reel-1", poster: "https://cdn/server-echoed.jpg" },
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.poster).toBe("https://cdn/server-echoed.jpg")
+    );
+    await mutation;
+
+    expect(mocks.updateReelPoster).toHaveBeenCalledWith("reel-1", {
+      posterUrl: "https://cdn/new.jpg",
+    });
+  });
+
+  it("rolls back to the baseline and toasts on failure", async () => {
+    mocks.updateReelPoster.mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() =>
+      useReelPoster("reel-1", "https://cdn/old.jpg")
+    );
+
+    await act(async () => {
+      await result.current.setPoster("https://cdn/new.jpg").catch(() => {});
+    });
+
+    expect(result.current.poster).toBe("https://cdn/old.jpg");
+    expect(toast.error).toHaveBeenCalledWith(
+      "Couldn't update this reel's poster"
+    );
+  });
+});

--- a/components/atoms/reels/ReelPosterButton.jsx
+++ b/components/atoms/reels/ReelPosterButton.jsx
@@ -1,10 +1,10 @@
-"use client";
+ï»¿"use client";
 /**
- * ReelPosterButton — opens `ReelPosterDialog` for a reel (#265).
+ * ReelPosterButton - opens `ReelPosterDialog` for a reel (#265).
  *
  * Purely presentational trigger, styled like the other reel action rail
  * buttons. Visibility (admin-only) is decided by the caller (`ReelCard`), not
- * here, so this stays a dumb button — consistent with `ReelModerationButton`.
+ * here, so this stays a dumb button - consistent with `ReelModerationButton`.
  *
  * @param {Object} props
  * @param {() => void} props.onClick

--- a/components/atoms/reels/ReelPosterButton.jsx
+++ b/components/atoms/reels/ReelPosterButton.jsx
@@ -1,0 +1,27 @@
+"use client";
+/**
+ * ReelPosterButton — opens `ReelPosterDialog` for a reel (#265).
+ *
+ * Purely presentational trigger, styled like the other reel action rail
+ * buttons. Visibility (admin-only) is decided by the caller (`ReelCard`), not
+ * here, so this stays a dumb button — consistent with `ReelModerationButton`.
+ *
+ * @param {Object} props
+ * @param {() => void} props.onClick
+ * @param {string} [props.className]
+ */
+import { ImageIcon } from "lucide-react";
+import ReelActionButton from "@/components/atoms/reels/ReelActionButton";
+
+const ReelPosterButton = ({ onClick, className }) => {
+  return (
+    <ReelActionButton
+      icon={<ImageIcon size={20} aria-hidden="true" />}
+      accessibleLabel="Manage this reel's poster"
+      onClick={onClick}
+      className={className}
+    />
+  );
+};
+
+export default ReelPosterButton;

--- a/components/organisms/reels/ReelCard.jsx
+++ b/components/organisms/reels/ReelCard.jsx
@@ -1,4 +1,4 @@
-"use client";
+ï»¿"use client";
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -47,6 +47,9 @@ const ReelCard = ({
   const [posterDialogOpen, setPosterDialogOpen] = useState(false);
 
   const { user } = useAuth();
+  // UI-visibility gate only, not access control -- the real enforcement
+  // has to happen server-side once PATCH /api/reels/:id/poster exists
+  // (see the TODO(backend) contract on updateReelPoster).
   const isAdmin = normalizeRole(user?.role) === ROLES.ADMIN;
 
   const isPaused = playing !== reel.id;
@@ -193,7 +196,7 @@ const ReelCard = ({
           )}
         </button>
 
-        {/* Right action rail — overlaid inside, all breakpoints (TikTok-style) */}
+        {/* Right action rail - overlaid inside, all breakpoints (TikTok-style) */}
         <div className="absolute bottom-24 right-2.5 z-30 flex flex-col items-center gap-5">
           <div className="mb-1 flex flex-col items-center">
             <Avatar className="h-11 w-11 border-2 border-white">
@@ -256,7 +259,7 @@ const ReelCard = ({
             <span className="text-sm font-semibold">
               @{reel.createdBy?.name || "Anonymous"}
             </span>
-            <span className="text-[11px] text-white/60">·</span>
+            <span className="text-[11px] text-white/60">{"\u00B7"}</span>
             <span className="text-[11px] text-white/70">{formattedDate}</span>
             <button
               type="button"

--- a/components/organisms/reels/ReelCard.jsx
+++ b/components/organisms/reels/ReelCard.jsx
@@ -14,6 +14,10 @@ import {
 } from "lucide-react";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import ReelActionButton from "@/components/atoms/reels/ReelActionButton";
+import ReelPosterButton from "@/components/atoms/reels/ReelPosterButton";
+import ReelPosterDialog from "@/components/organisms/reels/ReelPosterDialog";
+import { useAuth } from "@/hooks/useAuth";
+import { ROLES, normalizeRole } from "@/lib/auth/roles";
 import { cn } from "@/lib/utils";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
@@ -39,6 +43,11 @@ const ReelCard = ({
   const [likeCount, setLikeCount] = useState(reel.stats?.likes || 0);
   const [loveCount, setLoveCount] = useState(reel.stats?.loves || 0);
   const [muted, setMuted] = useState(true);
+  const [posterUrl, setPosterUrl] = useState(reel.poster ?? null);
+  const [posterDialogOpen, setPosterDialogOpen] = useState(false);
+
+  const { user } = useAuth();
+  const isAdmin = normalizeRole(user?.role) === ROLES.ADMIN;
 
   const isPaused = playing !== reel.id;
 
@@ -48,12 +57,14 @@ const ReelCard = ({
     setLikeCount(reel.stats?.likes || 0);
     setLoveCount(reel.stats?.loves || 0);
     setMuted(true);
+    setPosterUrl(reel.poster ?? null);
   }, [
     reel.id,
     reel.viewerState?.liked,
     reel.viewerState?.loved,
     reel.stats?.likes,
     reel.stats?.loves,
+    reel.poster,
   ]);
 
   useEffect(() => {
@@ -144,6 +155,7 @@ const ReelCard = ({
         <video
           ref={videoRef}
           src={reel.video}
+          poster={posterUrl || undefined}
           className="h-full w-full object-cover"
           playsInline
           loop
@@ -181,7 +193,7 @@ const ReelCard = ({
           )}
         </button>
 
-        {/* Right action rail â€” overlaid inside, all breakpoints (TikTok-style) */}
+        {/* Right action rail — overlaid inside, all breakpoints (TikTok-style) */}
         <div className="absolute bottom-24 right-2.5 z-30 flex flex-col items-center gap-5">
           <div className="mb-1 flex flex-col items-center">
             <Avatar className="h-11 w-11 border-2 border-white">
@@ -233,6 +245,9 @@ const ReelCard = ({
             accessibleLabel={`Share, ${reel.stats?.shares?.toLocaleString?.() || 0}`}
             onClick={onShare}
           />
+          {isAdmin && (
+            <ReelPosterButton onClick={() => setPosterDialogOpen(true)} />
+          )}
         </div>
 
         {/* Caption overlay (bottom-left) */}
@@ -241,7 +256,7 @@ const ReelCard = ({
             <span className="text-sm font-semibold">
               @{reel.createdBy?.name || "Anonymous"}
             </span>
-            <span className="text-[11px] text-white/60">Â·</span>
+            <span className="text-[11px] text-white/60">·</span>
             <span className="text-[11px] text-white/70">{formattedDate}</span>
             <button
               type="button"
@@ -286,6 +301,15 @@ const ReelCard = ({
           </button>
         )}
       </div>
+
+      {isAdmin && (
+        <ReelPosterDialog
+          open={posterDialogOpen}
+          onOpenChange={setPosterDialogOpen}
+          reel={reel}
+          onUpdated={(url) => setPosterUrl(url)}
+        />
+      )}
     </div>
   );
 };

--- a/components/organisms/reels/ReelPosterDialog.jsx
+++ b/components/organisms/reels/ReelPosterDialog.jsx
@@ -1,0 +1,265 @@
+"use client";
+/**
+ * ReelPosterDialog — admin poster (cover image) management for a reel (#265).
+ * ---------------------------------------------------------------------------
+ * Two ways to set a reel's poster:
+ *   1. "Pick a frame" — scrub the reel's own video with a slider, capture the
+ *      currently-displayed frame to a <canvas>, convert it to a Blob, and
+ *      upload that still to Cloudinary.
+ *   2. "Upload image" — pick a custom image file directly.
+ *
+ * Both paths converge on the same unsigned Cloudinary upload
+ * (`dnb_reels_posters` preset, matching the `dnb_*` naming used by course
+ * thumbnails) and then persist the resulting URL via `useReelPoster`, which
+ * updates instantly and rolls back + toasts if the (stubbed) backend call
+ * fails — see `lib/actions/reels-action.updateReelPoster`.
+ */
+import { useCallback, useMemo, useRef, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Slider } from "@/components/ui/slider";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import Button from "@/components/atoms/form/Button";
+import useReelPoster from "@/hooks/useReelPoster";
+import { useCloudinaryUpload } from "@/hooks/useCloudinaryUpload";
+import { Loader2, ImageIcon, Film } from "lucide-react";
+import { toast } from "sonner";
+
+const POSTER_UPLOAD_PRESET = "dnb_reels_posters";
+const POSTER_VALIDATION = {
+  maxSize: 5 * 1024 * 1024,
+  allowedTypes: ["image/*"],
+};
+
+/**
+ * Draw the current frame of a <video> element onto an offscreen <canvas> and
+ * resolve a JPEG Blob of it.
+ * @param {HTMLVideoElement} video
+ * @returns {Promise<Blob>}
+ */
+export function captureVideoFrame(video) {
+  return new Promise((resolve, reject) => {
+    if (!video || !video.videoWidth || !video.videoHeight) {
+      reject(new Error("Video isn't ready to capture yet."));
+      return;
+    }
+    const canvas = document.createElement("canvas");
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      reject(new Error("Canvas isn't supported in this browser."));
+      return;
+    }
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+    canvas.toBlob(
+      (blob) => {
+        if (blob) resolve(blob);
+        else reject(new Error("Couldn't capture that frame. Try again."));
+      },
+      "image/jpeg",
+      0.92
+    );
+  });
+}
+
+const ReelPosterDialog = ({ open, onOpenChange, reel, onUpdated }) => {
+  const videoRef = useRef(null);
+  const [duration, setDuration] = useState(0);
+  const [scrubTime, setScrubTime] = useState(0);
+  const [capturedPreview, setCapturedPreview] = useState(null);
+  const [capturing, setCapturing] = useState(false);
+
+  const { setPoster, isPending: persisting } = useReelPoster(
+    reel?.id,
+    reel?.poster
+  );
+  const frameUpload = useCloudinaryUpload(POSTER_UPLOAD_PRESET, POSTER_VALIDATION);
+  const fileUpload = useCloudinaryUpload(POSTER_UPLOAD_PRESET, POSTER_VALIDATION);
+
+  const busy = capturing || frameUpload.uploading || fileUpload.uploading || persisting;
+
+  const resetState = useCallback(() => {
+    setScrubTime(0);
+    setCapturedPreview(null);
+    setCapturing(false);
+    frameUpload.reset();
+    fileUpload.reset();
+  }, [frameUpload, fileUpload]);
+
+  const handleOpenChange = (next) => {
+    if (!next) resetState();
+    onOpenChange(next);
+  };
+
+  const handleLoadedMetadata = () => {
+    const video = videoRef.current;
+    if (video) setDuration(video.duration || 0);
+  };
+
+  const handleScrub = (values) => {
+    const [time] = values;
+    setScrubTime(time);
+    if (videoRef.current) {
+      videoRef.current.currentTime = time;
+    }
+  };
+
+  const handleCaptureAndUpload = async () => {
+    const video = videoRef.current;
+    setCapturing(true);
+    try {
+      const blob = await captureVideoFrame(video);
+      const file = new File([blob], `reel-${reel.id}-frame.jpg`, {
+        type: "image/jpeg",
+      });
+      setCapturedPreview(URL.createObjectURL(blob));
+      const secureUrl = await frameUpload.uploadFile(file);
+      await setPoster(secureUrl);
+      toast.success("Poster updated from video frame.");
+      onUpdated?.(secureUrl);
+      handleOpenChange(false);
+    } catch (err) {
+      // uploadFile already toasts upload errors; only surface capture-specific
+      // failures that didn't come from the upload hook.
+      if (!frameUpload.error) {
+        toast.error(err?.message || "Couldn't set that frame as the poster.");
+      }
+    } finally {
+      setCapturing(false);
+    }
+  };
+
+  const handleFileChange = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    try {
+      const secureUrl = await fileUpload.uploadFile(file);
+      await setPoster(secureUrl);
+      toast.success("Poster updated.");
+      onUpdated?.(secureUrl);
+      handleOpenChange(false);
+    } catch {
+      // fileUpload already toasts the specific error.
+    }
+  };
+
+  const formattedTime = useMemo(() => {
+    const s = Math.floor(scrubTime % 60)
+      .toString()
+      .padStart(2, "0");
+    const m = Math.floor(scrubTime / 60);
+    return `${m}:${s}`;
+  }, [scrubTime]);
+
+  if (!reel) return null;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle className="text-lg font-semibold">
+            Manage poster
+          </DialogTitle>
+          <DialogDescription>
+            Pick a frame from this reel or upload a custom cover image.
+          </DialogDescription>
+        </DialogHeader>
+
+        <Tabs defaultValue="frame" className="w-full">
+          <TabsList className="grid w-full grid-cols-2">
+            <TabsTrigger value="frame">
+              <Film className="mr-2 h-4 w-4" aria-hidden="true" />
+              Pick a frame
+            </TabsTrigger>
+            <TabsTrigger value="upload">
+              <ImageIcon className="mr-2 h-4 w-4" aria-hidden="true" />
+              Upload image
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="frame" className="space-y-4">
+            <div className="overflow-hidden rounded-xl bg-black">
+              <video
+                ref={videoRef}
+                src={reel.video}
+                className="max-h-72 w-full"
+                onLoadedMetadata={handleLoadedMetadata}
+                muted
+                playsInline
+              />
+            </div>
+            <div className="flex items-center gap-3">
+              <span className="w-10 shrink-0 text-xs tabular-nums text-muted-foreground">
+                {formattedTime}
+              </span>
+              <Slider
+                value={[scrubTime]}
+                min={0}
+                max={duration || 0}
+                step={0.1}
+                onValueChange={handleScrub}
+                disabled={!duration || busy}
+                aria-label="Scrub to a frame"
+              />
+            </div>
+            <Button
+              round
+              className="w-full bg-accent text-white"
+              onClick={handleCaptureAndUpload}
+              disabled={!duration || busy}
+              loading={capturing || frameUpload.uploading || persisting}
+            >
+              {capturing || frameUpload.uploading || persisting ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Setting poster…
+                </>
+              ) : (
+                "Use this frame as poster"
+              )}
+            </Button>
+          </TabsContent>
+
+          <TabsContent value="upload" className="space-y-4">
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="reel-poster-upload">Custom cover image</Label>
+              <Input
+                id="reel-poster-upload"
+                type="file"
+                accept="image/*"
+                disabled={busy}
+                onChange={handleFileChange}
+              />
+              <p className="text-xs text-muted-foreground">
+                JPG or PNG, up to 5MB.
+              </p>
+            </div>
+            {(fileUpload.uploading || persisting) && (
+              <p className="flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Uploading and setting poster…
+              </p>
+            )}
+          </TabsContent>
+        </Tabs>
+
+        <DialogFooter className="border-t border-border pt-4">
+          <Button outlined round onClick={() => handleOpenChange(false)} disabled={busy}>
+            Cancel
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ReelPosterDialog;

--- a/components/organisms/reels/ReelPosterDialog.jsx
+++ b/components/organisms/reels/ReelPosterDialog.jsx
@@ -1,18 +1,18 @@
-"use client";
+ï»¿"use client";
 /**
- * ReelPosterDialog — admin poster (cover image) management for a reel (#265).
+ * ReelPosterDialog - admin poster (cover image) management for a reel (#265).
  * ---------------------------------------------------------------------------
  * Two ways to set a reel's poster:
- *   1. "Pick a frame" — scrub the reel's own video with a slider, capture the
+ *   1. "Pick a frame" - scrub the reel's own video with a slider, capture the
  *      currently-displayed frame to a <canvas>, convert it to a Blob, and
  *      upload that still to Cloudinary.
- *   2. "Upload image" — pick a custom image file directly.
+ *   2. "Upload image" - pick a custom image file directly.
  *
  * Both paths converge on the same unsigned Cloudinary upload
  * (`dnb_reels_posters` preset, matching the `dnb_*` naming used by course
  * thumbnails) and then persist the resulting URL via `useReelPoster`, which
  * updates instantly and rolls back + toasts if the (stubbed) backend call
- * fails — see `lib/actions/reels-action.updateReelPoster`.
+ * fails - see `lib/actions/reels-action.updateReelPoster`.
  */
 import { useCallback, useMemo, useRef, useState } from "react";
 import {
@@ -75,7 +75,6 @@ const ReelPosterDialog = ({ open, onOpenChange, reel, onUpdated }) => {
   const videoRef = useRef(null);
   const [duration, setDuration] = useState(0);
   const [scrubTime, setScrubTime] = useState(0);
-  const [capturedPreview, setCapturedPreview] = useState(null);
   const [capturing, setCapturing] = useState(false);
 
   const { setPoster, isPending: persisting } = useReelPoster(
@@ -89,7 +88,6 @@ const ReelPosterDialog = ({ open, onOpenChange, reel, onUpdated }) => {
 
   const resetState = useCallback(() => {
     setScrubTime(0);
-    setCapturedPreview(null);
     setCapturing(false);
     frameUpload.reset();
     fileUpload.reset();
@@ -116,23 +114,31 @@ const ReelPosterDialog = ({ open, onOpenChange, reel, onUpdated }) => {
   const handleCaptureAndUpload = async () => {
     const video = videoRef.current;
     setCapturing(true);
+    // Capture failures (video not ready, canvas unsupported) don't go
+    // through either hook, so they get their own toast here. Everything
+    // past this point -- frameUpload.uploadFile and setPoster -- already
+    // toasts its own errors internally, so we deliberately don't add a
+    // second toast for those; we just stop and leave the dialog open.
+    let blob;
     try {
-      const blob = await captureVideoFrame(video);
+      blob = await captureVideoFrame(video);
+    } catch (err) {
+      setCapturing(false);
+      toast.error(err?.message || "Couldn't capture that frame.");
+      return;
+    }
+
+    try {
       const file = new File([blob], `reel-${reel.id}-frame.jpg`, {
         type: "image/jpeg",
       });
-      setCapturedPreview(URL.createObjectURL(blob));
       const secureUrl = await frameUpload.uploadFile(file);
       await setPoster(secureUrl);
       toast.success("Poster updated from video frame.");
       onUpdated?.(secureUrl);
       handleOpenChange(false);
-    } catch (err) {
-      // uploadFile already toasts upload errors; only surface capture-specific
-      // failures that didn't come from the upload hook.
-      if (!frameUpload.error) {
-        toast.error(err?.message || "Couldn't set that frame as the poster.");
-      }
+    } catch {
+      // Already toasted by uploadFile or setPoster.
     } finally {
       setCapturing(false);
     }
@@ -140,6 +146,9 @@ const ReelPosterDialog = ({ open, onOpenChange, reel, onUpdated }) => {
 
   const handleFileChange = async (event) => {
     const file = event.target.files?.[0];
+    // Clear the input immediately so selecting the exact same file again
+    // (e.g. retrying after a failed upload) still fires a change event.
+    event.target.value = "";
     if (!file) return;
     try {
       const secureUrl = await fileUpload.uploadFile(file);
@@ -148,7 +157,7 @@ const ReelPosterDialog = ({ open, onOpenChange, reel, onUpdated }) => {
       onUpdated?.(secureUrl);
       handleOpenChange(false);
     } catch {
-      // fileUpload already toasts the specific error.
+      // Already toasted by uploadFile or setPoster.
     }
   };
 
@@ -221,7 +230,7 @@ const ReelPosterDialog = ({ open, onOpenChange, reel, onUpdated }) => {
               {capturing || frameUpload.uploading || persisting ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
-                  Setting poster…
+                  Setting poster...
                 </>
               ) : (
                 "Use this frame as poster"
@@ -246,7 +255,7 @@ const ReelPosterDialog = ({ open, onOpenChange, reel, onUpdated }) => {
             {(fileUpload.uploading || persisting) && (
               <p className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" />
-                Uploading and setting poster…
+                Uploading and setting poster...
               </p>
             )}
           </TabsContent>

--- a/hooks/useReelPoster.js
+++ b/hooks/useReelPoster.js
@@ -1,0 +1,46 @@
+"use client";
+/**
+ * useReelPoster — optimistic poster (cover image) update for a single reel (#265).
+ * ---------------------------------------------------------------------------
+ * Wraps {@link useOptimisticMutation} to update a reel's `poster` URL
+ * instantly, reverting + toasting if the `PATCH /api/reels/:id/poster`
+ * mutation (stubbed in `lib/actions/reels-action`) fails. Queue safety is
+ * keyed by the reel id, mirroring `useReelModeration` (#335).
+ *
+ * This hook only persists an already-uploaded Cloudinary URL — it does not
+ * perform the upload itself. See `ReelPosterDialog` for frame capture /
+ * custom image upload.
+ *
+ * @example
+ * const { poster, setPoster, isPending } = useReelPoster(reel.id, reel.poster);
+ * await setPoster(uploadedSecureUrl);
+ *
+ * @param {string} reelId
+ * @param {string|null} [initialPoster=null]
+ * @returns {{ poster: string|null, setPoster: (url: string) => Promise<string|null>, isPending: boolean, error: Error|null }}
+ */
+import { useCallback } from "react";
+import useOptimisticMutation from "@/hooks/useOptimisticMutation";
+import { updateReelPoster } from "@/lib/actions/reels-action";
+
+export default function useReelPoster(reelId, initialPoster = null) {
+  const { value: poster, mutate, isPending, error } = useOptimisticMutation({
+    initialValue: initialPoster ?? null,
+    key: reelId,
+    errorMessage: "Couldn't update this reel's poster",
+  });
+
+  /** Persist a newly uploaded poster URL (optimistic, with rollback). */
+  const setPoster = useCallback(
+    (posterUrl) =>
+      mutate({
+        applyOptimistic: () => posterUrl,
+        run: (value) => updateReelPoster(reelId, { posterUrl: value }),
+        commit: (result, optimistic) =>
+          result?.reel ? result.reel.poster : optimistic,
+      }),
+    [mutate, reelId]
+  );
+
+  return { poster, setPoster, isPending, error };
+}

--- a/hooks/useReelPoster.js
+++ b/hooks/useReelPoster.js
@@ -1,13 +1,13 @@
-"use client";
+ï»¿"use client";
 /**
- * useReelPoster — optimistic poster (cover image) update for a single reel (#265).
+ * useReelPoster - optimistic poster (cover image) update for a single reel (#265).
  * ---------------------------------------------------------------------------
  * Wraps {@link useOptimisticMutation} to update a reel's `poster` URL
  * instantly, reverting + toasting if the `PATCH /api/reels/:id/poster`
  * mutation (stubbed in `lib/actions/reels-action`) fails. Queue safety is
  * keyed by the reel id, mirroring `useReelModeration` (#335).
  *
- * This hook only persists an already-uploaded Cloudinary URL — it does not
+ * This hook only persists an already-uploaded Cloudinary URL - it does not
  * perform the upload itself. See `ReelPosterDialog` for frame capture /
  * custom image upload.
  *

--- a/lib/actions/reels-action.js
+++ b/lib/actions/reels-action.js
@@ -1,4 +1,4 @@
-import axiosInstance from "@/lib/config/axios.config";
+﻿import axiosInstance from "@/lib/config/axios.config";
 
 const defaultPagination = {
   page: 1,
@@ -138,7 +138,7 @@ export const recordReelView = async (reelId) => {
  * TODO(backend): PATCH /api/reels/:id/visibility
  *   - Auth: requires a moderator/admin session token (server-side tier check).
  *   - Payload: { hidden: boolean }
- *   - 200 → { reel: { id: string, hidden: boolean, updatedAt: string } }
+ *   - 200 -> { reel: { id: string, hidden: boolean, updatedAt: string } }
  *   - 403 for non-moderators; 404 if the reel does not exist.
  *
  * @param {string} reelId
@@ -192,7 +192,7 @@ export const unhideReel = (reelId) => setReelVisibility(reelId, { hidden: false 
  * {@link setReelVisibility} (#335), so the poster-management UI (#265) can be
  * built and reviewed before the backend endpoint exists. The image itself is
  * already uploaded directly to Cloudinary (unsigned, `dnb_reels_posters`
- * preset) by the caller � this action only persists the resulting URL against
+ * preset) by the caller - this action only persists the resulting URL against
  * the reel. Swap the mock body for the `axiosInstance` call shown when the
  * backend lands. Keep the existing reel exports untouched.
  *

--- a/lib/actions/reels-action.js
+++ b/lib/actions/reels-action.js
@@ -184,3 +184,50 @@ export const hideReel = (reelId) => setReelVisibility(reelId, { hidden: true });
  * @returns {Promise<{reel: {id: string, hidden: boolean, updatedAt: string}}>}
  */
 export const unhideReel = (reelId) => setReelVisibility(reelId, { hidden: false });
+
+/**
+ * Set a reel's poster (cover image) URL.
+ * ---------------------------------------------------------------------------
+ * **STUBBED.** Resolves against a small in-memory map, same shape as
+ * {@link setReelVisibility} (#335), so the poster-management UI (#265) can be
+ * built and reviewed before the backend endpoint exists. The image itself is
+ * already uploaded directly to Cloudinary (unsigned, `dnb_reels_posters`
+ * preset) by the caller — this action only persists the resulting URL against
+ * the reel. Swap the mock body for the `axiosInstance` call shown when the
+ * backend lands. Keep the existing reel exports untouched.
+ *
+ * TODO(backend): PATCH /api/reels/:id/poster
+ *   - Auth: requires a moderator/admin session token (server-side tier check).
+ *   - Payload: { posterUrl: string }
+ *   - 200 -> { reel: { id: string, poster: string, updatedAt: string } }
+ *   - 403 for non-moderators; 404 if the reel does not exist; 422 if
+ *     posterUrl is missing/not a Cloudinary URL.
+ *
+ * @param {string} reelId
+ * @param {{posterUrl: string}} patch
+ * @returns {Promise<{reel: {id: string, poster: string, updatedAt: string}}>}
+ */
+const POSTER_MOCK_DELAY_MS = 400;
+const mockReelPosters = new Map();
+
+export const updateReelPoster = async (reelId, { posterUrl } = {}) => {
+  // TODO(backend):
+  //   return axiosInstance
+  //     .patch(`/api/reels/${reelId}/poster`, { posterUrl })
+  //     .then((res) => res.data);
+  if (!posterUrl || typeof posterUrl !== "string") {
+    return Promise.reject(new Error("A poster URL is required."));
+  }
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      mockReelPosters.set(reelId, posterUrl);
+      resolve({
+        reel: {
+          id: reelId,
+          poster: posterUrl,
+          updatedAt: new Date().toISOString(),
+        },
+      });
+    }, POSTER_MOCK_DELAY_MS);
+  });
+};


### PR DESCRIPTION
Closes #265

## Summary
Adds admin-only poster (cover image) management for reels — uploads no longer show a black frame before playback.

Two ways to set a poster:
- **Pick a frame** from the reel's own video (scrubber + canvas capture)
- **Upload a custom image** directly

Both paths upload to Cloudinary (`dnb_reels_posters` preset, unsigned — same convention as course thumbnails) and persist the URL via `updateReelPoster`.

## Backend note
`PATCH /api/reels/:id/poster` doesn't exist yet, so `updateReelPoster` is a documented stub (mirrors the existing `setReelVisibility` stub from #335), ready to swap in once the endpoint lands.

## Changes
- `lib/actions/reels-action.js` — `updateReelPoster` stub
- `hooks/useReelPoster.js` — optimistic update hook
- `components/organisms/reels/ReelPosterDialog.jsx` — frame-capture + upload UI
- `components/atoms/reels/ReelPosterButton.jsx` — admin-only trigger
- `components/organisms/reels/ReelCard.jsx` — `poster` attribute on `<video>`, admin gating, dialog wiring
- `.env.example` — documents the new Cloudinary preset

## Testing
13 new tests (stub action, optimistic hook, both upload flows). `npm run lint` and `npm run a11y` are clean on every file this PR touches.

**Note:** this repo's CI (a11y gate + `npm test`) currently has pre-existing failures unrelated to this PR — a parsing error in `admin-reports.js`, a duplicate declaration in `AppProviders.jsx`, and some flaky admin tests. Confirmed present on `dev` before this branch, not introduced here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added poster management for reels.
  * Administrators can capture a video frame or upload a custom image as a reel poster.
  * Reel videos now display their selected poster image.
  * Added image validation for uploads up to 5 MB, with success and error notifications.

* **Documentation**
  * Expanded environment configuration guidance for unsigned uploads covering reel posters and cover images.

* **Tests**
  * Added coverage for poster capture, uploads, persistence, optimistic updates, validation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->